### PR TITLE
Show cursor while stylus is hovering, before drawing starts.

### DIFF
--- a/configurator/src/app/view/widgets/color_picker/canvas.rs
+++ b/configurator/src/app/view/widgets/color_picker/canvas.rs
@@ -42,14 +42,14 @@ impl Program<Message> for SvCanvas {
             canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
                 state.dragging = false;
             }
-            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
-                if state.dragging {
-                    let pos = clamp_point(position, bounds);
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(self.message_from_position(bounds, pos)),
-                    );
-                }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position })
+                if state.dragging =>
+            {
+                let pos = clamp_point(position, bounds);
+                return (
+                    canvas::event::Status::Captured,
+                    Some(self.message_from_position(bounds, pos)),
+                );
             }
             _ => {}
         }
@@ -169,14 +169,14 @@ impl Program<Message> for HueCanvas {
             canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
                 state.dragging = false;
             }
-            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
-                if state.dragging {
-                    let pos = clamp_point(position, bounds);
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(self.message_from_position(bounds, pos)),
-                    );
-                }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position })
+                if state.dragging =>
+            {
+                let pos = clamp_point(position, bounds);
+                return (
+                    canvas::event::Status::Captured,
+                    Some(self.message_from_position(bounds, pos)),
+                );
             }
             _ => {}
         }

--- a/src/backend/wayland/handlers/pointer/cursor.rs
+++ b/src/backend/wayland/handlers/pointer/cursor.rs
@@ -10,7 +10,11 @@ use crate::input::{
 };
 
 impl WaylandState {
-    pub(super) fn update_pointer_cursor(&mut self, toolbar_hover: bool, conn: &Connection) {
+    pub(in crate::backend::wayland) fn update_pointer_cursor(
+        &mut self,
+        toolbar_hover: bool,
+        conn: &Connection,
+    ) {
         if self.toolbar_dragging() && self.pointer_lock_active() {
             self.hide_pointer_cursor();
             return;

--- a/src/backend/wayland/handlers/tablet/tool.rs
+++ b/src/backend/wayland/handlers/tablet/tool.rs
@@ -120,6 +120,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 state.stylus_surface = Some(surface.clone());
                 state.stylus_on_overlay = on_overlay;
                 state.stylus_on_toolbar = on_toolbar;
+                state.set_pointer_over_toolbar(on_toolbar);
                 state.set_toolbar_dragging(false);
                 state.stylus_tip_down = false;
                 state.stylus_base_thickness = Some(state.input_state.current_thickness);
@@ -151,6 +152,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 } else {
                     debug!("Tablet proximity in on non-overlay surface");
                 }
+                state.update_pointer_cursor(on_toolbar, _conn);
             }
             Event::ProximityOut => {
                 let tool_id = _proxy.id();
@@ -163,6 +165,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 state.stylus_tip_down = false;
                 state.stylus_on_overlay = false;
                 state.stylus_on_toolbar = false;
+                state.set_pointer_over_toolbar(false);
                 state.set_toolbar_dragging(false);
                 state.end_toolbar_move_drag();
                 if let Some(surf) = state.stylus_surface.take()
@@ -218,6 +221,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                         state.toolbar.mark_dirty();
                         state.input_state.needs_redraw = true;
                         state.refresh_keyboard_interactivity();
+                        state.update_pointer_cursor(true, _conn);
                     }
                     return;
                 }
@@ -246,6 +250,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     wy,
                 );
                 state.input_state.needs_redraw = true;
+                state.update_pointer_cursor(false, _conn);
             }
             Event::Up => {
                 let inline_active = state.inline_toolbars_active() && state.toolbar.is_visible();
@@ -253,13 +258,17 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     let (mx, my) = state.current_mouse();
                     state.inline_toolbar_release((mx as f64, my as f64));
                     state.stylus_on_toolbar = false;
+                    state.set_pointer_over_toolbar(false);
                     state.set_toolbar_dragging(false);
                     state.end_toolbar_move_drag();
+                    state.update_pointer_cursor(false, _conn);
                     return;
                 }
                 if state.stylus_on_toolbar {
+                    state.set_pointer_over_toolbar(true);
                     state.set_toolbar_dragging(false);
                     state.end_toolbar_move_drag();
+                    state.update_pointer_cursor(true, _conn);
                     return;
                 }
                 if !state.stylus_on_overlay {
@@ -295,6 +304,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                 let hover_cursor_pos = state.stylus_hover_cursor_pos();
                 state.mark_stylus_hover_cursor_dirty(None, hover_cursor_pos);
                 state.input_state.needs_redraw = true;
+                state.update_pointer_cursor(false, _conn);
             }
             Event::Motion { x, y } => {
                 if state.is_move_dragging()
@@ -310,6 +320,8 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     state.toolbar.mark_dirty();
                     state.input_state.needs_redraw = true;
                     state.set_current_mouse(x as i32, y as i32);
+                    state.set_pointer_over_toolbar(state.stylus_on_toolbar);
+                    state.update_pointer_cursor(state.stylus_on_toolbar, _conn);
                     return;
                 }
                 let previous_hover_cursor_pos = state.stylus_hover_cursor_pos();
@@ -318,8 +330,23 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     let xf = x;
                     let yf = y;
                     state.stylus_last_pos = Some((xf, yf));
-                    if let Some(surface) = state.stylus_surface.as_ref() {
-                        let evt = state.toolbar.pointer_motion(surface, (xf, yf));
+                    if let Some(surface) = state.stylus_surface.clone() {
+                        state.set_pointer_over_toolbar(true);
+                        if let Some((sx, sy)) =
+                            state.toolbar_surface_screen_coords(&surface, (xf, yf))
+                        {
+                            state.set_current_mouse(sx as i32, sy as i32);
+                            let (wx, wy) = state.zoomed_world_coords(sx, sy);
+                            state.input_state.update_pointer_positions(
+                                sx.round() as i32,
+                                sy.round() as i32,
+                                wx,
+                                wy,
+                            );
+                        } else {
+                            state.set_current_mouse(x as i32, y as i32);
+                        }
+                        let evt = state.toolbar.pointer_motion(&surface, (xf, yf));
                         if state.toolbar_dragging() {
                             // Use move_drag_intent if pointer_motion didn't return an intent
                             // This allows dragging to continue when stylus moves outside hit region
@@ -334,22 +361,26 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                         state.input_state.needs_redraw = true;
                         state.refresh_keyboard_interactivity();
                     }
-                    state.set_current_mouse(x as i32, y as i32);
+                    state.update_pointer_cursor(true, _conn);
                     return;
                 }
                 if inline_active {
                     state.stylus_last_pos = Some((x, y));
                     if state.inline_toolbar_motion((x, y)) {
                         state.stylus_on_toolbar = true;
+                        state.set_pointer_over_toolbar(true);
                         state.mark_stylus_hover_cursor_dirty(previous_hover_cursor_pos, None);
+                        state.update_pointer_cursor(true, _conn);
                         return;
                     } else {
                         state.stylus_on_toolbar = false;
+                        state.set_pointer_over_toolbar(false);
                     }
                 }
                 if !state.stylus_on_overlay {
                     return;
                 }
+                state.set_pointer_over_toolbar(false);
                 state.set_current_mouse(x as i32, y as i32);
                 let xf = x;
                 let yf = y;
@@ -369,6 +400,7 @@ impl Dispatch<ZwpTabletToolV2, ()> for WaylandState {
                     previous_hover_cursor_pos,
                     next_hover_cursor_pos,
                 );
+                state.update_pointer_cursor(false, _conn);
                 if state.stylus_tip_down {
                     state.stylus_pressure_thickness = Some(state.input_state.current_thickness);
                     state.record_stylus_peak(state.input_state.current_thickness);

--- a/src/input/state/actions/help_overlay.rs
+++ b/src/input/state/actions/help_overlay.rs
@@ -27,16 +27,12 @@ impl InputState {
                 self.toggle_help_overlay();
                 true
             }
-            Key::Backspace => {
-                if !self.help_overlay_search.is_empty() {
-                    self.help_overlay_search.pop();
-                    self.help_overlay_scroll = 0.0;
-                    self.dirty_tracker.mark_full();
-                    self.needs_redraw = true;
-                    true
-                } else {
-                    false
-                }
+            Key::Backspace if !self.help_overlay_search.is_empty() => {
+                self.help_overlay_search.pop();
+                self.help_overlay_scroll = 0.0;
+                self.dirty_tracker.mark_full();
+                self.needs_redraw = true;
+                true
             }
             Key::Space => {
                 if search_active {
@@ -47,16 +43,12 @@ impl InputState {
                 }
                 true
             }
-            Key::Char(ch) => {
-                if !ch.is_control() {
-                    self.help_overlay_search.push(ch);
-                    self.help_overlay_scroll = 0.0;
-                    self.dirty_tracker.mark_full();
-                    self.needs_redraw = true;
-                    true
-                } else {
-                    false
-                }
+            Key::Char(ch) if !ch.is_control() => {
+                self.help_overlay_search.push(ch);
+                self.help_overlay_scroll = 0.0;
+                self.dirty_tracker.mark_full();
+                self.needs_redraw = true;
+                true
             }
             // Disable page navigation while search is active
             Key::Left | Key::Right | Key::PageUp | Key::PageDown | Key::Home | Key::End
@@ -66,16 +58,12 @@ impl InputState {
             }
             Key::Left | Key::PageUp if !search_active => self.help_overlay_prev_page(),
             Key::Right | Key::PageDown if !search_active => self.help_overlay_next_page(),
-            Key::Home if !search_active => {
-                if self.help_overlay_page != 0 {
-                    self.help_overlay_page = 0;
-                    self.help_overlay_scroll = 0.0;
-                    self.dirty_tracker.mark_full();
-                    self.needs_redraw = true;
-                    true
-                } else {
-                    false
-                }
+            Key::Home if !search_active && self.help_overlay_page != 0 => {
+                self.help_overlay_page = 0;
+                self.help_overlay_scroll = 0.0;
+                self.dirty_tracker.mark_full();
+                self.needs_redraw = true;
+                true
             }
             Key::End if !search_active => {
                 // Use the max page constant; actual page count is computed during render

--- a/src/input/state/core/index.rs
+++ b/src/input/state/core/index.rs
@@ -246,7 +246,7 @@ impl InputState {
                     .into_iter()
                     .filter_map(|id| index_map.get(&id).map(|&idx| (idx, id)))
                     .collect();
-                sorted_candidates.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+                sorted_candidates.sort_unstable_by_key(|candidate| std::cmp::Reverse(candidate.0));
 
                 for (_, id) in sorted_candidates {
                     if self.hit_test_by_id(id, x, y, tolerance) {

--- a/src/input/state/core/properties/apply_selection/actions/arrow.rs
+++ b/src/input/state/core/properties/apply_selection/actions/arrow.rs
@@ -27,13 +27,9 @@ impl InputState {
         let result = self.apply_selection_change(
             |shape| matches!(shape, Shape::Arrow { .. }),
             |shape| match shape {
-                Shape::Arrow { head_at_end, .. } => {
-                    if *head_at_end != target {
-                        *head_at_end = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::Arrow { head_at_end, .. } if *head_at_end != target => {
+                    *head_at_end = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/properties/apply_selection/actions/color.rs
+++ b/src/input/state/core/properties/apply_selection/actions/color.rs
@@ -30,13 +30,11 @@ impl InputState {
                 | Shape::Ellipse { color, .. }
                 | Shape::Arrow { color, .. }
                 | Shape::Text { color, .. }
-                | Shape::StepMarker { color, .. } => {
-                    if *color != target {
-                        *color = target;
-                        true
-                    } else {
-                        false
-                    }
+                | Shape::StepMarker { color, .. }
+                    if *color != target =>
+                {
+                    *color = target;
+                    true
                 }
                 Shape::MarkerStroke { color, .. } => {
                     let new_color = Color {
@@ -50,13 +48,9 @@ impl InputState {
                         false
                     }
                 }
-                Shape::StickyNote { background, .. } => {
-                    if *background != target {
-                        *background = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::StickyNote { background, .. } if *background != target => {
+                    *background = target;
+                    true
                 }
                 _ => false,
             },
@@ -99,13 +93,11 @@ impl InputState {
                 | Shape::Ellipse { color, .. }
                 | Shape::Arrow { color, .. }
                 | Shape::Text { color, .. }
-                | Shape::StepMarker { color, .. } => {
-                    if *color != target {
-                        *color = target;
-                        true
-                    } else {
-                        false
-                    }
+                | Shape::StepMarker { color, .. }
+                    if *color != target =>
+                {
+                    *color = target;
+                    true
                 }
                 Shape::MarkerStroke { color, .. } => {
                     let new_color = Color {
@@ -119,13 +111,9 @@ impl InputState {
                         false
                     }
                 }
-                Shape::StickyNote { background, .. } => {
-                    if *background != target {
-                        *background = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::StickyNote { background, .. } if *background != target => {
+                    *background = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/properties/apply_selection/actions/fill.rs
+++ b/src/input/state/core/properties/apply_selection/actions/fill.rs
@@ -23,13 +23,9 @@ impl InputState {
         let result = self.apply_selection_change(
             |shape| matches!(shape, Shape::Rect { .. } | Shape::Ellipse { .. }),
             |shape| match shape {
-                Shape::Rect { fill, .. } | Shape::Ellipse { fill, .. } => {
-                    if *fill != target {
-                        *fill = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::Rect { fill, .. } | Shape::Ellipse { fill, .. } if *fill != target => {
+                    *fill = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/properties/apply_selection/actions/text.rs
+++ b/src/input/state/core/properties/apply_selection/actions/text.rs
@@ -54,13 +54,9 @@ impl InputState {
             |shape| match shape {
                 Shape::Text {
                     background_enabled, ..
-                } => {
-                    if *background_enabled != target {
-                        *background_enabled = target;
-                        true
-                    } else {
-                        false
-                    }
+                } if *background_enabled != target => {
+                    *background_enabled = target;
+                    true
                 }
                 _ => false,
             },


### PR DESCRIPTION
This updates the Wayland tablet input path so pen hover behaves like mouse motion for cursor visibility. Stylus proximity, motion, down, and up events now keep cursor state and pointer_over_toolbar in sync, which makes the cursor/tool-preview appear while moving a tablet pen without touching down. It also updates stylus toolbar hover handling to convert toolbar-local coordinates into screen coordinates before refreshing pointer state, so hover behavior stays correct over toolbar surfaces.

Technical notes:
 - Reused the existing pointer cursor update path from the tablet handler instead of duplicating cursor logic.
 - Adjusted the visibility of update_pointer_cursor so tablet handlers can call it.
 - Verified with cargo check.
