### PR TITLE
feat(ui): add config option to disable compositor capabilities warning toast

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -246,6 +246,9 @@ status_bar_position = "bottom-left"
 # Filter help overlay sections based on enabled features
 help_overlay_context_filter = true
 
+# Show compositor capabilities warning toast each time the overlay starts
+show_capabilities_warning = true
+
 # Command palette action toast duration (ms)
 command_palette_toast_duration_ms = 1500
 

--- a/configurator/src/app/view/ui/mod.rs
+++ b/configurator/src/app/view/ui/mod.rs
@@ -69,6 +69,12 @@ impl ConfiguratorApp {
                 self.defaults.ui_context_menu_enabled,
                 ToggleField::UiContextMenuEnabled,
             ),
+            toggle_row(
+                "Show capabilities warning toast",
+                self.draft.ui_show_capabilities_warning,
+                self.defaults.ui_show_capabilities_warning,
+                ToggleField::UiShowCapabilitiesWarning,
+            ),
             labeled_input(
                 "Command palette toast (ms)",
                 &self.draft.ui_command_palette_toast_duration_ms,

--- a/configurator/src/models/config/draft/from_config.rs
+++ b/configurator/src/models/config/draft/from_config.rs
@@ -70,6 +70,7 @@ impl ConfigDraft {
             ui_show_status_page_badge: config.ui.show_status_page_badge,
             ui_show_page_badge_with_status_bar: config.ui.show_floating_badge_always,
             ui_show_frozen_badge: config.ui.show_frozen_badge,
+            ui_show_capabilities_warning: config.ui.show_capabilities_warning,
             ui_context_menu_enabled: config.ui.context_menu.enabled,
             ui_preferred_output: config.ui.preferred_output.clone().unwrap_or_default(),
             ui_xdg_fullscreen: config.ui.xdg_fullscreen,

--- a/configurator/src/models/config/draft/mod.rs
+++ b/configurator/src/models/config/draft/mod.rs
@@ -59,6 +59,7 @@ pub struct ConfigDraft {
     pub ui_show_status_page_badge: bool,
     pub ui_show_page_badge_with_status_bar: bool,
     pub ui_show_frozen_badge: bool,
+    pub ui_show_capabilities_warning: bool,
     pub ui_context_menu_enabled: bool,
     pub ui_preferred_output: String,
     pub ui_xdg_fullscreen: bool,

--- a/configurator/src/models/config/setters.rs
+++ b/configurator/src/models/config/setters.rs
@@ -51,6 +51,7 @@ impl ConfigDraft {
             ToggleField::PerformanceVsync => self.performance_enable_vsync = value,
             ToggleField::UiShowStatusBar => self.ui_show_status_bar = value,
             ToggleField::UiShowFrozenBadge => self.ui_show_frozen_badge = value,
+            ToggleField::UiShowCapabilitiesWarning => self.ui_show_capabilities_warning = value,
             ToggleField::UiShowStatusBoardBadge => self.ui_show_status_board_badge = value,
             ToggleField::UiShowStatusPageBadge => self.ui_show_status_page_badge = value,
             ToggleField::UiShowPageBadgeWithStatusBar => {

--- a/configurator/src/models/config/to_config/ui.rs
+++ b/configurator/src/models/config/to_config/ui.rs
@@ -10,6 +10,7 @@ impl ConfigDraft {
         config.ui.show_status_page_badge = self.ui_show_status_page_badge;
         config.ui.show_floating_badge_always = self.ui_show_page_badge_with_status_bar;
         config.ui.show_frozen_badge = self.ui_show_frozen_badge;
+        config.ui.show_capabilities_warning = self.ui_show_capabilities_warning;
         config.ui.context_menu.enabled = self.ui_context_menu_enabled;
         let preferred_output = self.ui_preferred_output.trim();
         config.ui.preferred_output = if preferred_output.is_empty() {

--- a/configurator/src/models/fields/toggles.rs
+++ b/configurator/src/models/fields/toggles.rs
@@ -5,6 +5,7 @@ pub enum ToggleField {
     PerformanceVsync,
     UiShowStatusBar,
     UiShowFrozenBadge,
+    UiShowCapabilitiesWarning,
     UiHelpOverlayContextFilter,
     UiContextMenuEnabled,
     UiXdgFullscreen,

--- a/src/backend/wayland/state/onboarding.rs
+++ b/src/backend/wayland/state/onboarding.rs
@@ -505,6 +505,9 @@ impl WaylandState {
         if self.input_state.capability_toast_shown {
             return;
         }
+        if !self.config.ui.show_capabilities_warning {
+            return;
+        }
         if !self.surface.is_configured() {
             return;
         }

--- a/src/config/types/ui.rs
+++ b/src/config/types/ui.rs
@@ -52,6 +52,10 @@ pub struct UiConfig {
     #[serde(default = "default_help_overlay_context_filter")]
     pub help_overlay_context_filter: bool,
 
+    /// Show compositor capability warning toast on overlay start
+    #[serde(default = "default_show_capabilities_warning")]
+    pub show_capabilities_warning: bool,
+
     /// Preferred output name for the xdg-shell fallback overlay (GNOME).
     /// Falls back to last entered output or first available.
     #[serde(default)]
@@ -112,6 +116,7 @@ impl Default for UiConfig {
             status_bar_style: StatusBarStyle::default(),
             help_overlay_style: HelpOverlayStyle::default(),
             help_overlay_context_filter: default_help_overlay_context_filter(),
+            show_capabilities_warning: default_show_capabilities_warning(),
             preferred_output: None,
             multi_monitor_enabled: default_multi_monitor_enabled(),
             active_output_badge: default_active_output_badge(),
@@ -176,6 +181,10 @@ fn use_gnome_fallback_defaults() -> bool {
 }
 
 fn default_help_overlay_context_filter() -> bool {
+    true
+}
+
+fn default_show_capabilities_warning() -> bool {
     true
 }
 


### PR DESCRIPTION
Hi! Here is a small change adding a config option.

Problem: In daemon mode, the compositor capabilities warning toast is shown every time the overlay is toggled on. This can be annoying if one uses the global shortcut to show/hide the overlay frequently.

Solution: Add a `show_capabilities_warning` boolean to the `[ui]` config section (default `true`). When set to `false`, the toast is suppressed entirely.

```toml
[ui]
show_capabilities_warning = false
```

The option is also available in the configurator GUI under **UI Settings > General UI**.

If this is not a good solution feel free to close the PR. Another idea is to introduce an environment variable like `DISABLE_CAPABILITIES_WARNING`, and have the daemon set it to `1` the second time it launches the overlay process. This way the warning will be shown once and never again until the daemon is closed.