### PR TITLE
Show cursor while tablet stylus hovers

### DIFF
--- a/src/backend/wayland/handlers/tablet/tool.rs
+++ b/src/backend/wayland/handlers/tablet/tool.rs
@@ -3,9 +3,96 @@ use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
 use wayland_protocols::wp::tablet::zv2::client::zwp_tablet_tool_v2::ZwpTabletToolV2;
 
 use crate::backend::wayland::toolbar_intent::intent_to_event;
-use crate::input::{MouseButton, Tool};
+use crate::{
+    input::{DrawingState, EraserMode, MouseButton, Tool},
+    util::Rect,
+};
 
 use crate::backend::wayland::state::WaylandState;
+
+const STYLUS_CURSOR_DAMAGE_RADIUS: i32 = 64;
+
+impl WaylandState {
+    fn stylus_hover_cursor_pos(&self) -> Option<(f64, f64)> {
+        self.stylus_hover_cursor_position()
+    }
+
+    fn stylus_hover_needs_full_damage(
+        &self,
+        previous: Option<(f64, f64)>,
+        next: Option<(f64, f64)>,
+    ) -> bool {
+        if previous.is_none() && next.is_none() {
+            return false;
+        }
+
+        self.stylus_hover_eraser_needs_full_damage() || self.stylus_hover_ui_needs_full_damage()
+    }
+
+    fn stylus_hover_eraser_needs_full_damage(&self) -> bool {
+        self.input_state.eraser_mode == EraserMode::Stroke
+            && self.input_state.active_tool() == Tool::Eraser
+            && matches!(self.input_state.state, DrawingState::Idle)
+    }
+
+    fn stylus_hover_ui_needs_full_damage(&self) -> bool {
+        self.input_state.is_radial_menu_open()
+            || self.input_state.is_color_picker_popup_open()
+            || self.input_state.is_board_picker_open()
+            || self.input_state.is_properties_panel_open()
+            || self.input_state.is_context_menu_open()
+            || (self.inline_toolbars_active() && self.toolbar.is_visible())
+    }
+
+    fn mark_stylus_hover_cursor_dirty(
+        &mut self,
+        previous: Option<(f64, f64)>,
+        next: Option<(f64, f64)>,
+    ) {
+        if previous.is_none() && next.is_none() {
+            return;
+        }
+
+        if self.stylus_hover_needs_full_damage(previous, next) {
+            self.input_state.dirty_tracker.mark_full();
+            self.input_state.needs_redraw = true;
+            return;
+        }
+
+        let width = self.surface.width().min(i32::MAX as u32) as i32;
+        let height = self.surface.height().min(i32::MAX as u32) as i32;
+        for pos in [previous, next].into_iter().flatten() {
+            if let Some(rect) = stylus_cursor_damage_rect(pos, width, height) {
+                self.input_state.dirty_tracker.mark_rect(rect);
+            } else if width <= 0 || height <= 0 {
+                self.input_state.dirty_tracker.mark_full();
+            }
+        }
+        self.input_state.needs_redraw = true;
+    }
+}
+
+fn stylus_cursor_damage_rect(pos: (f64, f64), width: i32, height: i32) -> Option<Rect> {
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+
+    let x = pos.0.round() as i32;
+    let y = pos.1.round() as i32;
+    let min_x = x
+        .saturating_sub(STYLUS_CURSOR_DAMAGE_RADIUS)
+        .clamp(0, width);
+    let min_y = y
+        .saturating_sub(STYLUS_CURSOR_DAMAGE_RADIUS)
+        .clamp(0, height);
+    let max_x = x
+        .saturating_add(STYLUS_CURSOR_DAMAGE_RADIUS)
+        .clamp(0, width);
+    let max_y = y
+        .saturating_add(STYLUS_CURSOR_DAMAGE_RADIUS)
+        .clamp(0, height);
+    Rect::from_min_max(min_x, min_y, max_x, max_y)
+}
 
 impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
     fn event(
@@ -72,6 +159,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     "Tablet proximity out: tool {:?}, type: {:?}",
                     tool_id, tool_type
                 );
+                let hover_cursor_pos = state.stylus_hover_cursor_pos();
                 state.stylus_tip_down = false;
                 state.stylus_on_overlay = false;
                 state.stylus_on_toolbar = false;
@@ -86,6 +174,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 }
                 state.stylus_pressure_thickness = None;
                 state.stylus_last_pos = None;
+                state.mark_stylus_hover_cursor_dirty(hover_cursor_pos, None);
 
                 // Restore previous tool if we auto-switched to eraser
                 if state.stylus_auto_switched_to_eraser {
@@ -135,7 +224,9 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 if !state.stylus_on_overlay {
                     return;
                 }
+                let hover_cursor_pos = state.stylus_hover_cursor_pos();
                 state.stylus_tip_down = true;
+                state.mark_stylus_hover_cursor_dirty(hover_cursor_pos, None);
                 state.stylus_base_thickness = Some(state.input_state.current_thickness);
                 state.stylus_pressure_thickness = Some(state.input_state.current_thickness);
                 state.record_stylus_peak(state.input_state.current_thickness);
@@ -201,6 +292,8 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     wx,
                     wy,
                 );
+                let hover_cursor_pos = state.stylus_hover_cursor_pos();
+                state.mark_stylus_hover_cursor_dirty(None, hover_cursor_pos);
                 state.input_state.needs_redraw = true;
             }
             Event::Motion { x, y } => {
@@ -219,6 +312,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     state.set_current_mouse(x as i32, y as i32);
                     return;
                 }
+                let previous_hover_cursor_pos = state.stylus_hover_cursor_pos();
                 let inline_active = state.inline_toolbars_active() && state.toolbar.is_visible();
                 if state.stylus_on_toolbar {
                     let xf = x;
@@ -247,6 +341,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     state.stylus_last_pos = Some((x, y));
                     if state.inline_toolbar_motion((x, y)) {
                         state.stylus_on_toolbar = true;
+                        state.mark_stylus_hover_cursor_dirty(previous_hover_cursor_pos, None);
                         return;
                     } else {
                         state.stylus_on_toolbar = false;
@@ -268,6 +363,11 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     y.round() as i32,
                     wx,
                     wy,
+                );
+                let next_hover_cursor_pos = state.stylus_hover_cursor_pos();
+                state.mark_stylus_hover_cursor_dirty(
+                    previous_hover_cursor_pos,
+                    next_hover_cursor_pos,
                 );
                 if state.stylus_tip_down {
                     state.stylus_pressure_thickness = Some(state.input_state.current_thickness);
@@ -306,5 +406,42 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 debug!("Unhandled tablet tool event: {:?}", other);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stylus_cursor_damage_rect_covers_cursor_area() {
+        let rect = stylus_cursor_damage_rect((100.2, 80.7), 400, 300).expect("rect");
+
+        assert_eq!(
+            rect,
+            Rect::new(
+                100 - STYLUS_CURSOR_DAMAGE_RADIUS,
+                81 - STYLUS_CURSOR_DAMAGE_RADIUS,
+                STYLUS_CURSOR_DAMAGE_RADIUS * 2,
+                STYLUS_CURSOR_DAMAGE_RADIUS * 2,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn stylus_cursor_damage_rect_clamps_to_surface() {
+        let rect = stylus_cursor_damage_rect((4.0, 3.0), 400, 300).expect("rect");
+
+        assert_eq!(rect.x, 0);
+        assert_eq!(rect.y, 0);
+        assert_eq!(rect.width, 68);
+        assert_eq!(rect.height, 67);
+    }
+
+    #[test]
+    fn stylus_cursor_damage_rect_ignores_empty_surface() {
+        assert_eq!(stylus_cursor_damage_rect((10.0, 10.0), 0, 300), None);
+        assert_eq!(stylus_cursor_damage_rect((10.0, 10.0), 400, 0), None);
     }
 }

--- a/src/backend/wayland/state/core/accessors.rs
+++ b/src/backend/wayland/state/core/accessors.rs
@@ -27,6 +27,41 @@ impl WaylandState {
         self.data.has_pointer_focus
     }
 
+    pub(in crate::backend::wayland) fn has_cursor_focus(&self) -> bool {
+        self.has_pointer_focus() || self.stylus_hover_cursor_visible()
+    }
+
+    pub(in crate::backend::wayland) fn cursor_blocked_by_toolbar(&self) -> bool {
+        self.stylus_hover_cursor_position().is_none() && self.pointer_over_toolbar()
+    }
+
+    #[cfg(tablet)]
+    pub(in crate::backend::wayland) fn stylus_hover_cursor_visible(&self) -> bool {
+        self.stylus_on_overlay
+            && !self.stylus_on_toolbar
+            && !self.stylus_tip_down
+            && self.stylus_last_pos.is_some()
+    }
+
+    #[cfg(tablet)]
+    pub(in crate::backend::wayland) fn stylus_hover_cursor_position(&self) -> Option<(f64, f64)> {
+        if self.stylus_hover_cursor_visible() {
+            self.stylus_last_pos
+        } else {
+            None
+        }
+    }
+
+    #[cfg(not(tablet))]
+    pub(in crate::backend::wayland) fn stylus_hover_cursor_visible(&self) -> bool {
+        false
+    }
+
+    #[cfg(not(tablet))]
+    pub(in crate::backend::wayland) fn stylus_hover_cursor_position(&self) -> Option<(f64, f64)> {
+        None
+    }
+
     pub(in crate::backend::wayland) fn set_pointer_focus(&mut self, value: bool) {
         self.data.has_pointer_focus = value;
     }

--- a/src/backend/wayland/state/render/canvas/mod.rs
+++ b/src/backend/wayland/state/render/canvas/mod.rs
@@ -161,8 +161,12 @@ impl WaylandState {
 
         let (mx, my) =
             self.canvas_world_coords(self.current_mouse().0 as f64, self.current_mouse().1 as f64);
+        let (hover_mx, hover_my) = self
+            .stylus_hover_cursor_position()
+            .map(|(x, y)| self.canvas_world_coords(x, y))
+            .unwrap_or((mx, my));
 
-        self.render_eraser_hover_halos(ctx, mx, my);
+        self.render_eraser_hover_halos(ctx, hover_mx, hover_my);
 
         // Render provisional shape if actively drawing.
         let rendered_provisional = if let crate::input::DrawingState::Drawing {

--- a/src/backend/wayland/state/render/canvas/overlays.rs
+++ b/src/backend/wayland/state/render/canvas/overlays.rs
@@ -61,8 +61,8 @@ impl WaylandState {
             && !eraser_drawing
             && self.input_state.active_tool() == Tool::Eraser
             && matches!(self.input_state.state, DrawingState::Idle)
-            && self.has_pointer_focus()
-            && !self.pointer_over_toolbar();
+            && self.has_cursor_focus()
+            && !self.cursor_blocked_by_toolbar();
         if eraser_stroke && (eraser_drawing || eraser_hover) {
             self.input_state.ensure_spatial_index_for_active_frame();
             let ids = if eraser_drawing {

--- a/src/backend/wayland/state/render/tool_preview.rs
+++ b/src/backend/wayland/state/render/tool_preview.rs
@@ -62,3 +62,41 @@ pub(super) fn draw_tool_preview(
     }
     let _ = ctx.restore();
 }
+
+pub(super) fn draw_stylus_hover_cursor(
+    ctx: &cairo::Context,
+    tool: Tool,
+    color: Color,
+    x: f64,
+    y: f64,
+) {
+    let (r, g, b, radius) = match tool {
+        Tool::Eraser | Tool::Select => (0.96, 0.96, 0.98, 4.0),
+        _ => (color.r, color.g, color.b, 3.5),
+    };
+
+    let _ = ctx.save();
+    ctx.set_source_rgba(0.0, 0.0, 0.0, 0.35);
+    ctx.arc(
+        x + 1.0,
+        y + 1.0,
+        radius + 2.0,
+        0.0,
+        std::f64::consts::PI * 2.0,
+    );
+    let _ = ctx.fill();
+
+    ctx.set_source_rgba(1.0, 1.0, 1.0, 0.9);
+    ctx.arc(x, y, radius + 1.4, 0.0, std::f64::consts::PI * 2.0);
+    let _ = ctx.fill();
+
+    ctx.set_source_rgba(r, g, b, 0.95);
+    ctx.arc(x, y, radius, 0.0, std::f64::consts::PI * 2.0);
+    let _ = ctx.fill();
+
+    ctx.set_source_rgba(0.0, 0.0, 0.0, 0.72);
+    ctx.set_line_width(1.0);
+    ctx.arc(x, y, radius + 1.4, 0.0, std::f64::consts::PI * 2.0);
+    let _ = ctx.stroke();
+    let _ = ctx.restore();
+}

--- a/src/backend/wayland/state/render/ui.rs
+++ b/src/backend/wayland/state/render/ui.rs
@@ -1,4 +1,4 @@
-use super::tool_preview::draw_tool_preview;
+use super::tool_preview::{draw_stylus_hover_cursor, draw_tool_preview};
 use super::*;
 
 impl WaylandState {
@@ -11,22 +11,37 @@ impl WaylandState {
     ) {
         if render_ui {
             if self.input_state.show_tool_preview
-                && self.has_pointer_focus()
-                && !self.pointer_over_toolbar()
+                && self.has_cursor_focus()
+                && !self.cursor_blocked_by_toolbar()
                 && matches!(
                     self.input_state.state,
                     DrawingState::Idle | DrawingState::PendingTextClick { .. }
                 )
             {
-                let (cursor_x, cursor_y) = self.current_mouse();
+                let (cursor_x, cursor_y) =
+                    self.stylus_hover_cursor_position().unwrap_or_else(|| {
+                        let (x, y) = self.current_mouse();
+                        (x as f64, y as f64)
+                    });
                 draw_tool_preview(
                     ctx,
                     self.input_state.active_tool(),
                     self.input_state.current_color,
-                    cursor_x as f64,
-                    cursor_y as f64,
+                    cursor_x,
+                    cursor_y,
                     width as f64,
                     height as f64,
+                );
+            }
+            if let Some((cursor_x, cursor_y)) = self.stylus_hover_cursor_position()
+                && !self.cursor_blocked_by_toolbar()
+            {
+                draw_stylus_hover_cursor(
+                    ctx,
+                    self.input_state.active_tool(),
+                    self.input_state.current_color,
+                    cursor_x,
+                    cursor_y,
                 );
             }
             // Render frozen badge even if status bar is hidden


### PR DESCRIPTION
## Summary
- show the cursor and tool preview while a tablet stylus is hovering before drawing starts
- keep tablet hover state synced with pointer and toolbar hover handling

Fixes #181