### PR TITLE
Fix frozen capture on transformed outputs

### DIFF
--- a/src/backend/wayland/frozen/capture.rs
+++ b/src/backend/wayland/frozen/capture.rs
@@ -4,7 +4,10 @@ use smithay_client_toolkit::shm::{
     Shm,
     slot::{Buffer, SlotPool},
 };
-use wayland_client::{Dispatch, QueueHandle, WEnum, protocol::wl_shm};
+use wayland_client::{
+    Dispatch, QueueHandle, WEnum,
+    protocol::{wl_output, wl_shm},
+};
 use wayland_protocols_wlr::screencopy::v1::client::zwlr_screencopy_frame_v1::{
     Event as FrameEvent, Flags, ZwlrScreencopyFrameV1,
 };
@@ -265,12 +268,21 @@ impl FrozenState {
 
         capture.frame.destroy();
 
-        self.set_image(FrozenImage {
-            width: capture.width,
-            height: capture.height,
-            stride: (capture.width * 4) as i32,
-            data,
-        });
+        let output_transform = self
+            .active_geometry
+            .as_ref()
+            .map(|geo| geo.transform)
+            .unwrap_or(wl_output::Transform::Normal);
+
+        self.set_image(
+            FrozenImage {
+                width: capture.width,
+                height: capture.height,
+                stride: (capture.width * 4) as i32,
+                data,
+            }
+            .with_output_transform(output_transform),
+        );
 
         Ok(())
     }

--- a/src/backend/wayland/frozen/image.rs
+++ b/src/backend/wayland/frozen/image.rs
@@ -1,7 +1,143 @@
+use wayland_client::protocol::wl_output;
+
 /// CPU-side frozen image ready for Cairo rendering.
 pub struct FrozenImage {
     pub width: u32,
     pub height: u32,
     pub stride: i32,
     pub data: Vec<u8>,
+}
+
+impl FrozenImage {
+    /// Apply the wl_output transform advertised for the captured output.
+    ///
+    /// WLR screencopy buffers are returned in output framebuffer coordinates.
+    /// Frozen/zoom rendering paints them onto a logical surface, so rotated or
+    /// flipped outputs need the same transform applied to the captured pixels.
+    pub fn with_output_transform(mut self, transform: wl_output::Transform) -> Self {
+        if transform == wl_output::Transform::Normal {
+            return self;
+        }
+
+        if let Some((width, height, data)) = transform_argb(
+            self.width as usize,
+            self.height as usize,
+            &self.data,
+            transform,
+        ) {
+            self.width = width as u32;
+            self.height = height as u32;
+            self.stride = (width * 4) as i32;
+            self.data = data;
+        }
+
+        self
+    }
+}
+
+fn transform_argb(
+    width: usize,
+    height: usize,
+    data: &[u8],
+    transform: wl_output::Transform,
+) -> Option<(usize, usize, Vec<u8>)> {
+    if data.len() != width.checked_mul(height)?.checked_mul(4)? {
+        return None;
+    }
+
+    let swaps_axes = matches!(
+        transform,
+        wl_output::Transform::_90
+            | wl_output::Transform::_270
+            | wl_output::Transform::Flipped90
+            | wl_output::Transform::Flipped270
+    );
+    let (dest_width, dest_height) = if swaps_axes {
+        (height, width)
+    } else {
+        (width, height)
+    };
+    let mut transformed = vec![0u8; data.len()];
+
+    for y in 0..height {
+        for x in 0..width {
+            let (dest_x, dest_y) = transformed_coords(x, y, width, height, transform);
+            let src = (y * width + x) * 4;
+            let dest = (dest_y * dest_width + dest_x) * 4;
+            transformed[dest..dest + 4].copy_from_slice(&data[src..src + 4]);
+        }
+    }
+
+    Some((dest_width, dest_height, transformed))
+}
+
+fn transformed_coords(
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    transform: wl_output::Transform,
+) -> (usize, usize) {
+    match transform {
+        wl_output::Transform::Normal => (x, y),
+        wl_output::Transform::_90 => (y, width - 1 - x),
+        wl_output::Transform::_180 => (width - 1 - x, height - 1 - y),
+        wl_output::Transform::_270 => (height - 1 - y, x),
+        wl_output::Transform::Flipped => (width - 1 - x, y),
+        wl_output::Transform::Flipped90 => (y, x),
+        wl_output::Transform::Flipped180 => (x, height - 1 - y),
+        wl_output::Transform::Flipped270 => (height - 1 - y, width - 1 - x),
+        _ => (x, y),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image(width: u32, height: u32, values: &[u8]) -> FrozenImage {
+        let mut data = Vec::with_capacity(values.len() * 4);
+        for value in values {
+            data.extend_from_slice(&[*value, 0, 0, 0xFF]);
+        }
+
+        FrozenImage {
+            width,
+            height,
+            stride: (width * 4) as i32,
+            data,
+        }
+    }
+
+    fn values(image: &FrozenImage) -> Vec<u8> {
+        image.data.chunks_exact(4).map(|chunk| chunk[0]).collect()
+    }
+
+    #[test]
+    fn output_transform_270_rotates_into_logical_orientation() {
+        let transformed =
+            image(3, 2, &[1, 2, 3, 4, 5, 6]).with_output_transform(wl_output::Transform::_270);
+
+        assert_eq!((transformed.width, transformed.height), (2, 3));
+        assert_eq!(values(&transformed), vec![4, 1, 5, 2, 6, 3]);
+        assert_eq!(transformed.stride, 8);
+    }
+
+    #[test]
+    fn output_transform_90_rotates_into_logical_orientation() {
+        let transformed =
+            image(3, 2, &[1, 2, 3, 4, 5, 6]).with_output_transform(wl_output::Transform::_90);
+
+        assert_eq!((transformed.width, transformed.height), (2, 3));
+        assert_eq!(values(&transformed), vec![3, 6, 2, 5, 1, 4]);
+    }
+
+    #[test]
+    fn flipped_transform_mirrors_pixels() {
+        let transformed =
+            image(3, 2, &[1, 2, 3, 4, 5, 6]).with_output_transform(wl_output::Transform::Flipped);
+
+        assert_eq!((transformed.width, transformed.height), (3, 2));
+        assert_eq!(values(&transformed), vec![3, 2, 1, 6, 5, 4]);
+    }
 }

--- a/src/backend/wayland/frozen_geometry.rs
+++ b/src/backend/wayland/frozen_geometry.rs
@@ -1,3 +1,5 @@
+use wayland_client::protocol::wl_output;
+
 /// Geometry and scale details for the active output, used for cropping fallback captures.
 #[derive(Clone, Debug)]
 pub struct OutputGeometry {
@@ -6,6 +8,7 @@ pub struct OutputGeometry {
     pub logical_width: u32,
     pub logical_height: u32,
     pub scale: i32,
+    pub transform: wl_output::Transform,
 }
 
 impl OutputGeometry {
@@ -14,6 +17,7 @@ impl OutputGeometry {
         logical_size: Option<(i32, i32)>,
         fallback_size: (u32, u32),
         scale: i32,
+        transform: wl_output::Transform,
     ) -> Option<Self> {
         let (lx, ly) = logical_pos.unwrap_or((0, 0));
         let (lw, lh) = logical_size.unwrap_or((fallback_size.0 as i32, fallback_size.1 as i32));
@@ -26,6 +30,7 @@ impl OutputGeometry {
             logical_width: lw as u32,
             logical_height: lh as u32,
             scale,
+            transform,
         })
     }
 }
@@ -37,28 +42,58 @@ mod tests {
 
     #[test]
     fn update_from_uses_logical_and_scale() {
-        let geo = OutputGeometry::update_from(Some((10, 20)), Some((1920, 1080)), (800, 600), 2)
-            .expect("geometry");
+        let geo = OutputGeometry::update_from(
+            Some((10, 20)),
+            Some((1920, 1080)),
+            (800, 600),
+            2,
+            wl_output::Transform::_270,
+        )
+        .expect("geometry");
         assert_eq!(geo.logical_x, 10);
         assert_eq!(geo.logical_y, 20);
         assert_eq!(geo.logical_width, 1920);
         assert_eq!(geo.logical_height, 1080);
+        assert_eq!(geo.transform, wl_output::Transform::_270);
         assert_eq!(geo.physical_size(), (3840, 2160));
         assert_eq!(geo.physical_origin(), (20, 40));
     }
 
     #[test]
     fn update_from_uses_fallback_when_missing_logical_size() {
-        let geo = OutputGeometry::update_from(None, None, (800, 600), 1).expect("geometry");
+        let geo =
+            OutputGeometry::update_from(None, None, (800, 600), 1, wl_output::Transform::Normal)
+                .expect("geometry");
         assert_eq!(geo.logical_width, 800);
         assert_eq!(geo.logical_height, 600);
     }
 
     #[test]
     fn update_from_rejects_invalid_scale_or_size() {
-        assert!(OutputGeometry::update_from(None, Some((0, 600)), (800, 600), 1).is_none());
-        assert!(OutputGeometry::update_from(None, Some((800, 0)), (800, 600), 1).is_none());
-        assert!(OutputGeometry::update_from(None, None, (800, 600), 0).is_none());
+        assert!(
+            OutputGeometry::update_from(
+                None,
+                Some((0, 600)),
+                (800, 600),
+                1,
+                wl_output::Transform::Normal,
+            )
+            .is_none()
+        );
+        assert!(
+            OutputGeometry::update_from(
+                None,
+                Some((800, 0)),
+                (800, 600),
+                1,
+                wl_output::Transform::Normal,
+            )
+            .is_none()
+        );
+        assert!(
+            OutputGeometry::update_from(None, None, (800, 600), 0, wl_output::Transform::Normal)
+                .is_none()
+        );
     }
 }
 

--- a/src/backend/wayland/handlers/compositor.rs
+++ b/src/backend/wayland/handlers/compositor.rs
@@ -145,6 +145,7 @@ impl CompositorHandler for WaylandState {
                     logical_width: logical_w.max(0) as u32,
                     logical_height: logical_h.max(0) as u32,
                     scale,
+                    transform: info.transform,
                 },
             ));
             self.frozen
@@ -156,6 +157,7 @@ impl CompositorHandler for WaylandState {
                     logical_width: logical_w.max(0) as u32,
                     logical_height: logical_h.max(0) as u32,
                     scale,
+                    transform: info.transform,
                 },
             ));
             self.zoom

--- a/src/backend/wayland/handlers/layer.rs
+++ b/src/backend/wayland/handlers/layer.rs
@@ -70,11 +70,19 @@ impl LayerShellHandler for WaylandState {
                 .handle_resize(phys_w, phys_h, &mut self.input_state);
 
             // Refresh active geometry for portal fallback cropping using latest logical size/scale.
+            let output_transform = self
+                .surface
+                .current_output()
+                .as_ref()
+                .and_then(|output| self.output_state.info(output))
+                .map(|info| info.transform)
+                .unwrap_or(wayland_client::protocol::wl_output::Transform::Normal);
             if let Some(geo) = crate::backend::wayland::frozen_geometry::OutputGeometry::update_from(
                 None, // logical position is not available here
                 Some((self.surface.width() as i32, self.surface.height() as i32)),
                 (self.surface.width(), self.surface.height()),
                 self.surface.scale(),
+                output_transform,
             ) {
                 self.frozen.set_active_geometry(Some(geo.clone()));
                 self.zoom.set_active_geometry(Some(geo));

--- a/src/backend/wayland/handlers/output.rs
+++ b/src/backend/wayland/handlers/output.rs
@@ -43,6 +43,7 @@ impl OutputHandler for WaylandState {
                 info.logical_size,
                 (self.surface.width(), self.surface.height()),
                 info.scale_factor.max(1),
+                info.transform,
             ) {
                 self.frozen.set_active_geometry(Some(geo.clone()));
                 self.frozen

--- a/src/backend/wayland/handlers/xdg.rs
+++ b/src/backend/wayland/handlers/xdg.rs
@@ -115,11 +115,19 @@ impl WindowHandler for WaylandState {
         self.zoom
             .handle_resize(phys_w, phys_h, &mut self.input_state);
 
+        let output_transform = self
+            .surface
+            .current_output()
+            .as_ref()
+            .and_then(|output| self.output_state.info(output))
+            .map(|info| info.transform)
+            .unwrap_or(wayland_client::protocol::wl_output::Transform::Normal);
         if let Some(geo) = crate::backend::wayland::frozen_geometry::OutputGeometry::update_from(
             None, // logical position is not available here
             Some((self.surface.width() as i32, self.surface.height() as i32)),
             (self.surface.width(), self.surface.height()),
             self.surface.scale(),
+            output_transform,
         ) {
             self.frozen.set_active_geometry(Some(geo.clone()));
             self.zoom.set_active_geometry(Some(geo));

--- a/src/backend/wayland/zoom/capture.rs
+++ b/src/backend/wayland/zoom/capture.rs
@@ -4,7 +4,10 @@ use smithay_client_toolkit::shm::{
     Shm,
     slot::{Buffer, SlotPool},
 };
-use wayland_client::{Dispatch, QueueHandle, WEnum, protocol::wl_shm};
+use wayland_client::{
+    Dispatch, QueueHandle, WEnum,
+    protocol::{wl_output, wl_shm},
+};
 use wayland_protocols_wlr::screencopy::v1::client::zwlr_screencopy_frame_v1::{
     Event as FrameEvent, Flags, ZwlrScreencopyFrameV1,
 };
@@ -260,12 +263,21 @@ impl ZoomState {
 
         capture.frame.destroy();
 
-        self.set_image(FrozenImage {
-            width: capture.width,
-            height: capture.height,
-            stride: (capture.width * 4) as i32,
-            data,
-        });
+        let output_transform = self
+            .active_geometry
+            .as_ref()
+            .map(|geo| geo.transform)
+            .unwrap_or(wl_output::Transform::Normal);
+
+        self.set_image(
+            FrozenImage {
+                width: capture.width,
+                height: capture.height,
+                stride: (capture.width * 4) as i32,
+                data,
+            }
+            .with_output_transform(output_transform),
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- carry the active output wl_output transform through frozen/zoom capture geometry
- rotate or flip WLR screencopy buffers into logical surface orientation before storing frozen images
- add targeted transform coverage for rotated and flipped captures

Fixes #178

## Tests
- cargo test --bin wayscriber backend::wayland::frozen::image::tests
- cargo test --bin wayscriber backend::wayland::frozen_geometry::tests