### PR TITLE
Rebrand hyprmarker to wayscriber (v0.5.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,9 @@ test_run.sh
 run.sh
 
 # Packaging (but keep the service file)
-packaging/
-!packaging/hyprmarker.service
+packaging/**
+!packaging/wayscriber.service
+!packaging/PKGBUILD
+!packaging/PKGBUILD.hyprmarker-meta
 
 docs/board

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,42 +905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hyprmarker"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "cairo-rs",
- "cairo-sys-rs",
- "calloop",
- "chrono",
- "clap",
- "dirs",
- "env_logger",
- "futures",
- "ksni",
- "log",
- "memmap2",
- "nix 0.30.1",
- "pango",
- "pangocairo",
- "schemars",
- "serde",
- "serde_json",
- "signal-hook",
- "smithay-client-toolkit",
- "thiserror 1.0.69",
- "tokio",
- "toml",
- "url",
- "wayland-client",
- "wayland-protocols 0.32.9",
- "wayland-protocols-wlr 0.3.9",
- "wl-clipboard-rs",
- "zbus 4.4.0",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2302,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "wayscriber"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cairo-rs",
+ "cairo-sys-rs",
+ "calloop",
+ "chrono",
+ "clap",
+ "dirs",
+ "env_logger",
+ "futures",
+ "ksni",
+ "log",
+ "memmap2",
+ "nix 0.30.1",
+ "pango",
+ "pangocairo",
+ "schemars",
+ "serde",
+ "serde_json",
+ "signal-hook",
+ "smithay-client-toolkit",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "url",
+ "wayland-client",
+ "wayland-protocols 0.32.9",
+ "wayland-protocols-wlr 0.3.9",
+ "wl-clipboard-rs",
+ "zbus 4.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "hyprmarker"
-version = "0.4.0"
+name = "wayscriber"
+version = "0.5.0"
 edition = "2024"
+description = "Screen annotation tool for Wayland compositors"
+homepage = "https://wayscriber.com"
+repository = "https://github.com/devmobasa/wayscriber"
 
 [dependencies]
 # Wayland
@@ -45,3 +48,6 @@ chrono = "0.4"
 futures = "0.3"
 url = "2.5"
 serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# hyprmarker
+# wayscriber
 
-> TL;DR: hyprmarker is a ZoomIt-like screen annotation tool for Wayland compositors, written in Rust.
+> TL;DR: wayscriber is a ZoomIt-like screen annotation tool for Wayland compositors, written in Rust.
 > Works on compositors with the wlr-layer-shell protocol (Hyprland, Sway, river, …); building from source requires Rust 1.70+.
 > Quick start: [set it up in four steps](#quick-start).
 
@@ -21,57 +21,58 @@ https://github.com/user-attachments/assets/7c4b36ec-0f6a-4aad-93fb-f9c966d43873
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)
 
-- [Why hyprmarker?](#why-hyprmarker)
+- [Why wayscriber?](#why-wayscriber)
 - [Quick Start](#quick-start)
 - [Features at a Glance](#features-at-a-glance)
 - [Demo](#demo)
 - [Installation](#installation)
-- [Running hyprmarker](#running-hyprmarker)
+- [Running wayscriber](#running-wayscriber)
 - [Controls Reference](#controls-reference)
 - [Configuration](#configuration)
 - [Troubleshooting](#troubleshooting)
 - [Additional Information](#additional-information)
+- [Project History](#project-history)
 - [Contributing & Credits](#contributing--credits)
 
-## Why hyprmarker?
+## Why wayscriber?
 
 - Works across Wayland compositors (Sway, Wayfire, River, Hyprland, …) via wlr-layer-shell. Tested extensively on Hyprland and confirmed working on Niri; reports from other compositors welcome.
 - Built for live presentations, classroom sessions, and screenshares - toggle with a key and annotate your screen instantly without breaking flow.
-- Complements tools like [Satty](https://github.com/gabm/Satty): Satty excels at capture → annotate → save workflows, while hyprmarker stays resident as an always-available drawing layer with instant mode switching.
+- Complements tools like [Satty](https://github.com/gabm/Satty): Satty excels at capture → annotate → save workflows, while wayscriber stays resident as an always-available drawing layer with instant mode switching.
 
 ## Quick Start
 
-**1. Install hyprmarker**
-   - Arch Linux: `yay -S hyprmarker` or `paru -S hyprmarker` (AUR). The binary lands in `/usr/bin` and required tools (`wl-clipboard`, `grim`, `slurp`) are pulled in automatically.
+**1. Install wayscriber**
+   - Arch Linux: `yay -S wayscriber` or `paru -S wayscriber` (AUR). The binary lands in `/usr/bin` and required tools (`wl-clipboard`, `grim`, `slurp`) are pulled in automatically.
    - Other distros: see [Installation](#installation), then install `wl-clipboard`, `grim`, and `slurp` for the fastest screenshot workflow.
 
 **2. Choose how to run it:**
 
 ### Option 1: One-Shot Mode (Simple)
-Launch hyprmarker when you need it, exit when done:
+Launch wayscriber when you need it, exit when done:
 
 ```bash
-hyprmarker --active
+wayscriber --active
 ```
 
 Or bind to a key in `~/.config/hypr/hyprland.conf`:
 ```conf
-bind = SUPER, D, exec, hyprmarker --active
+bind = SUPER, D, exec, wayscriber --active
 ```
 
 Press `F10` for help, `F11` for configurator, `Escape` to exit.
 
 ### Option 2: Daemon Mode (Background Service)
-Run hyprmarker in the background and toggle it with a keybind:
+Run wayscriber in the background and toggle it with a keybind:
 
 **Enable the service:**
 ```bash
-systemctl --user enable --now hyprmarker.service
+systemctl --user enable --now wayscriber.service
 ```
 
 **Add keybinding** to `~/.config/hypr/hyprland.conf`:
 ```conf
-bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
+bind = SUPER, D, exec, pkill -SIGUSR1 wayscriber
 ```
 
 **Reload Hyprland:**
@@ -83,8 +84,8 @@ hyprctl reload
 
 **Alternative:** Use Hyprland's exec-once instead of systemd:
 ```conf
-exec-once = hyprmarker --daemon
-bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
+exec-once = wayscriber --daemon
+bind = SUPER, D, exec, pkill -SIGUSR1 wayscriber
 ```
 
 ## Features at a Glance
@@ -109,13 +110,13 @@ See **[docs/SETUP.md](docs/SETUP.md)** for detailed walkthroughs.
 
 ```bash
 # Using yay
-yay -S hyprmarker
+yay -S wayscriber
 
 # Or using paru
-paru -S hyprmarker
+paru -S wayscriber
 ```
 
-The package installs the user service at `/usr/lib/systemd/user/hyprmarker.service`.
+The package installs the user service at `/usr/lib/systemd/user/wayscriber.service`.
 
 ### Other Distros
 
@@ -138,12 +139,12 @@ sudo dnf install wl-clipboard grim slurp       # Fedora
 **Build from source:**
 
 ```bash
-git clone https://github.com/devmobasa/hyprmarker.git
-cd hyprmarker
+git clone https://github.com/devmobasa/wayscriber.git
+cd wayscriber
 cargo build --release
 ```
 
-The binary will be at `target/release/hyprmarker`.
+The binary will be at `target/release/wayscriber`.
 
 ### Manual Install Script
 
@@ -152,22 +153,22 @@ cargo build --release
 ./tools/install.sh
 ```
 
-The installer places the binary at `~/.local/bin/hyprmarker`, creates `~/.config/hyprmarker/`, and offers to configure Hyprland.
+The installer places the binary at `~/.local/bin/wayscriber`, creates `~/.config/wayscriber/`, and offers to configure Hyprland.
 
-## Running hyprmarker
+## Running wayscriber
 
 ### Daemon Mode
 
-Run hyprmarker in the background and toggle with a keybind.
+Run wayscriber in the background and toggle with a keybind.
 
 **Enable the service:**
 ```bash
-systemctl --user enable --now hyprmarker.service
+systemctl --user enable --now wayscriber.service
 ```
 
 **Add keybinding** to `~/.config/hypr/hyprland.conf`:
 ```conf
-bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
+bind = SUPER, D, exec, pkill -SIGUSR1 wayscriber
 ```
 
 **Reload Hyprland:**
@@ -179,17 +180,17 @@ The daemon shows a system tray icon (may be in Waybar drawer). Press `Super+D` t
 
 **Service commands:**
 ```bash
-systemctl --user status hyprmarker.service
-systemctl --user restart hyprmarker.service
-journalctl --user -u hyprmarker.service -f
+systemctl --user status wayscriber.service
+systemctl --user restart wayscriber.service
+journalctl --user -u wayscriber.service -f
 ```
 
 **Note:** If the daemon doesn't start after reboot, see [Troubleshooting](#daemon-not-starting-after-reboot).
 
 **Alternative:** Use Hyprland's exec-once instead of systemd:
 ```conf
-exec-once = hyprmarker --daemon
-bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
+exec-once = wayscriber --daemon
+bind = SUPER, D, exec, pkill -SIGUSR1 wayscriber
 ```
 
 ### One-Shot Mode
@@ -197,23 +198,23 @@ bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
 Launch directly into an active overlay without the daemon:
 
 ```bash
-hyprmarker --active
-hyprmarker --active --mode whiteboard
-hyprmarker --active --mode blackboard
+wayscriber --active
+wayscriber --active --mode whiteboard
+wayscriber --active --mode blackboard
 ```
 
 Bind it to keys if you prefer:
 
 ```conf
-bind = $mainMod, D, exec, hyprmarker --active
-bind = $mainMod SHIFT, D, exec, hyprmarker --active --mode whiteboard
+bind = $mainMod, D, exec, wayscriber --active
+bind = $mainMod SHIFT, D, exec, wayscriber --active --mode whiteboard
 ```
 
 Exit the overlay with `Escape` or `Ctrl+Q`.
 
 ### Screenshot Shortcuts
 
-hyprmarker ships with keyboard shortcuts for quick captures:
+wayscriber ships with keyboard shortcuts for quick captures:
 
 - `Ctrl+C` – copy the entire screen to the clipboard.
 - `Ctrl+S` – save the entire screen as a PNG (uses your capture directory).
@@ -222,7 +223,7 @@ hyprmarker ships with keyboard shortcuts for quick captures:
 - `Ctrl+Shift+O` – capture the active window (Hyprland fast path, portal fallback).
 - `Ctrl+6` / `Ctrl+Shift+6` – reserved for remembered-region clipboard/file captures (coming soon).
 
-**Requirements:** install `wl-clipboard`, `grim`, and `slurp` for the fastest Hyprland workflow. If they are missing, hyprmarker falls back to `xdg-desktop-portal`'s interactive picker.
+**Requirements:** install `wl-clipboard`, `grim`, and `slurp` for the fastest Hyprland workflow. If they are missing, wayscriber falls back to `xdg-desktop-portal`'s interactive picker.
 
 ## Controls Reference
 
@@ -267,12 +268,12 @@ Press `F10` at any time for the in-app keyboard and mouse cheat sheet.
 
 ## Configuration
 
-- Config file location: `~/.config/hyprmarker/config.toml`.
+- Config file location: `~/.config/wayscriber/config.toml`.
 - Copy defaults to get started:
 
   ```bash
-  mkdir -p ~/.config/hyprmarker
-  cp config.example.toml ~/.config/hyprmarker/config.toml
+  mkdir -p ~/.config/wayscriber
+  cp config.example.toml ~/.config/wayscriber/config.toml
   ```
 
 - Key sections to tweak:
@@ -306,25 +307,25 @@ loginctl enable-linger $USER
 
 **Simpler alternative:** Use Hyprland's `exec-once` instead:
 ```conf
-exec-once = hyprmarker --daemon
+exec-once = wayscriber --daemon
 ```
 
 ### Service won't start
 
-- Check status: `systemctl --user status hyprmarker.service`
-- Tail logs: `journalctl --user -u hyprmarker.service -f`
-- Restart: `systemctl --user restart hyprmarker.service`
+- Check status: `systemctl --user status wayscriber.service`
+- Tail logs: `journalctl --user -u wayscriber.service -f`
+- Restart: `systemctl --user restart wayscriber.service`
 
 ### Overlay not appearing
 
 1. Verify Wayland session: `echo $WAYLAND_DISPLAY`
 2. Ensure your compositor supports `wlr-layer-shell` (Hyprland, Sway, river, etc.)
-3. Run with logs for clues: `RUST_LOG=info hyprmarker --active`
+3. Run with logs for clues: `RUST_LOG=info wayscriber --active`
 
 ### Config issues
 
-- Confirm the file exists: `ls -la ~/.config/hyprmarker/config.toml`
-- Watch for TOML errors in logs: `RUST_LOG=info hyprmarker --active`
+- Confirm the file exists: `ls -la ~/.config/wayscriber/config.toml`
+- Watch for TOML errors in logs: `RUST_LOG=info wayscriber --active`
 
 ### Performance
 
@@ -354,7 +355,7 @@ enable_vsync = true
 ### Architecture Overview
 
 ```
-hyprmarker/
+wayscriber/
 ├── src/
 │   ├── main.rs           # Entry point, CLI parsing
 │   ├── daemon.rs         # Daemon mode with signal handling
@@ -386,14 +387,27 @@ hyprmarker/
 └── config.example.toml   # Example configuration
 ```
 
+### Project History
+
+Wayscriber shipped under the name **hyprmarker** through the v0.4 release line. The rename in v0.5.0 reflects the broader compositor support that has been built since the original Hyprland-only prototype. Use `wayscriber --migrate-config` to copy existing settings, and see **[docs/MIGRATION.md](docs/MIGRATION.md)** for the full compatibility checklist.
+
+**Coming from hyprmarker?** Uninstall the old package (`paru -R hyprmarker`, etc.) and disable the legacy user service before installing Wayscriber:
+
+```bash
+systemctl --user disable --now hyprmarker.service 2>/dev/null || true
+```
+
+Then install Wayscriber and enable `wayscriber.service` if you want the daemon on login.
+
 ### Documentation
 
 - **[docs/SETUP.md](docs/SETUP.md)** – system setup and installation details
 - **[docs/CONFIG.md](docs/CONFIG.md)** – configuration reference
+- **[docs/MIGRATION.md](docs/MIGRATION.md)** – guidance for migrating from hyprmarker
 
 ### Comparison with ZoomIt
 
-| Feature | ZoomIt (Windows) | hyprmarker (Linux) |
+| Feature | ZoomIt (Windows) | wayscriber (Linux) |
 |---------|------------------|--------------------|
 | Freehand drawing | ✅ | ✅ |
 | Straight lines | ✅ | ✅ |

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,5 +1,5 @@
-# hyprmarker configuration file
-# Location: ~/.config/hyprmarker/config.toml
+# wayscriber configuration file
+# Location: ~/.config/wayscriber/config.toml
 #
 # All settings are optional. If not specified, defaults will be used.
 # Delete this file to reset to defaults.
@@ -207,7 +207,7 @@ auto_adjust_pen = true
 enabled = true
 
 # Directory where PNG files are saved (supports ~ expansion)
-save_directory = "~/Pictures/Hyprmarker"
+save_directory = "~/Pictures/Wayscriber"
 
 # Filename template (uses chrono format specifiers)
 filename_template = "screenshot_%Y-%m-%d_%H%M%S"
@@ -257,7 +257,7 @@ return_to_transparent = ["Ctrl+Shift+T"]
 # Toggle help overlay
 toggle_help = ["F10"]
 
-# Launch the desktop configurator (requires hyprmarker-configurator)
+# Launch the desktop configurator (requires wayscriber-configurator)
 open_configurator = ["F11"]
 
 # Color selection shortcuts

--- a/configurator/Cargo.lock
+++ b/configurator/Cargo.lock
@@ -1686,50 +1686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "hyprmarker"
-version = "0.4.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "cairo-rs",
- "cairo-sys-rs",
- "calloop 0.14.3",
- "chrono",
- "clap",
- "dirs",
- "env_logger",
- "futures",
- "ksni",
- "log",
- "memmap2 0.9.8",
- "nix 0.30.1",
- "pango",
- "pangocairo",
- "schemars",
- "serde",
- "serde_json",
- "signal-hook",
- "smithay-client-toolkit 0.20.0",
- "thiserror 1.0.69",
- "tokio",
- "toml",
- "url",
- "wayland-client",
- "wayland-protocols 0.32.9",
- "wayland-protocols-wlr 0.3.9",
- "wl-clipboard-rs",
- "zbus 4.4.0",
-]
-
-[[package]]
-name = "hyprmarker-configurator"
-version = "0.4.0"
-dependencies = [
- "hyprmarker",
- "iced",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4366,6 +4322,50 @@ dependencies = [
  "log",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "wayscriber"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cairo-rs",
+ "cairo-sys-rs",
+ "calloop 0.14.3",
+ "chrono",
+ "clap",
+ "dirs",
+ "env_logger",
+ "futures",
+ "ksni",
+ "log",
+ "memmap2 0.9.8",
+ "nix 0.30.1",
+ "pango",
+ "pangocairo",
+ "schemars",
+ "serde",
+ "serde_json",
+ "signal-hook",
+ "smithay-client-toolkit 0.20.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "url",
+ "wayland-client",
+ "wayland-protocols 0.32.9",
+ "wayland-protocols-wlr 0.3.9",
+ "wl-clipboard-rs",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "wayscriber-configurator"
+version = "0.5.0"
+dependencies = [
+ "iced",
+ "wayscriber",
 ]
 
 [[package]]

--- a/configurator/Cargo.toml
+++ b/configurator/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "hyprmarker-configurator"
-version = "0.4.0"
+name = "wayscriber-configurator"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]
-hyprmarker = { path = ".." }
+wayscriber = { path = ".." }
 iced = { version = "0.12", features = ["tokio"] }

--- a/configurator/README.md
+++ b/configurator/README.md
@@ -1,6 +1,6 @@
-# Hyprmarker Configurator (Iced)
+# Wayscriber Configurator (Iced)
 
-Native Rust desktop UI for editing `~/.config/hyprmarker/config.toml`. The application is built on [`iced`](https://github.com/iced-rs/iced) and reuses the `hyprmarker::Config` types directly, so validation, defaults, and backup behavior match the CLI.
+Native Rust desktop UI for editing `~/.config/wayscriber/config.toml`. The application is built on [`iced`](https://github.com/iced-rs/iced) and reuses the `wayscriber::Config` types directly, so validation, defaults, and backup behavior match the CLI.
 
 ## Prerequisites
 

--- a/configurator/src/app.rs
+++ b/configurator/src/app.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
-use hyprmarker::config::Config;
+use wayscriber::config::Config;
 use iced::alignment::Horizontal;
 use iced::border::Radius;
 use iced::executor;
@@ -98,7 +98,7 @@ impl Application for ConfiguratorApp {
     }
 
     fn title(&self) -> String {
-        "Hyprmarker Configurator (Iced)".to_string()
+        "Wayscriber Configurator (Iced)".to_string()
     }
 
     fn theme(&self) -> Theme {
@@ -800,7 +800,9 @@ impl ConfiguratorApp {
 }
 
 async fn load_config_from_disk() -> Result<Arc<Config>, String> {
-    Config::load().map(Arc::new).map_err(|err| err.to_string())
+    Config::load()
+        .map(|loaded| Arc::new(loaded.config))
+        .map_err(|err| err.to_string())
 }
 
 async fn save_config_to_disk(config: Config) -> Result<(Option<PathBuf>, Arc<Config>), String> {

--- a/configurator/src/messages.rs
+++ b/configurator/src/messages.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use hyprmarker::config::Config;
+use wayscriber::config::Config;
 
 use crate::models::{
     BoardModeOption, ColorMode, FontStyleOption, FontWeightOption, KeybindingField,

--- a/configurator/src/models/color.rs
+++ b/configurator/src/models/color.rs
@@ -1,5 +1,5 @@
-use hyprmarker::config::enums::ColorSpec;
-use hyprmarker::util::name_to_color;
+use wayscriber::config::enums::ColorSpec;
+use wayscriber::util::name_to_color;
 use iced::Color;
 
 use super::error::FormError;

--- a/configurator/src/models/config.rs
+++ b/configurator/src/models/config.rs
@@ -1,4 +1,4 @@
-use hyprmarker::config::Config;
+use wayscriber::config::Config;
 
 use super::color::{ColorInput, ColorQuadInput, ColorTripletInput};
 use super::error::FormError;

--- a/configurator/src/models/fields.rs
+++ b/configurator/src/models/fields.rs
@@ -1,4 +1,4 @@
-use hyprmarker::config::StatusPosition;
+use wayscriber::config::StatusPosition;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FontStyleOption {

--- a/configurator/src/models/keybindings.rs
+++ b/configurator/src/models/keybindings.rs
@@ -1,4 +1,4 @@
-use hyprmarker::config::keybindings::KeybindingsConfig;
+use wayscriber::config::keybindings::KeybindingsConfig;
 
 use super::error::FormError;
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-hyprmarker supports customization through a TOML configuration file located at:
+wayscriber supports customization through a TOML configuration file located at:
 ```
-~/.config/hyprmarker/config.toml
+~/.config/wayscriber/config.toml
 ```
 
 All settings are optional. If the configuration file doesn't exist or settings are missing, sensible defaults will be used.
@@ -12,7 +12,7 @@ All settings are optional. If the configuration file doesn't exist or settings a
 ## Configuration File Location
 
 The configuration file should be placed at:
-- Linux: `~/.config/hyprmarker/config.toml`
+- Linux: `~/.config/wayscriber/config.toml`
 - The directory will be created automatically when you first create the config file
 
 ## Example Configuration
@@ -232,9 +232,9 @@ whiteboard_pen_color = [0.29, 0.23, 0.18]
 **CLI Override:**
 You can override the default mode from the command line:
 ```bash
-hyprmarker --active --mode whiteboard
-hyprmarker --active --mode blackboard
-hyprmarker --daemon --mode whiteboard
+wayscriber --active --mode whiteboard
+wayscriber --active --mode blackboard
+wayscriber --daemon --mode whiteboard
 ```
 
 **Defaults:**
@@ -254,7 +254,7 @@ Configures how screenshots are stored and shared.
 enabled = true
 
 # Directory for saved screenshots (supports ~ expansion)
-save_directory = "~/Pictures/Hyprmarker"
+save_directory = "~/Pictures/Wayscriber"
 
 # Filename template (chrono format specifiers allowed)
 filename_template = "screenshot_%Y-%m-%d_%H%M%S"
@@ -269,7 +269,7 @@ copy_to_clipboard = true
 **Tips:**
 - Set `copy_to_clipboard = false` if you prefer file-only captures.
 - Clipboard-only shortcuts ignore the save directory automatically.
-- Install `wl-clipboard`, `grim`, and `slurp` for the best Wayland experience; otherwise hyprmarker falls back to `xdg-desktop-portal`.
+- Install `wl-clipboard`, `grim`, and `slurp` for the best Wayland experience; otherwise wayscriber falls back to `xdg-desktop-portal`.
 
 ### `[keybindings]` - Custom Keybindings
 
@@ -305,7 +305,7 @@ return_to_transparent = ["Ctrl+Shift+T"]
 # Toggle help overlay
 toggle_help = ["F10"]
 
-# Launch the desktop configurator (requires hyprmarker-configurator)
+# Launch the desktop configurator (requires wayscriber-configurator)
 open_configurator = ["F11"]
 
 # Color selection shortcuts
@@ -399,17 +399,17 @@ All defaults match the original hardcoded keybindings to maintain compatibility.
 
 1. Create the directory:
    ```bash
-   mkdir -p ~/.config/hyprmarker
+   mkdir -p ~/.config/wayscriber
    ```
 
 2. Copy the example config:
    ```bash
-   cp config.example.toml ~/.config/hyprmarker/config.toml
+   cp config.example.toml ~/.config/wayscriber/config.toml
    ```
 
 3. Edit to your preferences:
    ```bash
-   nano ~/.config/hyprmarker/config.toml
+   nano ~/.config/wayscriber/config.toml
    ```
 
 ## Configuration Priority
@@ -419,7 +419,7 @@ Settings are loaded in this order:
 2. Configuration file values (override defaults)
 3. Runtime changes via keybindings (temporary, not saved)
 
-**Note:** Changes to the config file require restarting hyprmarker daemon to take effect.
+**Note:** Changes to the config file require restarting wayscriber daemon to take effect.
 
 To reload config changes:
 ```bash
@@ -427,8 +427,8 @@ To reload config changes:
 ./reload-daemon.sh
 
 # Or manually
-pkill hyprmarker
-hyprmarker --daemon &
+pkill wayscriber
+wayscriber --daemon &
 ```
 
 ## Troubleshooting
@@ -439,18 +439,18 @@ If your config file isn't being read:
 
 1. Check the file path:
    ```bash
-   ls -la ~/.config/hyprmarker/config.toml
+   ls -la ~/.config/wayscriber/config.toml
    ```
 
 2. Verify TOML syntax:
    ```bash
    # Install a TOML validator if needed
-   toml-validator ~/.config/hyprmarker/config.toml
+   toml-validator ~/.config/wayscriber/config.toml
    ```
 
 3. Check logs for errors:
    ```bash
-   RUST_LOG=info hyprmarker --active
+   RUST_LOG=info wayscriber --active
    ```
 
 ### Invalid Values
@@ -467,18 +467,18 @@ Check the application logs for warnings about config issues.
 
 ### Per-Project Configs
 
-While hyprmarker uses a single global config, you can:
+While wayscriber uses a single global config, you can:
 1. Create different config files
-2. Symlink the active one to `~/.config/hyprmarker/config.toml`
+2. Symlink the active one to `~/.config/wayscriber/config.toml`
 
 Example:
 ```bash
 # Create project-specific configs
-cp config.example.toml ~/configs/hyprmarker-presentation.toml
-cp config.example.toml ~/configs/hyprmarker-recording.toml
+cp config.example.toml ~/configs/wayscriber-presentation.toml
+cp config.example.toml ~/configs/wayscriber-recording.toml
 
 # Switch configs
-ln -sf ~/configs/hyprmarker-presentation.toml ~/.config/hyprmarker/config.toml
+ln -sf ~/configs/wayscriber-presentation.toml ~/.config/wayscriber/config.toml
 ```
 
 ### Configuration Examples

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,53 @@
+# Migration Guide: hyprmarker → Wayscriber
+
+This document tracks the rename of the project from **hyprmarker** to **Wayscriber** (introduced in v0.5.0). The goal is to make the transition smooth for existing users while communicating the new scope of the project: a compositor-agnostic annotation layer for Wayland.
+
+## What's New
+
+- Binary name is now `wayscriber`.
+- Configurator binary is now `wayscriber-configurator`.
+- Configuration lives under `~/.config/wayscriber/`.
+- The systemd user unit installs as `wayscriber.service`.
+- Project website and documentation live at [https://wayscriber.com](https://wayscriber.com).
+
+## Migration Checklist
+
+1. **Preview the config copy**
+   ```bash
+   wayscriber --migrate-config --dry-run
+   ```
+   Review the summary to confirm the source/destination paths.
+
+2. **Copy the configuration**
+   ```bash
+   wayscriber --migrate-config
+   ```
+   This copies everything from `~/.config/hyprmarker/` to `~/.config/wayscriber/` and, if needed,
+   backs up an existing Wayscriber config to a timestamped `wayscriber.backup.*` directory.
+
+3. **Disable the legacy systemd service**
+   ```bash
+   systemctl --user disable --now hyprmarker.service 2>/dev/null || true
+   ```
+   This stops the old daemon and prevents it from starting on login.
+
+   If you installed via a package manager, remove the legacy package before installing Wayscriber (e.g. `paru -R hyprmarker`).
+
+4. **Update Hyprland keybindings (optional)**
+   ```bash
+   sed -i.bak 's/hyprmarker/wayscriber/g' ~/.config/hypr/hyprland.conf
+   ```
+   Inspect the `.bak` backup if you want to review the changes first.
+
+After completing those steps, press `Super+D` (or your custom binding) to confirm the overlay opens. If you run into issues, check `journalctl --user -u wayscriber`.
+
+## Compatibility Notes
+
+- The package now ships a `hyprmarker` compatibility binary that forwards to `wayscriber` and prints a warning. Suppress the notice in scripts by setting `HYPRMARKER_SILENCE_RENAME=1`.
+- Environment variable overrides for the configurator accept both `WAYSCRIBER_CONFIGURATOR` and the legacy `HYPRMARKER_CONFIGURATOR` names.
+- Legacy configuration files remain untouched after the migration so you can roll back if needed.
+- On Arch Linux, the `wayscriber` AUR package replaces `hyprmarker`. The legacy `hyprmarker` AUR entry now depends on `wayscriber` and will be retired after the grace period.
+
+## Need Help?
+
+Open an issue with the `rename` label on the repository or drop a message in the community channels. Include details about your setup (distro, compositor, install method) so we can reproduce problems quickly.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -11,7 +11,7 @@ Run the install script:
 
 This will:
 1. Build the release binary
-2. Copy it to `~/.local/bin/hyprmarker`
+2. Copy it to `~/.local/bin/wayscriber`
 3. Tell you how to add Hyprland keybind
 
 ### Manual Install
@@ -24,8 +24,8 @@ cargo build --release
 
 # Copy to user bin
 mkdir -p ~/.local/bin
-cp target/release/hyprmarker ~/.local/bin/
-chmod +x ~/.local/bin/hyprmarker
+cp target/release/wayscriber ~/.local/bin/
+chmod +x ~/.local/bin/wayscriber
 
 # Make sure ~/.local/bin is in your PATH
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
@@ -38,9 +38,9 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 Add to `~/.config/hypr/hyprland.conf`:
 
 ```conf
-# hyprmarker - Screen annotation daemon (Super+D to toggle)
-exec-once = hyprmarker --daemon
-bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
+# wayscriber - Screen annotation daemon (Super+D to toggle)
+exec-once = wayscriber --daemon
+bind = SUPER, D, exec, pkill -SIGUSR1 wayscriber
 ```
 
 Then reload:
@@ -56,7 +56,7 @@ For quick one-time annotations without daemon:
 
 ```bash
 # Run directly (not recommended - daemon mode is better)
-hyprmarker --active
+wayscriber --active
 ```
 
 This starts a fresh overlay each time. Exit with Escape.
@@ -88,10 +88,10 @@ Test the setup:
 
 ```bash
 # Test binary is accessible
-which hyprmarker
+which wayscriber
 
 # Test daemon mode
-hyprmarker --daemon &
+wayscriber --daemon &
 
 # Test keybind
 Press Super+D (should show overlay)
@@ -100,7 +100,7 @@ Press Escape (should hide overlay)
 
 ## Autostart
 
-Daemon mode is already included in Method 1! The `exec-once` line will start hyprmarker automatically on login.
+Daemon mode is already included in Method 1! The `exec-once` line will start wayscriber automatically on login.
 
 ## Troubleshooting
 
@@ -124,7 +124,7 @@ Daemon mode is already included in Method 1! The `exec-once` line will start hyp
 ## Uninstall
 
 ```bash
-rm ~/.local/bin/hyprmarker
+rm ~/.local/bin/wayscriber
 # Remove keybind from hyprland.conf
 ```
 
@@ -135,8 +135,8 @@ rm ~/.local/bin/hyprmarker
 1. Install: `./tools/install.sh`
 2. Add to hyprland.conf:
    ```conf
-   exec-once = hyprmarker --daemon
-   bind = SUPER, D, exec, pkill -SIGUSR1 hyprmarker
+   exec-once = wayscriber --daemon
+   bind = SUPER, D, exec, pkill -SIGUSR1 wayscriber
    ```
 3. Reload: `hyprctl reload`
 4. Use: Press Super+D to toggle overlay

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,0 +1,120 @@
+# Maintainer: hyprarcher <hyprarcher@proton.me>
+pkgname=hyprmarker
+pkgver=0.4.0
+pkgrel=1
+pkgdesc='ZoomIt-like screen annotation tool for Wayland compositors with wlr-layer-shell support'
+arch=('x86_64' 'aarch64')
+url='https://github.com/devmobasa/hyprmarker'
+license=('MIT')
+depends=(
+    'cairo'
+    'wayland'
+    'pango'
+    'gcc-libs'
+    'glibc'
+    'wl-clipboard'
+    'grim'
+    'slurp'
+)
+makedepends=(
+    'cargo'
+    'git'
+)
+# Use GitHub as source
+source=("git+$url.git#tag=v$pkgver")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release --all-features
+    cargo build --frozen --release --manifest-path configurator/Cargo.toml
+}
+
+package() {
+    cd "$pkgname"
+
+    # Install binary
+    install -Dm755 "target/release/hyprmarker" "$pkgdir/usr/bin/hyprmarker"
+    install -Dm755 "target/release/hyprmarker-configurator" "$pkgdir/usr/bin/hyprmarker-configurator"
+
+    # Install systemd user service
+    install -Dm644 packaging/hyprmarker.service "$pkgdir/usr/lib/systemd/user/hyprmarker.service"
+
+    # Install example config
+    install -Dm644 config.example.toml "$pkgdir/usr/share/doc/$pkgname/config.example.toml"
+
+    # Install documentation
+    install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+
+    # Install license if available
+    [ -f LICENSE ] && install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE" || true
+}
+# Maintainer: wayscriber maintainers <devmobasa+aur@proton.me>
+pkgname=wayscriber
+pkgver=0.5.0
+pkgrel=1
+pkgdesc='Screen annotation tool for Wayland compositors (formerly hyprmarker)'
+arch=('x86_64' 'aarch64')
+url='https://wayscriber.com'
+license=('MIT')
+depends=(
+    'cairo'
+    'wayland'
+    'pango'
+    'gcc-libs'
+    'glibc'
+    'wl-clipboard'
+    'grim'
+    'slurp'
+)
+makedepends=(
+    'cargo'
+    'git'
+)
+provides=('hyprmarker')
+conflicts=('hyprmarker<0.5.0')
+source=("git+https://github.com/devmobasa/wayscriber.git#tag=v$pkgver")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+    cargo fetch --locked --manifest-path configurator/Cargo.toml --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+    cd "$pkgname"
+    export RUSTUP_TOOLCHAIN=stable
+    export CARGO_TARGET_DIR=target
+    cargo build --frozen --release --bins
+    cargo build --frozen --release --bins --manifest-path configurator/Cargo.toml
+}
+
+package() {
+    cd "$pkgname"
+
+    # Install binaries (new names + compatibility aliases)
+    install -Dm755 "target/release/wayscriber" "$pkgdir/usr/bin/wayscriber"
+    install -Dm755 "target/release/hyprmarker" "$pkgdir/usr/bin/hyprmarker"
+    install -Dm755 "target/release/wayscriber-configurator" "$pkgdir/usr/bin/wayscriber-configurator"
+    install -Dm755 "target/release/hyprmarker-configurator" "$pkgdir/usr/bin/hyprmarker-configurator"
+
+    # Install systemd user service
+    install -Dm644 packaging/wayscriber.service "$pkgdir/usr/lib/systemd/user/wayscriber.service"
+
+    # Install documentation and example config
+    install -Dm644 config.example.toml "$pkgdir/usr/share/doc/$pkgname/config.example.toml"
+    install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+
+    # Install license if available
+    [ -f LICENSE ] && install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE" || true
+}

--- a/packaging/PKGBUILD.hyprmarker-meta
+++ b/packaging/PKGBUILD.hyprmarker-meta
@@ -1,0 +1,27 @@
+# Maintainer: wayscriber maintainers <devmobasa+aur@proton.me>
+pkgname=hyprmarker
+pkgver=0.5.0
+pkgrel=1
+pkgdesc='Transitional meta package for the Wayscriber rename'
+arch=('any')
+url='https://wayscriber.com'
+license=('MIT')
+depends=('wayscriber')
+provides=('hyprmarker')
+conflicts=('hyprmarker<0.5.0')
+pkgver() {
+    cd "$srcdir"
+    echo "$pkgver"
+}
+
+package() {
+    install -d "$pkgdir/usr/share/doc/$pkgname"
+    cat <<'EOF' > "$pkgdir/usr/share/doc/$pkgname/README"
+hyprmarker has been renamed to Wayscriber.
+
+This transitional package pulls in the new `wayscriber` package and will be
+removed after the rename grace period. Update your scripts and keybindings to
+invoke `wayscriber` directly. See https://github.com/devmobasa/wayscriber for
+the migration guide.
+EOF
+}

--- a/packaging/wayscriber.service
+++ b/packaging/wayscriber.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Hyprmarker - Screen annotation tool for Wayland
-Documentation=https://github.com/devmobasa/hyprmarker
+Description=Wayscriber - Screen annotation tool for Wayland
+Documentation=https://wayscriber.com
 PartOf=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/hyprmarker --daemon
+ExecStart=/usr/bin/wayscriber --daemon
 Restart=on-failure
 RestartSec=5
 # Ensure Wayland environment is available

--- a/src/bin/dump_config_schema.rs
+++ b/src/bin/dump_config_schema.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    let schema = hyprmarker::Config::json_schema();
+    let schema = wayscriber::Config::json_schema();
     println!("{}", serde_json::to_string_pretty(&schema)?);
     Ok(())
 }

--- a/src/bin/hyprmarker.rs
+++ b/src/bin/hyprmarker.rs
@@ -1,0 +1,34 @@
+use std::env;
+use std::process::{Command, exit};
+
+fn main() {
+    match run_alias() {
+        Ok(code) => exit(code),
+        Err(err) => {
+            eprintln!("Failed to launch wayscriber: {err}");
+            exit(1);
+        }
+    }
+}
+
+fn run_alias() -> Result<i32, Box<dyn std::error::Error>> {
+    let alias_exe = env::current_exe()?;
+    let target_exe = alias_exe.with_file_name("wayscriber");
+
+    if !target_exe.exists() {
+        return Err(format!("expected companion binary at {}", target_exe.display()).into());
+    }
+
+    let mut command = Command::new(target_exe);
+    command.args(env::args_os().skip(1));
+    command.env(
+        wayscriber::legacy::LEGACY_ALIAS_ENV,
+        alias_exe
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("hyprmarker"),
+    );
+
+    let status = command.status()?;
+    Ok(status.code().unwrap_or(1))
+}

--- a/src/capture/file.rs
+++ b/src/capture/file.rs
@@ -21,7 +21,7 @@ impl Default for FileSaveConfig {
         Self {
             save_directory: dirs::picture_dir()
                 .unwrap_or_else(|| PathBuf::from("~"))
-                .join("Hyprmarker"),
+                .join("Wayscriber"),
             filename_template: "screenshot_%Y-%m-%d_%H%M%S".to_string(),
             format: "png".to_string(),
         }
@@ -148,7 +148,7 @@ mod tests {
             config
                 .save_directory
                 .to_string_lossy()
-                .contains("Hyprmarker")
+                .contains("Wayscriber")
         );
     }
 }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,4 +1,4 @@
-//! Screenshot capture functionality for hyprmarker.
+//! Screenshot capture functionality for wayscriber.
 //!
 //! This module provides screenshot capture capabilities including:
 //! - Full screen capture

--- a/src/config/migration.rs
+++ b/src/config/migration.rs
@@ -1,0 +1,281 @@
+use super::{legacy_config_dir, primary_config_dir};
+use anyhow::{Context, Result, anyhow};
+use chrono::Local;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Describes the actions taken (or planned) while migrating configuration files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationActions {
+    /// No legacy configuration directory was found; nothing to do.
+    NoLegacyConfig,
+    /// Dry-run summary with metadata about what would happen.
+    DryRun {
+        target_exists: bool,
+        files_to_copy: usize,
+    },
+    /// Migration completed successfully.
+    Migrated {
+        target_existed: bool,
+        files_copied: usize,
+        backup_path: Option<PathBuf>,
+    },
+}
+
+/// Report returned after attempting to migrate configuration files.
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    pub legacy_dir: PathBuf,
+    pub target_dir: PathBuf,
+    pub actions: MigrationActions,
+}
+
+/// Copies configuration files from the legacy hyprmarker directory into the new Wayscriber
+/// directory. When `dry_run` is true the function only reports what would happen.
+pub fn migrate_config(dry_run: bool) -> Result<MigrationReport> {
+    let legacy_dir = legacy_config_dir()?;
+    let target_dir = primary_config_dir()?;
+
+    if !legacy_dir.exists() {
+        return Ok(MigrationReport {
+            legacy_dir,
+            target_dir,
+            actions: MigrationActions::NoLegacyConfig,
+        });
+    }
+
+    let target_exists = target_dir.exists();
+    let files_to_copy = copy_directory(&legacy_dir, &target_dir, true)?;
+
+    if dry_run {
+        return Ok(MigrationReport {
+            legacy_dir: legacy_dir.clone(),
+            target_dir: target_dir.clone(),
+            actions: MigrationActions::DryRun {
+                target_exists,
+                files_to_copy,
+            },
+        });
+    }
+
+    let mut backup_path = None;
+    let target_existed = target_exists;
+
+    if target_existed {
+        let timestamp = Local::now().format("%Y%m%d%H%M%S");
+        let candidate = target_dir
+            .parent()
+            .map(|parent| parent.join(format!("wayscriber.backup.{timestamp}")))
+            .ok_or_else(|| anyhow!("Could not determine parent directory for {:?}", target_dir))?;
+
+        if candidate.exists() {
+            return Err(anyhow!(
+                "Backup directory already exists at {}",
+                candidate.display()
+            ));
+        }
+
+        fs::create_dir_all(candidate.parent().unwrap()).with_context(|| {
+            format!("Failed to prepare backup directory {}", candidate.display())
+        })?;
+        fs::rename(&target_dir, &candidate).with_context(|| {
+            format!(
+                "Failed to move existing directory {} to {}",
+                target_dir.display(),
+                candidate.display()
+            )
+        })?;
+        backup_path = Some(candidate);
+    }
+
+    let files_copied = copy_directory(&legacy_dir, &target_dir, false)?;
+
+    Ok(MigrationReport {
+        legacy_dir,
+        target_dir,
+        actions: MigrationActions::Migrated {
+            target_existed,
+            files_copied,
+            backup_path,
+        },
+    })
+}
+
+fn copy_directory(src: &Path, dest: &Path, dry_run: bool) -> Result<usize> {
+    if !dry_run {
+        fs::create_dir_all(dest)
+            .with_context(|| format!("Failed to create directory {}", dest.display()))?;
+    }
+
+    let mut file_count = 0usize;
+
+    for entry in
+        fs::read_dir(src).with_context(|| format!("Failed to list directory {}", src.display()))?
+    {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("Failed to inspect {}", entry_path.display()))?;
+
+        if file_type.is_dir() {
+            file_count += copy_directory(&entry_path, &dest_path, dry_run)?;
+        } else {
+            file_count += 1;
+            if !dry_run {
+                if let Some(parent) = dest_path.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("Failed to create parent directory {}", parent.display())
+                    })?;
+                }
+
+                fs::copy(&entry_path, &dest_path).with_context(|| {
+                    format!(
+                        "Failed to copy {} to {}",
+                        entry_path.display(),
+                        dest_path.display()
+                    )
+                })?;
+            }
+        }
+    }
+
+    Ok(file_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn with_temp_config_home<F, T>(f: F) -> T
+    where
+        F: FnOnce(&Path) -> T,
+    {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let temp = TempDir::new().expect("tempdir");
+        let original = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: tests serialize access via the mutex above and restore the environment
+        // variable afterward.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", temp.path()); }
+        let result = f(temp.path());
+        match original {
+            Some(value) => unsafe { std::env::set_var("XDG_CONFIG_HOME", value) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
+        }
+        result
+    }
+
+    #[test]
+    fn migrate_copies_legacy_into_new_directory() {
+        with_temp_config_home(|config_root| {
+            let legacy_dir = config_root.join("hyprmarker");
+            fs::create_dir_all(&legacy_dir).unwrap();
+            fs::write(legacy_dir.join("config.toml"), "legacy = true").unwrap();
+            fs::write(legacy_dir.join("extra.txt"), "payload").unwrap();
+
+            let report = migrate_config(false).expect("migration succeeds");
+            let target = report.target_dir.join("config.toml");
+
+            assert!(target.exists(), "target config should be created");
+            assert_eq!(
+                fs::read_to_string(target).unwrap(),
+                "legacy = true",
+                "config contents copied"
+            );
+
+            assert!(
+                matches!(
+                    report.actions,
+                    MigrationActions::Migrated {
+                        target_existed: false,
+                        files_copied: 2,
+                        backup_path: None
+                    }
+                ),
+                "expected migration report with copied files"
+            );
+        });
+    }
+
+    #[test]
+    fn migrate_creates_backup_when_target_exists() {
+        with_temp_config_home(|config_root| {
+            let legacy_dir = config_root.join("hyprmarker");
+            fs::create_dir_all(&legacy_dir).unwrap();
+            fs::write(legacy_dir.join("config.toml"), "legacy = true").unwrap();
+
+            let target_dir = config_root.join("wayscriber");
+            fs::create_dir_all(&target_dir).unwrap();
+            fs::write(target_dir.join("config.toml"), "replacement = false").unwrap();
+
+            let report = migrate_config(false).expect("migration succeeds");
+
+            match report.actions {
+                MigrationActions::Migrated {
+                    target_existed,
+                    files_copied,
+                    backup_path: Some(ref backup),
+                } => {
+                    assert!(target_existed);
+                    assert_eq!(files_copied, 1);
+                    assert!(backup.exists(), "backup directory should exist");
+                    assert!(
+                        backup
+                            .file_name()
+                            .unwrap()
+                            .to_string_lossy()
+                            .starts_with("wayscriber.backup."),
+                        "backup directory name should be timestamped"
+                    );
+                    let backup_file = backup.join("config.toml");
+                    assert!(backup_file.exists());
+                    assert_eq!(
+                        fs::read_to_string(backup_file).unwrap(),
+                        "replacement = false"
+                    );
+                }
+                other => panic!("unexpected migration result: {:?}", other),
+            }
+
+            assert_eq!(
+                fs::read_to_string(report.target_dir.join("config.toml")).unwrap(),
+                "legacy = true"
+            );
+        });
+    }
+
+    #[test]
+    fn migrate_supports_dry_run() {
+        with_temp_config_home(|config_root| {
+            let legacy_dir = config_root.join("hyprmarker");
+            fs::create_dir_all(&legacy_dir).unwrap();
+            fs::write(legacy_dir.join("config.toml"), "legacy = true").unwrap();
+
+            let report = migrate_config(true).expect("dry-run succeeds");
+
+            match report.actions {
+                MigrationActions::DryRun {
+                    target_exists,
+                    files_to_copy,
+                } => {
+                    assert!(!target_exists);
+                    assert_eq!(files_to_copy, 1);
+                }
+                other => panic!("unexpected dry-run result: {:?}", other),
+            }
+
+            let config_dir = primary_config_dir().unwrap();
+            assert!(
+                !config_dir.exists(),
+                "dry-run should not create target directories"
+            );
+        });
+    }
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -453,7 +453,7 @@ fn default_capture_enabled() -> bool {
 }
 
 fn default_capture_directory() -> String {
-    "~/Pictures/Hyprmarker".to_string()
+    "~/Pictures/Wayscriber".to_string()
 }
 
 fn default_capture_filename() -> String {

--- a/src/draw/color.rs
+++ b/src/draw/color.rs
@@ -7,7 +7,7 @@
 /// # Examples
 ///
 /// ```
-/// use hyprmarker::draw::Color;
+/// use wayscriber::draw::Color;
 /// let red = Color { r: 1.0, g: 0.0, b: 0.0, a: 1.0 };
 /// let semi_transparent_blue = Color { r: 0.0, g: 0.0, b: 1.0, a: 0.5 };
 /// ```

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -6,6 +6,7 @@ use super::modifiers::Modifiers;
 use super::tool::Tool;
 use crate::config::{Action, BoardConfig, KeyBinding};
 use crate::draw::{CanvasSet, Color, FontDescriptor, Shape};
+use crate::legacy;
 use crate::util;
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
@@ -138,8 +139,8 @@ impl InputState {
     }
 
     fn launch_configurator(&self) {
-        let binary = std::env::var("HYPRMARKER_CONFIGURATOR")
-            .unwrap_or_else(|_| "hyprmarker-configurator".to_string());
+        let binary = legacy::configurator_override()
+            .unwrap_or_else(|| "wayscriber-configurator".to_string());
 
         match Command::new(&binary)
             .stdin(Stdio::null())
@@ -149,14 +150,14 @@ impl InputState {
         {
             Ok(child) => {
                 log::info!(
-                    "Launched hyprmarker-configurator (binary: {binary}, pid: {})",
+                    "Launched wayscriber-configurator (binary: {binary}, pid: {})",
                     child.id()
                 );
             }
             Err(err) => {
-                log::error!("Failed to launch hyprmarker-configurator using '{binary}': {err}");
+                log::error!("Failed to launch wayscriber-configurator using '{binary}': {err}");
                 log::error!(
-                    "Set HYPRMARKER_CONFIGURATOR to override the executable path if needed."
+                    "Set WAYSCRIBER_CONFIGURATOR (or legacy HYPRMARKER_CONFIGURATOR) to override the executable path if needed."
                 );
             }
         }

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+/// Environment variable set by the legacy shim (`hyprmarker`) before invoking the real binary.
+pub const LEGACY_ALIAS_ENV: &str = "WAYSCRIBER_LEGACY_INVOCATION";
+
+/// Environment variable users can set to silence rename warnings during scripted runs.
+pub const LEGACY_SILENCE_ENV: &str = "HYPRMARKER_SILENCE_RENAME";
+
+/// Returns the value provided by the legacy shim, if the binary was launched via compatibility alias.
+pub fn alias_invocation() -> Option<String> {
+    env::var(LEGACY_ALIAS_ENV).ok()
+}
+
+/// Returns true if rename warnings should be suppressed for the current process.
+pub fn warnings_suppressed() -> bool {
+    env::var_os(LEGACY_SILENCE_ENV).is_some()
+}
+
+/// Returns override value for the configurator binary, checking both new and legacy env vars.
+pub fn configurator_override() -> Option<String> {
+    env::var("WAYSCRIBER_CONFIGURATOR")
+        .ok()
+        .or_else(|| env::var("HYPRMARKER_CONFIGURATOR").ok())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-//! Library exports for reusing hyprmarker subsystems.
+//! Library exports for reusing wayscriber subsystems.
+//!
+//! Formerly known as **hyprmarker** prior to the v0.5.0 rename.
 //!
 //! Exposes configuration data structures alongside the supporting modules they
 //! rely on so that external tools (e.g. GUI configurators) can share validation
@@ -7,6 +9,7 @@
 pub mod config;
 pub mod draw;
 pub mod input;
+pub mod legacy;
 pub mod util;
 
 pub use config::Config;

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -62,7 +62,7 @@ pub async fn send_notification(
 
     proxy
         .notify(
-            "Hyprmarker",
+            "Wayscriber",
             0,
             icon,
             summary,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -158,12 +158,12 @@ pub fn render_help_overlay(
     screen_height: u32,
 ) {
     let version_line = format!(
-        "  Hyprmarker {}  |  F11 → Open Configurator",
+        "  Wayscriber {}  |  F11 → Open Configurator",
         env!("CARGO_PKG_VERSION")
     );
 
     let help_text = vec![
-        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ HYPRMARKER CONTROLS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ WAYSCRIBER CONTROLS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
         "",
         version_line.as_str(),
         "",

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,18 +4,26 @@ Helper scripts for development and installation.
 
 ## Scripts
 
-- **install.sh** - Installation script for hyprmarker
+- **install.sh** - Installation script for wayscriber
   - Builds and installs binary to `~/.local/bin`
   - Sets up config directory
   - Optionally configures systemd or Hyprland autostart
   - Usage: `./tools/install.sh`
 
 - **run.sh** - Quick run script for development
-  - Runs hyprmarker in daemon mode with debug logging
+  - Runs wayscriber in daemon mode with debug logging
   - Usage: `./tools/run.sh`
 
 - **reload-daemon.sh** - Reload running daemon
   - Kills and restarts the daemon (picks up config changes)
   - Usage: `./tools/reload-daemon.sh`
+
+- **migrate-systemd-service.sh** - Switch systemd user unit to Wayscriber
+  - Disables `hyprmarker.service`, installs/enables `wayscriber.service`
+  - Usage: `./tools/migrate-systemd-service.sh`
+
+- **check-hyprland-config.sh** - Audit Hyprland config for legacy references
+  - Shows or replaces `hyprmarker` entries with `wayscriber`
+  - Usage: `./tools/check-hyprland-config.sh [--apply]`
 
 All scripts work from any location in the project.

--- a/tools/fetch-all-deps.sh
+++ b/tools/fetch-all-deps.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-echo "Fetching hyprmarker dependencies..."
+echo "Fetching wayscriber dependencies..."
 cargo fetch --locked --manifest-path "$repo_root/Cargo.toml"
 
 if [[ -f "$repo_root/configurator/Cargo.toml" ]]; then

--- a/tools/reload-daemon.sh
+++ b/tools/reload-daemon.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
-# Reload hyprmarker daemon
+# Reload wayscriber daemon
 # This will kill the old daemon and start a new one with updated config
 
-echo "Stopping hyprmarker daemon..."
-pkill hyprmarker
+echo "Stopping wayscriber daemon..."
+pkill wayscriber
 
 # Wait a moment for clean shutdown
 sleep 0.5
 
-echo "Starting hyprmarker daemon..."
-hyprmarker --daemon &
+echo "Starting wayscriber daemon..."
+wayscriber --daemon &
 
 # Wait to verify it started
 sleep 0.5
 
-if pgrep -x hyprmarker > /dev/null; then
-    echo "✓ Daemon restarted successfully (PID: $(pgrep -x hyprmarker))"
+if pgrep -x wayscriber > /dev/null; then
+    echo "✓ Daemon restarted successfully (PID: $(pgrep -x wayscriber))"
     echo "Press Super+D to toggle overlay"
 else
     echo "✗ Failed to start daemon"

--- a/tools/update-aur.sh
+++ b/tools/update-aur.sh
@@ -4,24 +4,43 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-AUR_DIR="$HOME/aur-packages"
-
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PACKAGE_NAME="${1:-wayscriber}"
+case "$PACKAGE_NAME" in
+    wayscriber)
+        SOURCE_FILE="$PROJECT_ROOT/packaging/PKGBUILD"
+        AUR_REPO="wayscriber"
+        PACKAGE_URL="https://aur.archlinux.org/packages/wayscriber"
+        ;;
+    hyprmarker|hyprmarker-meta)
+        SOURCE_FILE="$PROJECT_ROOT/packaging/PKGBUILD.hyprmarker-meta"
+        AUR_REPO="hyprmarker"
+        PACKAGE_URL="https://aur.archlinux.org/packages/hyprmarker"
+        ;;
+    *)
+        echo -e "${RED}Unknown package '$PACKAGE_NAME'. Supported: wayscriber, hyprmarker${NC}"
+        exit 1
+        ;;
+esac
+
+AUR_DIR="$HOME/aur-packages/$PACKAGE_NAME"
+
 echo "═══════════════════════════════════════════════════════════════"
-echo "  HYPRMARKER - AUR UPDATE AUTOMATION"
+echo "  WAYSCRIBER - AUR UPDATE AUTOMATION ($PACKAGE_NAME)"
 echo "═══════════════════════════════════════════════════════════════"
 echo ""
 
 # Check we're in the right directory
 if [ ! -f "$PROJECT_ROOT/Cargo.toml" ]; then
-    echo -e "${RED}❌ Error: Not in hyprmarker project root${NC}"
+    echo -e "${RED}❌ Error: Not in wayscriber project root${NC}"
     exit 1
 fi
 
@@ -49,34 +68,43 @@ fi
 
 # Check AUR directory exists
 if [ ! -d "$AUR_DIR" ]; then
-    echo -e "${RED}❌ Error: AUR directory not found: $AUR_DIR${NC}"
-    echo ""
-    echo "Initialize it first:"
-    echo "  mkdir -p $AUR_DIR"
-    echo "  cd $AUR_DIR"
-    echo "  git init"
-    echo "  git remote add origin ssh://aur@aur.archlinux.org/hyprmarker.git"
-    exit 1
+    echo -e "${YELLOW}AUR working directory not found: $AUR_DIR${NC}"
+    echo "Creating a fresh clone..."
+    mkdir -p "$AUR_DIR"
+    cd "$AUR_DIR"
+    git init
+    git remote add origin "ssh://aur@aur.archlinux.org/$AUR_REPO.git"
+else
+    cd "$AUR_DIR"
 fi
+
+git fetch origin 2>/dev/null || true
+git checkout master 2>/dev/null || git checkout -b master
+git pull --rebase origin master 2>/dev/null || true
+cd "$PROJECT_ROOT"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "STEP 1: Update PKGBUILD"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
-# Copy PKGBUILD.aur to AUR directory
-if [ ! -f "$PROJECT_ROOT/packaging/PKGBUILD.aur" ]; then
-    echo -e "${RED}❌ Error: PKGBUILD.aur not found${NC}"
+# Copy template PKGBUILD
+if [ ! -f "$SOURCE_FILE" ]; then
+    echo -e "${RED}❌ Error: template $SOURCE_FILE not found${NC}"
     exit 1
 fi
 
-cp "$PROJECT_ROOT/packaging/PKGBUILD.aur" "$AUR_DIR/PKGBUILD"
-echo -e "${GREEN}✅ Copied PKGBUILD.aur to $AUR_DIR/PKGBUILD${NC}"
+cp "$SOURCE_FILE" "$AUR_DIR/PKGBUILD"
+echo -e "${GREEN}Copied $SOURCE_FILE to $AUR_DIR/PKGBUILD${NC}"
 
 # Update version in PKGBUILD
 cd "$AUR_DIR"
-sed -i "s/^pkgver=.*/pkgver=$CARGO_VERSION/" PKGBUILD
-sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+if grep -q '^pkgver=' PKGBUILD; then
+    sed -i "s/^pkgver=.*/pkgver=$CARGO_VERSION/" PKGBUILD
+fi
+if grep -q '^pkgrel=' PKGBUILD; then
+    sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+fi
 
 echo -e "${GREEN}✅ Updated PKGBUILD: pkgver=$CARGO_VERSION, pkgrel=1${NC}"
 echo ""
@@ -130,12 +158,6 @@ read -p "Push to AUR? (y/n) " -n 1 -r
 echo ""
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     # Check if git is initialized
-    if [ ! -d "$AUR_DIR/.git" ]; then
-        echo "Initializing git repository..."
-        git init
-        git remote add origin ssh://aur@aur.archlinux.org/hyprmarker.git
-    fi
-
     # Add and commit
     git add PKGBUILD .SRCINFO .gitignore 2>/dev/null || git add PKGBUILD .SRCINFO
     git commit -m "Update to v$CARGO_VERSION"
@@ -156,12 +178,12 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo -e "${GREEN}✅ AUR PACKAGE UPDATED SUCCESSFULLY${NC}"
     echo "═══════════════════════════════════════════════════════════════"
     echo ""
-    echo "Package URL: https://aur.archlinux.org/packages/hyprmarker"
+    echo "Package URL: $PACKAGE_URL"
     echo "Version: $CARGO_VERSION"
     echo ""
     echo "Users can update with:"
-    echo "  yay -Syu hyprmarker"
-    echo "  paru -Syu hyprmarker"
+    echo "  yay -Syu wayscriber"
+    echo "  paru -Syu wayscriber"
     echo ""
 else
     echo -e "${YELLOW}⚠️  Push to AUR cancelled${NC}"


### PR DESCRIPTION
This major rename reflects the project's evolution from a Hyprland-specific tool to a compositor-agnostic Wayland screen annotation utility.

Major changes:
- Renamed all binaries: hyprmarker → wayscriber
- Updated package metadata (Cargo.toml)
- Added compatibility aliases (hyprmarker remains as wrapper)
- Implemented config migration (--migrate-config)
- Updated all documentation and examples
- Added MIGRATION.md guide for users
- Updated systemd service files
- Preserved backward compatibility for 6-month grace period