### PR TITLE
eraser: densify stroke-erase path sampling

### DIFF
--- a/src/input/state/core/selection_actions.rs
+++ b/src/input/state/core/selection_actions.rs
@@ -60,8 +60,52 @@ impl InputState {
     }
 
     pub(crate) fn erase_strokes_by_points(&mut self, points: &[(i32, i32)]) -> bool {
-        let ids = self.hit_test_all_for_points(points, self.eraser_hit_radius());
+        let sampled = self.sample_eraser_path_points(points);
+        let ids = self.hit_test_all_for_points(&sampled, self.eraser_hit_radius());
         self.delete_shapes_by_ids(&ids)
+    }
+
+    fn sample_eraser_path_points(&self, points: &[(i32, i32)]) -> Vec<(i32, i32)> {
+        if points.len() < 2 {
+            return points.to_vec();
+        }
+
+        let step = (self.eraser_hit_radius() * 0.9).max(1.0);
+        let mut needs_sampling = false;
+        for window in points.windows(2) {
+            let dx = (window[1].0 - window[0].0) as f64;
+            let dy = (window[1].1 - window[0].1) as f64;
+            if (dx * dx + dy * dy).sqrt() > step {
+                needs_sampling = true;
+                break;
+            }
+        }
+
+        if !needs_sampling {
+            return points.to_vec();
+        }
+
+        let mut sampled = Vec::with_capacity(points.len());
+        sampled.push(points[0]);
+        for window in points.windows(2) {
+            let (x0, y0) = window[0];
+            let (x1, y1) = window[1];
+            let dx = (x1 - x0) as f64;
+            let dy = (y1 - y0) as f64;
+            let dist = (dx * dx + dy * dy).sqrt();
+            let steps = ((dist / step).ceil() as i32).max(1);
+            for i in 1..=steps {
+                let t = i as f64 / steps as f64;
+                let point = (
+                    (x0 as f64 + dx * t).round() as i32,
+                    (y0 as f64 + dy * t).round() as i32,
+                );
+                if sampled.last().copied() != Some(point) {
+                    sampled.push(point);
+                }
+            }
+        }
+        sampled
     }
 
     pub(crate) fn duplicate_selection(&mut self) -> bool {

--- a/src/input/state/mouse.rs
+++ b/src/input/state/mouse.rs
@@ -309,7 +309,11 @@ impl InputState {
                     Tool::Eraser => {
                         if self.eraser_mode == EraserMode::Stroke {
                             self.clear_provisional_dirty();
-                            self.erase_strokes_by_points(&points);
+                            let mut path = points;
+                            if path.last().copied() != Some((x, y)) {
+                                path.push((x, y));
+                            }
+                            self.erase_strokes_by_points(&path);
                             return;
                         }
                         Shape::EraserStroke {

--- a/src/input/state/tests.rs
+++ b/src/input/state/tests.rs
@@ -941,3 +941,177 @@ fn keyboard_context_menu_sets_initial_focus() {
         ContextMenuState::Hidden => panic!("Context menu should be open"),
     }
 }
+
+#[test]
+fn erase_stroke_samples_sparse_path() {
+    let mut state = create_test_input_state();
+    state.eraser_size = 4.0;
+    state.eraser_mode = EraserMode::Stroke;
+
+    let line_id = state.canvas_set.active_frame_mut().add_shape(Shape::Line {
+        x1: 0,
+        y1: 0,
+        x2: 100,
+        y2: 0,
+        color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 1.0,
+    });
+
+    let erased = state.erase_strokes_by_points(&[(0, -10), (100, 10)]);
+    assert!(erased, "stroke eraser should remove intersected line");
+    assert!(state.canvas_set.active_frame().shape(line_id).is_none());
+}
+
+#[test]
+fn erase_stroke_includes_release_segment() {
+    let mut state = create_test_input_state();
+    state.eraser_size = 4.0;
+    state.eraser_mode = EraserMode::Stroke;
+    state.set_tool_override(Some(Tool::Eraser));
+
+    let line_id = state.canvas_set.active_frame_mut().add_shape(Shape::Line {
+        x1: 0,
+        y1: 0,
+        x2: 100,
+        y2: 0,
+        color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 1.0,
+    });
+
+    state.on_mouse_press(MouseButton::Left, 0, -10);
+    state.on_mouse_release(MouseButton::Left, 100, 10);
+
+    assert!(state.canvas_set.active_frame().shape(line_id).is_none());
+}
+
+#[test]
+fn erase_stroke_samples_randomized_crossings() {
+    fn next_unit(seed: &mut u64) -> f64 {
+        *seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let value = ((*seed >> 33) as u32) as f64;
+        value / (u32::MAX as f64)
+    }
+
+    let mut seed = 0x1234_5678_9abc_def0u64;
+    for _ in 0..16 {
+        let mut state = create_test_input_state();
+        state.eraser_size = 4.0;
+        state.eraser_mode = EraserMode::Stroke;
+
+        let line_id = state.canvas_set.active_frame_mut().add_shape(Shape::Line {
+            x1: 0,
+            y1: 0,
+            x2: 100,
+            y2: 0,
+            color: Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            thick: 1.0,
+        });
+
+        let unit = next_unit(&mut seed);
+        let angle = std::f64::consts::PI * (0.35 + unit * 0.3);
+        let dx = angle.cos();
+        let dy = angle.sin();
+        let length = 80.0;
+        let x0 = 50.0 - dx * length;
+        let y0 = 0.0 - dy * length;
+        let x1 = 50.0 + dx * length;
+        let y1 = 0.0 + dy * length;
+
+        let erased = state.erase_strokes_by_points(&[
+            (x0.round() as i32, y0.round() as i32),
+            (x1.round() as i32, y1.round() as i32),
+        ]);
+
+        assert!(
+            erased,
+            "stroke eraser should remove line at angle {}",
+            angle
+        );
+        assert!(state.canvas_set.active_frame().shape(line_id).is_none());
+    }
+}
+
+#[test]
+fn erase_stroke_hits_various_shapes() {
+    let cases = vec![
+        (
+            Shape::Rect {
+                x: 10,
+                y: 10,
+                w: 40,
+                h: 20,
+                fill: false,
+                color: Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                },
+                thick: 1.0,
+            },
+            vec![(0, 10), (100, 10)],
+        ),
+        (
+            Shape::Ellipse {
+                cx: 50,
+                cy: 50,
+                rx: 20,
+                ry: 10,
+                fill: false,
+                color: Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                },
+                thick: 1.0,
+            },
+            vec![(0, 40), (100, 40)],
+        ),
+        (
+            Shape::Arrow {
+                x1: 10,
+                y1: 90,
+                x2: 90,
+                y2: 90,
+                color: Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                },
+                thick: 1.0,
+                arrow_length: 20.0,
+                arrow_angle: 30.0,
+                head_at_end: true,
+            },
+            vec![(0, 90), (100, 90)],
+        ),
+    ];
+
+    for (shape, path) in cases {
+        let mut state = create_test_input_state();
+        state.eraser_size = 4.0;
+        state.eraser_mode = EraserMode::Stroke;
+        let shape_id = state.canvas_set.active_frame_mut().add_shape(shape);
+
+        let erased = state.erase_strokes_by_points(&path);
+        assert!(erased, "stroke eraser should remove intersected shape");
+        assert!(state.canvas_set.active_frame().shape(shape_id).is_none());
+    }
+}


### PR DESCRIPTION
Sample along erase paths with slight overlap, include release point, and add tests for sparse paths, release-only paths, and varied shapes.

Resolves #61 