### PR TITLE
backend/keyboard: accept non-ascii characters

### DIFF
--- a/src/backend/wayland/handlers/keyboard.rs
+++ b/src/backend/wayland/handlers/keyboard.rs
@@ -285,9 +285,9 @@ impl KeyboardHandler for WaylandState {
 fn keysym_to_key(keysym: Keysym) -> Key {
     match keysym {
         Keysym::Escape => Key::Escape,
-        Keysym::Return => Key::Return,
+        Keysym::Return | Keysym::KP_Enter => Key::Return,
         Keysym::BackSpace => Key::Backspace,
-        Keysym::Tab => Key::Tab,
+        Keysym::Tab | Keysym::KP_Tab => Key::Tab,
         Keysym::space => Key::Space,
         Keysym::Up => Key::Up,
         Keysym::Down => Key::Down,
@@ -302,47 +302,18 @@ fn keysym_to_key(keysym: Keysym) -> Key {
         Keysym::Control_L | Keysym::Control_R => Key::Ctrl,
         Keysym::Alt_L | Keysym::Alt_R => Key::Alt,
         Keysym::Menu => Key::Menu,
-        Keysym::plus => Key::Char('+'),
-        Keysym::equal => Key::Char('='),
-        Keysym::minus => Key::Char('-'),
-        Keysym::underscore => Key::Char('_'),
-        Keysym::_0 | Keysym::KP_0 => Key::Char('0'),
-        Keysym::t => Key::Char('t'),
-        Keysym::T => Key::Char('T'),
-        Keysym::e => Key::Char('e'),
-        Keysym::E => Key::Char('E'),
-        Keysym::r => Key::Char('r'),
-        Keysym::R => Key::Char('R'),
-        Keysym::g => Key::Char('g'),
-        Keysym::G => Key::Char('G'),
-        Keysym::b => Key::Char('b'),
-        Keysym::B => Key::Char('B'),
-        Keysym::y => Key::Char('y'),
-        Keysym::Y => Key::Char('Y'),
-        Keysym::o => Key::Char('o'),
-        Keysym::O => Key::Char('O'),
-        Keysym::p => Key::Char('p'),
-        Keysym::P => Key::Char('P'),
-        Keysym::w => Key::Char('w'),
-        Keysym::W => Key::Char('W'),
-        Keysym::k => Key::Char('k'),
-        Keysym::K => Key::Char('K'),
-        Keysym::z => Key::Char('z'),
-        Keysym::Z => Key::Char('Z'),
         Keysym::F1 => Key::F1,
         Keysym::F2 => Key::F2,
+        Keysym::F3 => Key::F3,
         Keysym::F4 => Key::F4,
+        Keysym::F5 => Key::F5,
+        Keysym::F6 => Key::F6,
+        Keysym::F7 => Key::F7,
+        Keysym::F8 => Key::F8,
         Keysym::F9 => Key::F9,
         Keysym::F10 => Key::F10,
         Keysym::F11 => Key::F11,
         Keysym::F12 => Key::F12,
-        _ => {
-            let raw = keysym.raw();
-            if (0x20..=0x7E).contains(&raw) {
-                Key::Char(raw as u8 as char)
-            } else {
-                Key::Unknown
-            }
-        }
+        _ => keysym.key_char().map_or(Key::Unknown, Key::Char),
     }
 }

--- a/src/input/events.rs
+++ b/src/input/events.rs
@@ -49,8 +49,18 @@ pub enum Key {
     F1,
     /// F2 function key (toolbar toggle)
     F2,
+    /// F3 function key
+    F3,
     /// F4 function key (toggle status bar)
     F4,
+    /// F5 function key
+    F5,
+    /// F6 function key
+    F6,
+    /// F7 function key
+    F7,
+    /// F8 function key
+    F8,
     /// F9 function key (toggle toolbar)
     F9,
     /// F10 function key (toggle help)


### PR DESCRIPTION
rn only ascii characters are accepted, and others return `Key::Unknown`. This removes the check and uses `Keysym::key_char()` to obtain the character. 

Also remvoed match cases for `t, e, r, g, b, y, o, p, w, k, z` as `key_char()` already handles them, unless if I'm missing something.

I've only tested with Arabic, but I'd assume it will for other layouts
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7b364da3-bc94-413b-9424-6b1396cdb31d" />
