### PR TITLE
Add configurable per-button drag tool bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ Press <kbd>F1</kbd> for the complete in-app cheat sheet.
 | Text mode | <kbd>T</kbd>, <kbd>Click</kbd> to position, type, <kbd>Enter</kbd> to finish |
 | Sticky note | <kbd>N</kbd>, <kbd>Click</kbd> to place, type, <kbd>Enter</kbd> to finish |
 
-Drag modifier mappings are configurable in `config.toml` via `[drawing]` (`drag_tool`, `shift_drag_tool`, `ctrl_drag_tool`, `ctrl_shift_drag_tool`, `tab_drag_tool`) or in the configurator Drawing tab.
+Drag modifier mappings are configurable in `config.toml` via `[drawing]` (`drag_tool`, `shift_drag_tool`, `ctrl_drag_tool`, `ctrl_shift_drag_tool`, `tab_drag_tool`) or in the configurator Drawing tab. For per-button workflows, use `[drawing.drag_tools.left]`, `[drawing.drag_tools.right]`, and `[drawing.drag_tools.middle]`; each binding can set a tool and optional color.
 
 </details>
 
@@ -646,6 +646,10 @@ wayscriber-configurator   # or press F11
 [drawing]
 default_color = "red"
 default_thickness = 3.0
+
+[drawing.drag_tools.right]
+drag_tool = "pen"
+drag_color = "blue"
 
 [presets]
 # slot_count: 3-5

--- a/config.example.toml
+++ b/config.example.toml
@@ -688,6 +688,23 @@ ctrl_drag_tool = "rect"
 ctrl_shift_drag_tool = "arrow"
 tab_drag_tool = "ellipse"
 
+# Optional per-mouse-button drag mapping. These override the flat drag_tool
+# fields above when present. Right/middle default to their built-in behavior
+# unless configured here. Use "default" for a button's built-in behavior.
+# Colors are optional and can be names or RGB arrays.
+#
+# [drawing.drag_tools.left]
+# drag_tool = "pen"
+# shift_drag_tool = "pen"
+# shift_drag_color = "red"
+#
+# [drawing.drag_tools.right]
+# drag_tool = "pen"
+# drag_color = "blue"
+#
+# [drawing.drag_tools.middle]
+# drag_tool = "default"
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Font Configuration (Pango-based text rendering)
 # ───────────────────────────────────────────────────────────────────────────────

--- a/configurator/src/app/update/fields.rs
+++ b/configurator/src/app/update/fields.rs
@@ -2,10 +2,11 @@ use iced::Command;
 
 use crate::messages::Message;
 use crate::models::{
-    ColorMode, ColorPickerId, DragToolField, EraserModeOption, FontStyleOption, FontWeightOption,
-    KeybindingField, NamedColorOption, OverrideOption, PresenterToolBehaviorOption, QuadField,
-    SessionCompressionOption, SessionStorageModeOption, StatusPositionOption, TextField,
-    ToggleField, ToolOption, ToolbarLayoutModeOption, ToolbarOverrideField, TripletField,
+    ColorMode, ColorPickerId, DragColorOption, DragMouseButton, DragToolField, DragToolOption,
+    EraserModeOption, FontStyleOption, FontWeightOption, KeybindingField, NamedColorOption,
+    OverrideOption, PresenterToolBehaviorOption, QuadField, SessionCompressionOption,
+    SessionStorageModeOption, StatusPositionOption, TextField, ToggleField,
+    ToolbarLayoutModeOption, ToolbarOverrideField, TripletField,
 };
 #[cfg(feature = "tablet-input")]
 use crate::models::{PressureThicknessEditModeOption, PressureThicknessEntryModeOption};
@@ -105,13 +106,26 @@ impl ConfiguratorApp {
         Command::none()
     }
 
-    pub(super) fn handle_drawing_drag_tool_changed(
+    pub(super) fn handle_drawing_mouse_drag_tool_changed(
         &mut self,
+        button: DragMouseButton,
         field: DragToolField,
-        option: ToolOption,
+        option: DragToolOption,
     ) -> Command<Message> {
         self.status = StatusMessage::idle();
-        self.draft.set_drag_tool(field, option);
+        self.draft.set_mouse_drag_tool(button, field, option);
+        self.refresh_dirty_flag();
+        Command::none()
+    }
+
+    pub(super) fn handle_drawing_mouse_drag_color_changed(
+        &mut self,
+        button: DragMouseButton,
+        field: DragToolField,
+        option: DragColorOption,
+    ) -> Command<Message> {
+        self.status = StatusMessage::idle();
+        self.draft.set_mouse_drag_color(button, field, option);
         self.refresh_dirty_flag();
         Command::none()
     }

--- a/configurator/src/app/update/mod.rs
+++ b/configurator/src/app/update/mod.rs
@@ -50,8 +50,11 @@ impl ConfiguratorApp {
             Message::ColorModeChanged(mode) => self.handle_color_mode_changed(mode),
             Message::NamedColorSelected(option) => self.handle_named_color_selected(option),
             Message::EraserModeChanged(option) => self.handle_eraser_mode_changed(option),
-            Message::DrawingDragToolChanged(field, option) => {
-                self.handle_drawing_drag_tool_changed(field, option)
+            Message::DrawingMouseDragToolChanged(button, field, option) => {
+                self.handle_drawing_mouse_drag_tool_changed(button, field, option)
+            }
+            Message::DrawingMouseDragColorChanged(button, field, option) => {
+                self.handle_drawing_mouse_drag_color_changed(button, field, option)
             }
             Message::StatusPositionChanged(option) => self.handle_status_position_changed(option),
             Message::ToolbarLayoutModeChanged(option) => {

--- a/configurator/src/app/view/drawing/mod.rs
+++ b/configurator/src/app/view/drawing/mod.rs
@@ -5,7 +5,11 @@ use iced::widget::{column, pick_list, row, scrollable, text};
 use iced::{Element, Length};
 
 use crate::messages::Message;
-use crate::models::{DragToolField, EraserModeOption, TextField, ToggleField, ToolOption};
+use crate::models::{
+    DragColorOption, DragMouseButton, DragToolField, DragToolOption, EraserModeOption, TextField,
+    ToggleField,
+};
+use wayscriber::config::DragButtonConfig;
 
 use self::color::drawing_color_block;
 use self::font::font_controls;
@@ -22,12 +26,35 @@ impl ConfiguratorApp {
             Some(self.draft.drawing_default_eraser_mode),
             Message::EraserModeChanged,
         );
-        let drag_tool_pick = |field: DragToolField, selected: ToolOption| {
-            pick_list(ToolOption::list(), Some(selected), move |option| {
-                Message::DrawingDragToolChanged(field, option)
-            })
-            .width(Length::Fill)
-        };
+        let drag_button_controls =
+            |button: DragMouseButton, current: &DragButtonConfig, defaults: &DragButtonConfig| {
+                column![
+                    text(button.label()).size(14),
+                    row![
+                        drag_binding_control(button, DragToolField::Drag, current, defaults,),
+                        drag_binding_control(button, DragToolField::ShiftDrag, current, defaults,)
+                    ]
+                    .spacing(12),
+                    row![
+                        drag_binding_control(button, DragToolField::CtrlDrag, current, defaults,),
+                        drag_binding_control(
+                            button,
+                            DragToolField::CtrlShiftDrag,
+                            current,
+                            defaults,
+                        )
+                    ]
+                    .spacing(12),
+                    row![drag_binding_control(
+                        button,
+                        DragToolField::TabDrag,
+                        current,
+                        defaults,
+                    )]
+                    .spacing(12)
+                ]
+                .spacing(8)
+            };
 
         let column = column![
             text("Drawing Defaults").size(20),
@@ -73,53 +100,21 @@ impl ConfiguratorApp {
             ]
             .spacing(12),
             text("Drag Tool Mapping").size(16),
-            row![
-                labeled_control(
-                    DragToolField::Drag.label(),
-                    drag_tool_pick(DragToolField::Drag, self.draft.drawing_drag_tool).into(),
-                    self.defaults.drawing_drag_tool.label().to_string(),
-                    self.draft.drawing_drag_tool != self.defaults.drawing_drag_tool,
-                ),
-                labeled_control(
-                    DragToolField::ShiftDrag.label(),
-                    drag_tool_pick(DragToolField::ShiftDrag, self.draft.drawing_shift_drag_tool)
-                        .into(),
-                    self.defaults.drawing_shift_drag_tool.label().to_string(),
-                    self.draft.drawing_shift_drag_tool != self.defaults.drawing_shift_drag_tool,
-                )
-            ]
-            .spacing(12),
-            row![
-                labeled_control(
-                    DragToolField::CtrlDrag.label(),
-                    drag_tool_pick(DragToolField::CtrlDrag, self.draft.drawing_ctrl_drag_tool)
-                        .into(),
-                    self.defaults.drawing_ctrl_drag_tool.label().to_string(),
-                    self.draft.drawing_ctrl_drag_tool != self.defaults.drawing_ctrl_drag_tool,
-                ),
-                labeled_control(
-                    DragToolField::CtrlShiftDrag.label(),
-                    drag_tool_pick(
-                        DragToolField::CtrlShiftDrag,
-                        self.draft.drawing_ctrl_shift_drag_tool,
-                    )
-                    .into(),
-                    self.defaults
-                        .drawing_ctrl_shift_drag_tool
-                        .label()
-                        .to_string(),
-                    self.draft.drawing_ctrl_shift_drag_tool
-                        != self.defaults.drawing_ctrl_shift_drag_tool,
-                )
-            ]
-            .spacing(12),
-            row![labeled_control(
-                DragToolField::TabDrag.label(),
-                drag_tool_pick(DragToolField::TabDrag, self.draft.drawing_tab_drag_tool).into(),
-                self.defaults.drawing_tab_drag_tool.label().to_string(),
-                self.draft.drawing_tab_drag_tool != self.defaults.drawing_tab_drag_tool,
-            )]
-            .spacing(12),
+            drag_button_controls(
+                DragMouseButton::Left,
+                &self.draft.drawing_drag_tools.left,
+                &self.defaults.drawing_drag_tools.left,
+            ),
+            drag_button_controls(
+                DragMouseButton::Right,
+                &self.draft.drawing_drag_tools.right,
+                &self.defaults.drawing_drag_tools.right,
+            ),
+            drag_button_controls(
+                DragMouseButton::Middle,
+                &self.draft.drawing_drag_tools.middle,
+                &self.defaults.drawing_drag_tools.middle,
+            ),
             row![
                 labeled_input_with_feedback(
                     "Marker opacity (0.05-0.9)",
@@ -176,5 +171,65 @@ impl ConfiguratorApp {
         .width(Length::Fill);
 
         scrollable(column).into()
+    }
+}
+
+fn drag_binding_control<'a>(
+    button: DragMouseButton,
+    field: DragToolField,
+    current: &DragButtonConfig,
+    defaults: &DragButtonConfig,
+) -> Element<'a, Message> {
+    let selected = drag_tool_for_field(current, field);
+    let default = drag_tool_for_field(defaults, field);
+    let color = drag_color_for_field(current, field);
+    let default_color = drag_color_for_field(defaults, field);
+    column![
+        labeled_control(
+            field.label(),
+            pick_list(
+                DragToolOption::list_for_button(button),
+                Some(selected),
+                move |option| { Message::DrawingMouseDragToolChanged(button, field, option) }
+            )
+            .width(Length::Fill)
+            .into(),
+            default.label().to_string(),
+            selected != default,
+        ),
+        labeled_control(
+            "Color",
+            pick_list(DragColorOption::list(), Some(color), move |option| {
+                Message::DrawingMouseDragColorChanged(button, field, option)
+            })
+            .width(Length::Fill)
+            .into(),
+            default_color.label().to_string(),
+            color != default_color,
+        )
+    ]
+    .spacing(6)
+    .into()
+}
+
+fn drag_tool_for_field(config: &DragButtonConfig, field: DragToolField) -> DragToolOption {
+    match field {
+        DragToolField::Drag => DragToolOption::from_drag_tool(config.drag_tool),
+        DragToolField::ShiftDrag => DragToolOption::from_drag_tool(config.shift_drag_tool),
+        DragToolField::CtrlDrag => DragToolOption::from_drag_tool(config.ctrl_drag_tool),
+        DragToolField::CtrlShiftDrag => DragToolOption::from_drag_tool(config.ctrl_shift_drag_tool),
+        DragToolField::TabDrag => DragToolOption::from_drag_tool(config.tab_drag_tool),
+    }
+}
+
+fn drag_color_for_field(config: &DragButtonConfig, field: DragToolField) -> DragColorOption {
+    match field {
+        DragToolField::Drag => DragColorOption::from_color(config.drag_color.as_ref()),
+        DragToolField::ShiftDrag => DragColorOption::from_color(config.shift_drag_color.as_ref()),
+        DragToolField::CtrlDrag => DragColorOption::from_color(config.ctrl_drag_color.as_ref()),
+        DragToolField::CtrlShiftDrag => {
+            DragColorOption::from_color(config.ctrl_shift_drag_color.as_ref())
+        }
+        DragToolField::TabDrag => DragColorOption::from_color(config.tab_drag_color.as_ref()),
     }
 }

--- a/configurator/src/app/view/widgets/color_picker/canvas.rs
+++ b/configurator/src/app/view/widgets/color_picker/canvas.rs
@@ -42,14 +42,14 @@ impl Program<Message> for SvCanvas {
             canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
                 state.dragging = false;
             }
-            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
-                if state.dragging {
-                    let pos = clamp_point(position, bounds);
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(self.message_from_position(bounds, pos)),
-                    );
-                }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position })
+                if state.dragging =>
+            {
+                let pos = clamp_point(position, bounds);
+                return (
+                    canvas::event::Status::Captured,
+                    Some(self.message_from_position(bounds, pos)),
+                );
             }
             _ => {}
         }
@@ -169,14 +169,14 @@ impl Program<Message> for HueCanvas {
             canvas::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
                 state.dragging = false;
             }
-            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
-                if state.dragging {
-                    let pos = clamp_point(position, bounds);
-                    return (
-                        canvas::event::Status::Captured,
-                        Some(self.message_from_position(bounds, pos)),
-                    );
-                }
+            canvas::Event::Mouse(iced::mouse::Event::CursorMoved { position })
+                if state.dragging =>
+            {
+                let pos = clamp_point(position, bounds);
+                return (
+                    canvas::event::Status::Captured,
+                    Some(self.message_from_position(bounds, pos)),
+                );
             }
             _ => {}
         }

--- a/configurator/src/messages.rs
+++ b/configurator/src/messages.rs
@@ -5,12 +5,13 @@ use wayscriber::config::Config;
 
 use crate::models::{
     BoardBackgroundOption, BoardItemTextField, BoardItemToggleField, ColorMode, ColorPickerId,
-    ColorPickerValue, DaemonAction, DaemonActionResult, DaemonRuntimeStatus, DragToolField,
-    EraserModeOption, FontStyleOption, FontWeightOption, KeybindingField, KeybindingsTabId,
-    NamedColorOption, OverrideOption, PresenterToolBehaviorOption, PresetEraserKindOption,
-    PresetEraserModeOption, PresetTextField, PresetToggleField, QuadField,
-    SessionCompressionOption, SessionStorageModeOption, StatusPositionOption, TabId, TextField,
-    ToggleField, ToolOption, ToolbarLayoutModeOption, ToolbarOverrideField, TripletField, UiTabId,
+    ColorPickerValue, DaemonAction, DaemonActionResult, DaemonRuntimeStatus, DragColorOption,
+    DragMouseButton, DragToolField, DragToolOption, EraserModeOption, FontStyleOption,
+    FontWeightOption, KeybindingField, KeybindingsTabId, NamedColorOption, OverrideOption,
+    PresenterToolBehaviorOption, PresetEraserKindOption, PresetEraserModeOption, PresetTextField,
+    PresetToggleField, QuadField, SessionCompressionOption, SessionStorageModeOption,
+    StatusPositionOption, TabId, TextField, ToggleField, ToolOption, ToolbarLayoutModeOption,
+    ToolbarOverrideField, TripletField, UiTabId,
 };
 #[cfg(feature = "tablet-input")]
 use crate::models::{PressureThicknessEditModeOption, PressureThicknessEntryModeOption};
@@ -40,7 +41,8 @@ pub enum Message {
     ColorModeChanged(ColorMode),
     NamedColorSelected(NamedColorOption),
     EraserModeChanged(EraserModeOption),
-    DrawingDragToolChanged(DragToolField, ToolOption),
+    DrawingMouseDragToolChanged(DragMouseButton, DragToolField, DragToolOption),
+    DrawingMouseDragColorChanged(DragMouseButton, DragToolField, DragColorOption),
     StatusPositionChanged(StatusPositionOption),
     ToolbarLayoutModeChanged(ToolbarLayoutModeOption),
     ToolbarOverrideModeChanged(ToolbarLayoutModeOption),

--- a/configurator/src/models/config/draft/from_config.rs
+++ b/configurator/src/models/config/draft/from_config.rs
@@ -21,6 +21,7 @@ impl ConfigDraft {
         let (style_option, style_value) = FontStyleOption::from_value(&config.drawing.font_style);
         let (weight_option, weight_value) =
             FontWeightOption::from_value(&config.drawing.font_weight);
+        let drawing_drag_tools = config.drawing.effective_drag_tools();
         Self {
             drawing_color: ColorInput::from_color(&config.drawing.default_color),
             drawing_default_thickness: format_float(config.drawing.default_thickness),
@@ -45,6 +46,7 @@ impl ConfigDraft {
                 config.drawing.ctrl_shift_drag_tool,
             ),
             drawing_tab_drag_tool: ToolOption::from_tool(config.drawing.tab_drag_tool),
+            drawing_drag_tools,
             drawing_font_style_option: style_option,
             drawing_font_weight_option: weight_option,
 

--- a/configurator/src/models/config/draft/mod.rs
+++ b/configurator/src/models/config/draft/mod.rs
@@ -12,6 +12,7 @@ use super::super::keybindings::KeybindingsDraft;
 use super::boards::BoardsDraft;
 use super::presets::PresetsDraft;
 use super::toolbar_overrides::ToolbarModeOverridesDraft;
+use wayscriber::config::MouseDragToolsConfig;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConfigDraft {
@@ -34,6 +35,7 @@ pub struct ConfigDraft {
     pub drawing_ctrl_drag_tool: ToolOption,
     pub drawing_ctrl_shift_drag_tool: ToolOption,
     pub drawing_tab_drag_tool: ToolOption,
+    pub drawing_drag_tools: MouseDragToolsConfig,
     pub drawing_font_style_option: FontStyleOption,
     pub drawing_font_weight_option: FontWeightOption,
 

--- a/configurator/src/models/config/presets.rs
+++ b/configurator/src/models/config/presets.rs
@@ -6,7 +6,8 @@ use super::super::fields::{
 use super::super::util::format_float;
 use super::parse::{parse_optional_f64, parse_required_f64};
 use wayscriber::config::{
-    Config, PRESET_SLOTS_MAX, PRESET_SLOTS_MIN, PresetSlotsConfig, ToolPresetConfig,
+    Config, MouseDragToolsConfig, PRESET_SLOTS_MAX, PRESET_SLOTS_MIN, PresetSlotsConfig,
+    ToolPresetConfig,
 };
 use wayscriber::input::Tool;
 
@@ -27,6 +28,7 @@ pub struct PresetSlotDraft {
     pub arrow_angle: String,
     pub arrow_head_at_end: OverrideOption,
     pub show_status_bar: OverrideOption,
+    pub drag_tools: Option<MouseDragToolsConfig>,
 }
 
 impl PresetSlotDraft {
@@ -50,6 +52,7 @@ impl PresetSlotDraft {
                 arrow_angle: preset.arrow_angle.map(format_float).unwrap_or_default(),
                 arrow_head_at_end: OverrideOption::from_option(preset.arrow_head_at_end),
                 show_status_bar: OverrideOption::from_option(preset.show_status_bar),
+                drag_tools: preset.drag_tools.clone(),
             },
             None => {
                 let mut slot = Self::default_from_config(defaults);
@@ -76,6 +79,7 @@ impl PresetSlotDraft {
             arrow_angle: String::new(),
             arrow_head_at_end: OverrideOption::Default,
             show_status_bar: OverrideOption::Default,
+            drag_tools: None,
         }
     }
 
@@ -146,6 +150,7 @@ impl PresetSlotDraft {
             arrow_angle,
             arrow_head_at_end: self.arrow_head_at_end.to_option(),
             show_status_bar: self.show_status_bar.to_option(),
+            drag_tools: self.drag_tools.clone(),
         })
     }
 }

--- a/configurator/src/models/config/setters.rs
+++ b/configurator/src/models/config/setters.rs
@@ -1,6 +1,7 @@
 use super::super::fields::{
-    DragToolField, FontStyleOption, FontWeightOption, OverrideOption, QuadField, TextField,
-    ToggleField, ToolOption, ToolbarLayoutModeOption, ToolbarOverrideField, TripletField,
+    DragColorOption, DragMouseButton, DragToolField, DragToolOption, FontStyleOption,
+    FontWeightOption, OverrideOption, QuadField, TextField, ToggleField, ToolbarLayoutModeOption,
+    ToolbarOverrideField, TripletField,
 };
 use super::draft::ConfigDraft;
 
@@ -30,14 +31,79 @@ impl ConfigDraft {
             .set(field, value);
     }
 
-    pub fn set_drag_tool(&mut self, field: DragToolField, value: ToolOption) {
+    pub fn set_mouse_drag_tool(
+        &mut self,
+        button: DragMouseButton,
+        field: DragToolField,
+        value: DragToolOption,
+    ) {
+        let value = supported_drag_tool_option(button, field, value);
+        let button_config = match button {
+            DragMouseButton::Left => &mut self.drawing_drag_tools.left,
+            DragMouseButton::Right => &mut self.drawing_drag_tools.right,
+            DragMouseButton::Middle => &mut self.drawing_drag_tools.middle,
+        };
         match field {
-            DragToolField::Drag => self.drawing_drag_tool = value,
-            DragToolField::ShiftDrag => self.drawing_shift_drag_tool = value,
-            DragToolField::CtrlDrag => self.drawing_ctrl_drag_tool = value,
-            DragToolField::CtrlShiftDrag => self.drawing_ctrl_shift_drag_tool = value,
-            DragToolField::TabDrag => self.drawing_tab_drag_tool = value,
+            DragToolField::Drag => button_config.drag_tool = value.to_drag_tool(),
+            DragToolField::ShiftDrag => button_config.shift_drag_tool = value.to_drag_tool(),
+            DragToolField::CtrlDrag => button_config.ctrl_drag_tool = value.to_drag_tool(),
+            DragToolField::CtrlShiftDrag => {
+                button_config.ctrl_shift_drag_tool = value.to_drag_tool();
+            }
+            DragToolField::TabDrag => button_config.tab_drag_tool = value.to_drag_tool(),
         }
+
+        if button == DragMouseButton::Left {
+            match field {
+                DragToolField::Drag => {
+                    if let Some(tool) = value.to_tool_option() {
+                        self.drawing_drag_tool = tool;
+                    }
+                }
+                DragToolField::ShiftDrag => {
+                    if let Some(tool) = value.to_tool_option() {
+                        self.drawing_shift_drag_tool = tool;
+                    }
+                }
+                DragToolField::CtrlDrag => {
+                    if let Some(tool) = value.to_tool_option() {
+                        self.drawing_ctrl_drag_tool = tool;
+                    }
+                }
+                DragToolField::CtrlShiftDrag => {
+                    if let Some(tool) = value.to_tool_option() {
+                        self.drawing_ctrl_shift_drag_tool = tool;
+                    }
+                }
+                DragToolField::TabDrag => {
+                    if let Some(tool) = value.to_tool_option() {
+                        self.drawing_tab_drag_tool = tool;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn set_mouse_drag_color(
+        &mut self,
+        button: DragMouseButton,
+        field: DragToolField,
+        value: DragColorOption,
+    ) {
+        let button_config = match button {
+            DragMouseButton::Left => &mut self.drawing_drag_tools.left,
+            DragMouseButton::Right => &mut self.drawing_drag_tools.right,
+            DragMouseButton::Middle => &mut self.drawing_drag_tools.middle,
+        };
+        let color_slot = match field {
+            DragToolField::Drag => &mut button_config.drag_color,
+            DragToolField::ShiftDrag => &mut button_config.shift_drag_color,
+            DragToolField::CtrlDrag => &mut button_config.ctrl_drag_color,
+            DragToolField::CtrlShiftDrag => &mut button_config.ctrl_shift_drag_color,
+            DragToolField::TabDrag => &mut button_config.tab_drag_color,
+        };
+        let existing = color_slot.clone();
+        *color_slot = value.to_color_spec(existing);
     }
 
     pub fn set_toggle(&mut self, field: ToggleField, value: bool) {
@@ -261,5 +327,22 @@ impl ConfigDraft {
                 .click_highlight_outline_color
                 .set_component(index, value),
         }
+    }
+}
+
+fn supported_drag_tool_option(
+    button: DragMouseButton,
+    field: DragToolField,
+    value: DragToolOption,
+) -> DragToolOption {
+    match (button, value) {
+        (DragMouseButton::Left, DragToolOption::Default) => match field {
+            DragToolField::Drag => DragToolOption::Pen,
+            DragToolField::ShiftDrag => DragToolOption::Line,
+            DragToolField::CtrlDrag => DragToolOption::Rect,
+            DragToolField::CtrlShiftDrag => DragToolOption::Arrow,
+            DragToolField::TabDrag => DragToolOption::Ellipse,
+        },
+        _ => value,
     }
 }

--- a/configurator/src/models/config/tests.rs
+++ b/configurator/src/models/config/tests.rs
@@ -1,12 +1,12 @@
 use super::super::color::ColorInput;
 use super::super::fields::{
-    FontWeightOption, QuadField, SessionStorageModeOption, TextField, ToggleField, ToolOption,
-    TripletField,
+    DragMouseButton, DragToolField, DragToolOption, FontWeightOption, QuadField,
+    SessionStorageModeOption, TextField, ToggleField, ToolOption, TripletField,
 };
 use super::super::{ColorMode, NamedColorOption};
 use super::ConfigDraft;
 use wayscriber::config::{ColorSpec, Config, ToolPresetConfig, XdgFocusLossBehavior};
-use wayscriber::input::Tool;
+use wayscriber::input::{DragTool, Tool};
 
 #[test]
 fn config_draft_to_config_reports_errors() {
@@ -64,6 +64,20 @@ fn setters_update_draft_state() {
     draft.set_toggle(ToggleField::ArrowHeadAtEnd, true);
     assert!(draft.boards.auto_create);
     assert!(draft.arrow_head_at_end);
+
+    draft.set_mouse_drag_tool(
+        DragMouseButton::Left,
+        DragToolField::Drag,
+        DragToolOption::Default,
+    );
+    assert_eq!(draft.drawing_drag_tools.left.drag_tool, DragTool::Pen);
+
+    draft.set_mouse_drag_tool(
+        DragMouseButton::Right,
+        DragToolField::Drag,
+        DragToolOption::Pen,
+    );
+    assert_eq!(draft.drawing_drag_tools.right.drag_tool, DragTool::Pen);
 }
 
 #[test]
@@ -93,6 +107,7 @@ fn config_draft_round_trips_presets_and_history() {
         arrow_angle: Some(30.0),
         arrow_head_at_end: Some(true),
         show_status_bar: Some(false),
+        drag_tools: None,
     };
     config.presets.set_slot(1, Some(preset));
 
@@ -141,6 +156,11 @@ fn config_draft_round_trips_drag_tool_mapping() {
     config.drawing.ctrl_drag_tool = Tool::Pen;
     config.drawing.ctrl_shift_drag_tool = Tool::Rect;
     config.drawing.tab_drag_tool = Tool::Ellipse;
+    let mut drag_tools = config.drawing.effective_drag_tools();
+    drag_tools.right.drag_tool = DragTool::Pen;
+    drag_tools.right.drag_color = Some(ColorSpec::Name("blue".to_string()));
+    drag_tools.middle.drag_tool = DragTool::Eraser;
+    config.drawing.drag_tools = Some(drag_tools.clone());
 
     let draft = ConfigDraft::from_config(&config);
     assert_eq!(draft.drawing_drag_tool, ToolOption::Arrow);
@@ -169,6 +189,7 @@ fn config_draft_round_trips_drag_tool_mapping() {
         round_trip.drawing.tab_drag_tool,
         config.drawing.tab_drag_tool
     );
+    assert_eq!(round_trip.drawing.drag_tools, Some(drag_tools));
 }
 
 #[test]

--- a/configurator/src/models/config/to_config/drawing.rs
+++ b/configurator/src/models/config/to_config/drawing.rs
@@ -2,6 +2,7 @@ use super::super::draft::ConfigDraft;
 use super::super::parse::{parse_field, parse_usize_field};
 use crate::models::error::FormError;
 use wayscriber::config::Config;
+use wayscriber::input::Tool;
 
 impl ConfigDraft {
     pub(super) fn apply_drawing(&self, config: &mut Config, errors: &mut Vec<FormError>) {
@@ -39,11 +40,18 @@ impl ConfigDraft {
         config.drawing.font_style = self.drawing_font_style.clone();
         config.drawing.text_background_enabled = self.drawing_text_background_enabled;
         config.drawing.default_fill_enabled = self.drawing_default_fill_enabled;
-        config.drawing.drag_tool = self.drawing_drag_tool.to_tool();
-        config.drawing.shift_drag_tool = self.drawing_shift_drag_tool.to_tool();
-        config.drawing.ctrl_drag_tool = self.drawing_ctrl_drag_tool.to_tool();
-        config.drawing.ctrl_shift_drag_tool = self.drawing_ctrl_shift_drag_tool.to_tool();
-        config.drawing.tab_drag_tool = self.drawing_tab_drag_tool.to_tool();
+        config.drawing.drag_tool = legacy_tool(self.drawing_drag_tools.left.drag_tool, Tool::Pen);
+        config.drawing.shift_drag_tool =
+            legacy_tool(self.drawing_drag_tools.left.shift_drag_tool, Tool::Line);
+        config.drawing.ctrl_drag_tool =
+            legacy_tool(self.drawing_drag_tools.left.ctrl_drag_tool, Tool::Rect);
+        config.drawing.ctrl_shift_drag_tool = legacy_tool(
+            self.drawing_drag_tools.left.ctrl_shift_drag_tool,
+            Tool::Arrow,
+        );
+        config.drawing.tab_drag_tool =
+            legacy_tool(self.drawing_drag_tools.left.tab_drag_tool, Tool::Ellipse);
+        config.drawing.drag_tools = Some(self.drawing_drag_tools.clone());
         parse_field(
             &self.drawing_hit_test_tolerance,
             "drawing.hit_test_tolerance",
@@ -71,4 +79,8 @@ impl ConfigDraft {
         });
         config.arrow.head_at_end = self.arrow_head_at_end;
     }
+}
+
+fn legacy_tool(tool: wayscriber::input::DragTool, fallback: Tool) -> Tool {
+    tool.as_tool().unwrap_or(fallback)
 }

--- a/configurator/src/models/fields/mod.rs
+++ b/configurator/src/models/fields/mod.rs
@@ -19,7 +19,7 @@ pub use status::StatusPositionOption;
 pub use toggles::{
     PresetTextField, PresetToggleField, QuadField, TextField, ToggleField, TripletField,
 };
-pub use tool::{DragToolField, ToolOption};
+pub use tool::{DragColorOption, DragMouseButton, DragToolField, DragToolOption, ToolOption};
 pub use toolbar::{OverrideOption, ToolbarLayoutModeOption, ToolbarOverrideField};
 
 #[cfg(test)]

--- a/configurator/src/models/fields/tests.rs
+++ b/configurator/src/models/fields/tests.rs
@@ -46,3 +46,13 @@ fn session_storage_and_compression_round_trip() {
         SessionCompression::On
     ));
 }
+
+#[test]
+fn drag_tool_options_match_button_capabilities() {
+    let left = DragToolOption::list_for_button(DragMouseButton::Left);
+    assert!(!left.contains(&DragToolOption::Default));
+
+    let right = DragToolOption::list_for_button(DragMouseButton::Right);
+    assert!(right.contains(&DragToolOption::Default));
+    assert_eq!(right, DragToolOption::list());
+}

--- a/configurator/src/models/fields/tool.rs
+++ b/configurator/src/models/fields/tool.rs
@@ -1,4 +1,22 @@
-use wayscriber::input::Tool;
+use wayscriber::config::ColorSpec;
+use wayscriber::input::{DragTool, Tool};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DragMouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+impl DragMouseButton {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Left => "Left button",
+            Self::Right => "Right button",
+            Self::Middle => "Middle button",
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DragToolField {
@@ -103,6 +121,208 @@ impl ToolOption {
 }
 
 impl std::fmt::Display for ToolOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DragToolOption {
+    Default,
+    Select,
+    Pen,
+    Line,
+    Rect,
+    Ellipse,
+    Arrow,
+    Blur,
+    Marker,
+    StepMarker,
+    Highlight,
+    Eraser,
+}
+
+impl DragToolOption {
+    pub fn list() -> Vec<Self> {
+        vec![
+            Self::Default,
+            Self::Select,
+            Self::Pen,
+            Self::Line,
+            Self::Rect,
+            Self::Ellipse,
+            Self::Arrow,
+            Self::Blur,
+            Self::Marker,
+            Self::StepMarker,
+            Self::Highlight,
+            Self::Eraser,
+        ]
+    }
+
+    pub fn list_for_button(button: DragMouseButton) -> Vec<Self> {
+        let mut options = Self::list();
+        if button == DragMouseButton::Left {
+            options.retain(|option| *option != Self::Default);
+        }
+        options
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Default => "Button default",
+            Self::Select => "Select",
+            Self::Pen => "Pen",
+            Self::Line => "Line",
+            Self::Rect => "Rectangle",
+            Self::Ellipse => "Ellipse",
+            Self::Arrow => "Arrow",
+            Self::Blur => "Blur",
+            Self::Marker => "Marker",
+            Self::StepMarker => "Step",
+            Self::Highlight => "Highlight",
+            Self::Eraser => "Eraser",
+        }
+    }
+
+    pub fn to_drag_tool(self) -> DragTool {
+        match self {
+            Self::Default => DragTool::Default,
+            Self::Select => DragTool::Select,
+            Self::Pen => DragTool::Pen,
+            Self::Line => DragTool::Line,
+            Self::Rect => DragTool::Rect,
+            Self::Ellipse => DragTool::Ellipse,
+            Self::Arrow => DragTool::Arrow,
+            Self::Blur => DragTool::Blur,
+            Self::Marker => DragTool::Marker,
+            Self::StepMarker => DragTool::StepMarker,
+            Self::Highlight => DragTool::Highlight,
+            Self::Eraser => DragTool::Eraser,
+        }
+    }
+
+    pub fn from_drag_tool(tool: DragTool) -> Self {
+        match tool {
+            DragTool::Default => Self::Default,
+            DragTool::Select => Self::Select,
+            DragTool::Pen => Self::Pen,
+            DragTool::Line => Self::Line,
+            DragTool::Rect => Self::Rect,
+            DragTool::Ellipse => Self::Ellipse,
+            DragTool::Arrow => Self::Arrow,
+            DragTool::Blur => Self::Blur,
+            DragTool::Marker => Self::Marker,
+            DragTool::StepMarker => Self::StepMarker,
+            DragTool::Highlight => Self::Highlight,
+            DragTool::Eraser => Self::Eraser,
+        }
+    }
+
+    pub fn to_tool_option(self) -> Option<ToolOption> {
+        match self {
+            Self::Default => None,
+            Self::Select => Some(ToolOption::Select),
+            Self::Pen => Some(ToolOption::Pen),
+            Self::Line => Some(ToolOption::Line),
+            Self::Rect => Some(ToolOption::Rect),
+            Self::Ellipse => Some(ToolOption::Ellipse),
+            Self::Arrow => Some(ToolOption::Arrow),
+            Self::Blur => Some(ToolOption::Blur),
+            Self::Marker => Some(ToolOption::Marker),
+            Self::StepMarker => Some(ToolOption::StepMarker),
+            Self::Highlight => Some(ToolOption::Highlight),
+            Self::Eraser => Some(ToolOption::Eraser),
+        }
+    }
+}
+
+impl std::fmt::Display for DragToolOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DragColorOption {
+    Current,
+    Red,
+    Green,
+    Blue,
+    Yellow,
+    Orange,
+    Pink,
+    White,
+    Black,
+    Custom,
+}
+
+impl DragColorOption {
+    pub fn list() -> Vec<Self> {
+        vec![
+            Self::Current,
+            Self::Red,
+            Self::Green,
+            Self::Blue,
+            Self::Yellow,
+            Self::Orange,
+            Self::Pink,
+            Self::White,
+            Self::Black,
+        ]
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Current => "Current color",
+            Self::Red => "Red",
+            Self::Green => "Green",
+            Self::Blue => "Blue",
+            Self::Yellow => "Yellow",
+            Self::Orange => "Orange",
+            Self::Pink => "Pink",
+            Self::White => "White",
+            Self::Black => "Black",
+            Self::Custom => "Custom RGB",
+        }
+    }
+
+    pub fn from_color(color: Option<&ColorSpec>) -> Self {
+        match color {
+            None => Self::Current,
+            Some(ColorSpec::Rgb(_)) => Self::Custom,
+            Some(ColorSpec::Name(name)) => match name.trim().to_lowercase().as_str() {
+                "red" => Self::Red,
+                "green" => Self::Green,
+                "blue" => Self::Blue,
+                "yellow" => Self::Yellow,
+                "orange" => Self::Orange,
+                "pink" => Self::Pink,
+                "white" => Self::White,
+                "black" => Self::Black,
+                _ => Self::Custom,
+            },
+        }
+    }
+
+    pub fn to_color_spec(self, existing: Option<ColorSpec>) -> Option<ColorSpec> {
+        let name = match self {
+            Self::Current => return None,
+            Self::Custom => return existing,
+            Self::Red => "red",
+            Self::Green => "green",
+            Self::Blue => "blue",
+            Self::Yellow => "yellow",
+            Self::Orange => "orange",
+            Self::Pink => "pink",
+            Self::White => "white",
+            Self::Black => "black",
+        };
+        Some(ColorSpec::Name(name.to_string()))
+    }
+}
+
+impl std::fmt::Display for DragColorOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.label())
     }

--- a/configurator/src/models/mod.rs
+++ b/configurator/src/models/mod.rs
@@ -16,11 +16,11 @@ pub use daemon::{
     ShortcutApplyCapability, ShortcutBackend,
 };
 pub use fields::{
-    DragToolField, EraserModeOption, FontStyleOption, FontWeightOption, OverrideOption,
-    PresenterToolBehaviorOption, PresetEraserKindOption, PresetEraserModeOption, PresetTextField,
-    PresetToggleField, QuadField, SessionCompressionOption, SessionStorageModeOption,
-    StatusPositionOption, TextField, ToggleField, ToolOption, ToolbarLayoutModeOption,
-    ToolbarOverrideField, TripletField,
+    DragColorOption, DragMouseButton, DragToolField, DragToolOption, EraserModeOption,
+    FontStyleOption, FontWeightOption, OverrideOption, PresenterToolBehaviorOption,
+    PresetEraserKindOption, PresetEraserModeOption, PresetTextField, PresetToggleField, QuadField,
+    SessionCompressionOption, SessionStorageModeOption, StatusPositionOption, TextField,
+    ToggleField, ToolOption, ToolbarLayoutModeOption, ToolbarOverrideField, TripletField,
 };
 #[cfg(feature = "tablet-input")]
 pub use fields::{PressureThicknessEditModeOption, PressureThicknessEntryModeOption};

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -68,6 +68,20 @@ shift_drag_tool = "line"
 ctrl_drag_tool = "rect"
 ctrl_shift_drag_tool = "arrow"
 tab_drag_tool = "ellipse"
+
+# Optional per-button override. Right/middle keep their built-in behavior
+# unless configured. Use "default" for a button's built-in behavior.
+[drawing.drag_tools.left]
+drag_tool = "pen"
+shift_drag_tool = "pen"
+shift_drag_color = "red"
+
+[drawing.drag_tools.right]
+drag_tool = "pen"
+drag_color = "blue"
+
+[drawing.drag_tools.middle]
+drag_tool = "default"
 ```
 
 **Color Options:**
@@ -141,7 +155,7 @@ show_status_bar = true
 ```
 
 **Required fields:** `tool`, `color`, `size`  
-**Optional fields:** `eraser_kind`, `eraser_mode`, `marker_opacity`, `fill_enabled`, `font_size`, `text_background_enabled`, `arrow_length`, `arrow_angle`, `arrow_head_at_end`, `show_status_bar`
+**Optional fields:** `eraser_kind`, `eraser_mode`, `marker_opacity`, `fill_enabled`, `font_size`, `text_background_enabled`, `arrow_length`, `arrow_angle`, `arrow_head_at_end`, `show_status_bar`, `drag_tools`
 
 ### `[history]` - Undo/Redo Playback
 

--- a/src/backend/wayland/backend/state_init/input_state.rs
+++ b/src/backend/wayland/backend/state_init/input_state.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::config::{Action, Config, KeyBinding, KeybindingsConfig};
 use crate::draw::FontDescriptor;
-use crate::input::{ClickHighlightSettings, InputState, modifiers::DragToolBindings};
+use crate::input::{ClickHighlightSettings, DragToolBindings, InputState};
 
 pub(super) fn build_input_state(config: &Config) -> InputState {
     let font_descriptor = FontDescriptor::new(
@@ -43,13 +43,7 @@ pub(super) fn build_input_state(config: &Config) -> InputState {
         config.presenter_mode.clone(),
     );
     input_state.set_action_bindings(action_bindings);
-    input_state.set_drag_tool_bindings(DragToolBindings {
-        drag: config.drawing.drag_tool,
-        shift_drag: config.drawing.shift_drag_tool,
-        ctrl_drag: config.drawing.ctrl_drag_tool,
-        ctrl_shift_drag: config.drawing.ctrl_shift_drag_tool,
-        tab_drag: config.drawing.tab_drag_tool,
-    });
+    input_state.set_drag_tool_bindings(build_drag_tool_bindings(config));
 
     input_state.set_hit_test_tolerance(config.drawing.hit_test_tolerance);
     input_state.set_hit_test_threshold(config.drawing.hit_test_linear_threshold);
@@ -95,6 +89,11 @@ pub(super) fn build_input_state(config: &Config) -> InputState {
     input_state.init_presets_from_config(&config.presets);
 
     input_state
+}
+
+fn build_drag_tool_bindings(config: &Config) -> DragToolBindings {
+    let drag_tools = config.drawing.effective_drag_tools();
+    DragToolBindings::from_config(&drag_tools)
 }
 
 fn build_action_map(config: &Config) -> HashMap<KeyBinding, Action> {
@@ -209,12 +208,41 @@ mod tests {
         assert_eq!(
             input.drag_tool_bindings,
             crate::input::DragToolBindings {
-                drag: crate::input::Tool::Arrow,
-                shift_drag: crate::input::Tool::Eraser,
-                ctrl_drag: crate::input::Tool::Pen,
-                ctrl_shift_drag: crate::input::Tool::Rect,
-                tab_drag: crate::input::Tool::Ellipse,
-            }
+                left: crate::input::DragButtonBindings {
+                    drag: crate::input::DragBinding::from_tool(crate::input::Tool::Arrow),
+                    shift_drag: crate::input::DragBinding::from_tool(crate::input::Tool::Eraser),
+                    ctrl_drag: crate::input::DragBinding::from_tool(crate::input::Tool::Pen),
+                    ctrl_shift_drag: crate::input::DragBinding::from_tool(crate::input::Tool::Rect,),
+                    tab_drag: crate::input::DragBinding::from_tool(crate::input::Tool::Ellipse),
+                },
+                right: crate::input::DragButtonBindings::button_default(),
+                middle: crate::input::DragButtonBindings::button_default(),
+            },
+        );
+    }
+
+    #[test]
+    fn build_input_state_applies_mouse_button_drag_tool_bindings() {
+        let mut config = Config::default();
+        let mut drag_tools = config.drawing.effective_drag_tools();
+        drag_tools.left.drag_tool = crate::input::DragTool::Line;
+        drag_tools.right.drag_tool = crate::input::DragTool::Pen;
+        drag_tools.right.drag_color = Some(crate::config::ColorSpec::Name("blue".to_string()));
+        config.drawing.drag_tools = Some(drag_tools);
+
+        let input = build_input_state(&config);
+
+        assert_eq!(
+            input.drag_tool_bindings.left.drag.tool,
+            crate::input::DragTool::Line
+        );
+        assert_eq!(
+            input.drag_tool_bindings.right.drag.tool,
+            crate::input::DragTool::Pen
+        );
+        assert_eq!(
+            input.drag_tool_bindings.right.drag.color,
+            Some(crate::config::ColorSpec::Name("blue".to_string()).to_color())
         );
     }
 }

--- a/src/backend/wayland/state/onboarding.rs
+++ b/src/backend/wayland/state/onboarding.rs
@@ -243,10 +243,7 @@ impl WaylandState {
                 changed = true;
             }
 
-            loop {
-                let Some(step) = state.active_step else {
-                    break;
-                };
+            while let Some(step) = state.active_step {
                 match step {
                     FirstRunStep::BackgroundModeSetup => {
                         if !state.first_run_background_mode_prompted {

--- a/src/backend/wayland/state/render/canvas/text.rs
+++ b/src/backend/wayland/state/render/canvas/text.rs
@@ -69,20 +69,18 @@ impl WaylandState {
                 font_descriptor,
                 background_enabled,
                 wrap_width,
-            } => {
-                if !text.is_empty() {
-                    crate::draw::render_text(
-                        ctx,
-                        *x,
-                        *y,
-                        text,
-                        *color,
-                        *size,
-                        font_descriptor,
-                        *background_enabled,
-                        *wrap_width,
-                    );
-                }
+            } if !text.is_empty() => {
+                crate::draw::render_text(
+                    ctx,
+                    *x,
+                    *y,
+                    text,
+                    *color,
+                    *size,
+                    font_descriptor,
+                    *background_enabled,
+                    *wrap_width,
+                );
             }
             Shape::StickyNote {
                 x,
@@ -92,23 +90,20 @@ impl WaylandState {
                 size,
                 font_descriptor,
                 wrap_width,
-            } => {
-                if !text.is_empty() {
-                    crate::draw::render_sticky_note(
-                        ctx,
-                        *x,
-                        *y,
-                        text,
-                        *background,
-                        *size,
-                        font_descriptor,
-                        *wrap_width,
-                    );
-                }
+            } if !text.is_empty() => {
+                crate::draw::render_sticky_note(
+                    ctx,
+                    *x,
+                    *y,
+                    text,
+                    *background,
+                    *size,
+                    font_descriptor,
+                    *wrap_width,
+                );
             }
             _ => {}
         }
-
         let _ = ctx.pop_group_to_source();
         // Render the ghost with increased opacity (was 0.25, now 0.40)
         let _ = ctx.paint_with_alpha(0.40);

--- a/src/backend/wayland/state/toolbar/events.rs
+++ b/src/backend/wayland/state/toolbar/events.rs
@@ -240,7 +240,7 @@ impl WaylandState {
     ) {
         match action {
             crate::input::state::PresetAction::Save { slot, preset } => {
-                self.config.presets.set_slot(slot, Some(preset));
+                self.config.presets.set_slot(slot, Some(*preset));
                 if let Err(err) = self.config.save() {
                     log::warn!("Failed to save preset slot {}: {}", slot, err);
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,11 +39,11 @@ pub use types::TabletInputConfig;
 #[allow(unused_imports)]
 pub use types::{
     ArrowConfig, BoardBackgroundConfig, BoardColorConfig, BoardConfig, BoardItemConfig,
-    BoardsConfig, CaptureConfig, ClickHighlightConfig, DrawingConfig, HelpOverlayStyle,
-    HistoryConfig, PRESET_SLOTS_MAX, PRESET_SLOTS_MIN, PerformanceConfig, PresenterModeConfig,
-    PresenterToolBehavior, PresetSlotsConfig, SessionCompression, SessionConfig,
-    SessionStorageMode, StatusBarStyle, ToolPresetConfig, ToolbarConfig, ToolbarLayoutMode,
-    ToolbarModeOverride, ToolbarModeOverrides, UiConfig,
+    BoardsConfig, CaptureConfig, ClickHighlightConfig, DragButtonConfig, DrawingConfig,
+    HelpOverlayStyle, HistoryConfig, MouseDragToolsConfig, PRESET_SLOTS_MAX, PRESET_SLOTS_MIN,
+    PerformanceConfig, PresenterModeConfig, PresenterToolBehavior, PresetSlotsConfig,
+    SessionCompression, SessionConfig, SessionStorageMode, StatusBarStyle, ToolPresetConfig,
+    ToolbarConfig, ToolbarLayoutMode, ToolbarModeOverride, ToolbarModeOverrides, UiConfig,
 };
 
 // Re-export for public API (unused internally but part of public interface)

--- a/src/config/tests/load.rs
+++ b/src/config/tests/load.rs
@@ -38,6 +38,81 @@ fn load_parses_xdg_focus_loss_behavior_stay() {
 }
 
 #[test]
+fn load_parses_mouse_button_drag_tool_bindings() {
+    with_temp_config_home(|config_root| {
+        let primary_dir = config_root.join(PRIMARY_CONFIG_DIR);
+        fs::create_dir_all(&primary_dir).unwrap();
+        fs::write(
+            primary_dir.join("config.toml"),
+            "[drawing.drag_tools.left]\ndrag_tool = 'line'\nshift_drag_tool = 'pen'\n\n[drawing.drag_tools.right]\ndrag_tool = 'pen'\ndrag_color = 'blue'\n",
+        )
+        .unwrap();
+
+        let loaded = Config::load().expect("load succeeds");
+        let drag_tools = loaded.config.drawing.drag_tools.expect("drag tools config");
+        assert_eq!(drag_tools.left.drag_tool, crate::input::DragTool::Line);
+        assert_eq!(drag_tools.left.shift_drag_tool, crate::input::DragTool::Pen);
+        assert_eq!(drag_tools.right.drag_tool, crate::input::DragTool::Pen);
+        assert_eq!(
+            drag_tools.right.drag_color,
+            Some(ColorSpec::Name("blue".to_string()))
+        );
+    });
+}
+
+#[test]
+fn effective_drag_tools_preserve_legacy_left_when_only_right_is_configured() {
+    with_temp_config_home(|config_root| {
+        let primary_dir = config_root.join(PRIMARY_CONFIG_DIR);
+        fs::create_dir_all(&primary_dir).unwrap();
+        fs::write(
+            primary_dir.join("config.toml"),
+            "[drawing]\ndrag_tool = 'arrow'\nshift_drag_tool = 'eraser'\n\n[drawing.drag_tools.right]\ndrag_tool = 'pen'\n",
+        )
+        .unwrap();
+
+        let loaded = Config::load().expect("load succeeds");
+        let drag_tools = loaded.config.drawing.effective_drag_tools();
+        assert_eq!(drag_tools.left.drag_tool, crate::input::DragTool::Arrow);
+        assert_eq!(
+            drag_tools.left.shift_drag_tool,
+            crate::input::DragTool::Eraser
+        );
+        assert_eq!(drag_tools.right.drag_tool, crate::input::DragTool::Pen);
+    });
+}
+
+#[test]
+fn effective_drag_tools_preserve_explicit_builtin_left_mapping() {
+    with_temp_config_home(|config_root| {
+        let primary_dir = config_root.join(PRIMARY_CONFIG_DIR);
+        fs::create_dir_all(&primary_dir).unwrap();
+        fs::write(
+            primary_dir.join("config.toml"),
+            "[drawing]\ndrag_tool = 'arrow'\nshift_drag_tool = 'eraser'\n\n[drawing.drag_tools.left]\ndrag_tool = 'pen'\nshift_drag_tool = 'line'\nctrl_drag_tool = 'rect'\nctrl_shift_drag_tool = 'arrow'\ntab_drag_tool = 'ellipse'\n",
+        )
+        .unwrap();
+
+        let loaded = Config::load().expect("load succeeds");
+        let drag_tools = loaded.config.drawing.effective_drag_tools();
+        assert_eq!(drag_tools.left.drag_tool, crate::input::DragTool::Pen);
+        assert_eq!(
+            drag_tools.left.shift_drag_tool,
+            crate::input::DragTool::Line
+        );
+        assert_eq!(drag_tools.left.ctrl_drag_tool, crate::input::DragTool::Rect);
+        assert_eq!(
+            drag_tools.left.ctrl_shift_drag_tool,
+            crate::input::DragTool::Arrow
+        );
+        assert_eq!(
+            drag_tools.left.tab_drag_tool,
+            crate::input::DragTool::Ellipse
+        );
+    });
+}
+
+#[test]
 fn ui_defaults_follow_desktop_for_xdg_focus_loss() {
     let desktop_like_gnome = [
         "XDG_CURRENT_DESKTOP",

--- a/src/config/tests/validate.rs
+++ b/src/config/tests/validate.rs
@@ -108,6 +108,7 @@ fn validate_clamps_preset_fields() {
         arrow_angle: Some(5.0),
         arrow_head_at_end: None,
         show_status_bar: None,
+        drag_tools: None,
     });
 
     config.validate_and_clamp();

--- a/src/config/types/drawing.rs
+++ b/src/config/types/drawing.rs
@@ -1,5 +1,5 @@
 use crate::config::enums::ColorSpec;
-use crate::input::{EraserMode, Tool};
+use crate::input::{DragTool, EraserMode, Tool};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -70,6 +70,13 @@ pub struct DrawingConfig {
     #[serde(default = "default_tab_drag_tool")]
     pub tab_drag_tool: Tool,
 
+    /// Optional per-mouse-button drag tool mapping.
+    ///
+    /// When omitted, the legacy drag-tool fields above apply to left-button
+    /// drags and right/middle buttons keep their built-in behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drag_tools: Option<MouseDragToolsConfig>,
+
     /// Font family name for text rendering (e.g., "Sans", "Monospace", "JetBrains Mono")
     /// Falls back to "Sans" if the specified font is not available
     /// Note: Install fonts system-wide and reference by family name
@@ -108,10 +115,265 @@ impl Default for DrawingConfig {
             ctrl_drag_tool: default_ctrl_drag_tool(),
             ctrl_shift_drag_tool: default_ctrl_shift_drag_tool(),
             tab_drag_tool: default_tab_drag_tool(),
+            drag_tools: None,
             font_family: default_font_family(),
             font_weight: default_font_weight(),
             font_style: default_font_style(),
             text_background_enabled: default_text_background(),
+        }
+    }
+}
+
+/// Drag bindings for all supported mouse buttons.
+#[derive(Debug, Clone, PartialEq, Serialize, JsonSchema)]
+pub struct MouseDragToolsConfig {
+    /// Left mouse button drag bindings.
+    #[serde(default = "default_left_drag_button")]
+    pub left: DragButtonConfig,
+
+    /// Right mouse button drag bindings.
+    #[serde(default = "default_button_behavior_drag_button")]
+    pub right: DragButtonConfig,
+
+    /// Middle mouse button drag bindings.
+    #[serde(default = "default_button_behavior_drag_button")]
+    pub middle: DragButtonConfig,
+
+    /// Whether the left table was present in the user's config.
+    #[serde(skip)]
+    #[schemars(skip)]
+    left_explicit: bool,
+}
+
+impl MouseDragToolsConfig {
+    pub fn from_legacy(
+        drag_tool: Tool,
+        shift_drag_tool: Tool,
+        ctrl_drag_tool: Tool,
+        ctrl_shift_drag_tool: Tool,
+        tab_drag_tool: Tool,
+    ) -> Self {
+        Self {
+            left: DragButtonConfig::from_legacy(
+                drag_tool,
+                shift_drag_tool,
+                ctrl_drag_tool,
+                ctrl_shift_drag_tool,
+                tab_drag_tool,
+            ),
+            right: DragButtonConfig::button_behavior(),
+            middle: DragButtonConfig::button_behavior(),
+            left_explicit: false,
+        }
+    }
+
+    pub fn from_buttons(
+        left: DragButtonConfig,
+        right: DragButtonConfig,
+        middle: DragButtonConfig,
+    ) -> Self {
+        Self {
+            left,
+            right,
+            middle,
+            left_explicit: true,
+        }
+    }
+
+    pub fn left_explicit(&self) -> bool {
+        self.left_explicit
+    }
+
+    pub fn resolve_with_left_defaults(mut self, left_defaults: &DragButtonConfig) -> Self {
+        if self.left_explicit() {
+            self.left.apply_defaults_from(left_defaults);
+        } else {
+            self.left = left_defaults.clone();
+        }
+        self.left_explicit = true;
+        self
+    }
+}
+
+impl<'de> Deserialize<'de> for MouseDragToolsConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct MouseDragToolsConfigFields {
+            left: Option<DragButtonConfig>,
+            right: Option<DragButtonConfig>,
+            middle: Option<DragButtonConfig>,
+        }
+
+        let fields = MouseDragToolsConfigFields::deserialize(deserializer)?;
+        let left_explicit = fields.left.is_some();
+        Ok(Self {
+            left: fields.left.unwrap_or_else(default_left_drag_button),
+            right: fields
+                .right
+                .unwrap_or_else(default_button_behavior_drag_button),
+            middle: fields
+                .middle
+                .unwrap_or_else(default_button_behavior_drag_button),
+            left_explicit,
+        })
+    }
+}
+
+impl Default for MouseDragToolsConfig {
+    fn default() -> Self {
+        Self::from_legacy(
+            default_drag_tool(),
+            default_shift_drag_tool(),
+            default_ctrl_drag_tool(),
+            default_ctrl_shift_drag_tool(),
+            default_tab_drag_tool(),
+        )
+    }
+}
+
+/// Drag bindings for one mouse button.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DragButtonConfig {
+    /// Tool/action used for drag with no modifier.
+    #[serde(default = "default_button_behavior_drag_tool")]
+    pub drag_tool: DragTool,
+    /// Optional color used for drag with no modifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drag_color: Option<ColorSpec>,
+
+    /// Tool/action used for Shift+drag.
+    #[serde(default = "default_button_behavior_drag_tool")]
+    pub shift_drag_tool: DragTool,
+    /// Optional color used for Shift+drag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shift_drag_color: Option<ColorSpec>,
+
+    /// Tool/action used for Ctrl+drag.
+    #[serde(default = "default_button_behavior_drag_tool")]
+    pub ctrl_drag_tool: DragTool,
+    /// Optional color used for Ctrl+drag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ctrl_drag_color: Option<ColorSpec>,
+
+    /// Tool/action used for Ctrl+Shift+drag.
+    #[serde(default = "default_button_behavior_drag_tool")]
+    pub ctrl_shift_drag_tool: DragTool,
+    /// Optional color used for Ctrl+Shift+drag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ctrl_shift_drag_color: Option<ColorSpec>,
+
+    /// Tool/action used for Tab+drag.
+    #[serde(default = "default_button_behavior_drag_tool")]
+    pub tab_drag_tool: DragTool,
+    /// Optional color used for Tab+drag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab_drag_color: Option<ColorSpec>,
+}
+
+impl DragButtonConfig {
+    pub fn from_legacy(
+        drag_tool: Tool,
+        shift_drag_tool: Tool,
+        ctrl_drag_tool: Tool,
+        ctrl_shift_drag_tool: Tool,
+        tab_drag_tool: Tool,
+    ) -> Self {
+        Self {
+            drag_tool: DragTool::from_tool(drag_tool),
+            drag_color: None,
+            shift_drag_tool: DragTool::from_tool(shift_drag_tool),
+            shift_drag_color: None,
+            ctrl_drag_tool: DragTool::from_tool(ctrl_drag_tool),
+            ctrl_drag_color: None,
+            ctrl_shift_drag_tool: DragTool::from_tool(ctrl_shift_drag_tool),
+            ctrl_shift_drag_color: None,
+            tab_drag_tool: DragTool::from_tool(tab_drag_tool),
+            tab_drag_color: None,
+        }
+    }
+
+    pub fn button_behavior() -> Self {
+        Self {
+            drag_tool: DragTool::Default,
+            drag_color: None,
+            shift_drag_tool: DragTool::Default,
+            shift_drag_color: None,
+            ctrl_drag_tool: DragTool::Default,
+            ctrl_drag_color: None,
+            ctrl_shift_drag_tool: DragTool::Default,
+            ctrl_shift_drag_color: None,
+            tab_drag_tool: DragTool::Default,
+            tab_drag_color: None,
+        }
+    }
+
+    fn apply_defaults_from(&mut self, defaults: &Self) {
+        if self.drag_tool == DragTool::Default {
+            self.drag_tool = defaults.drag_tool;
+            if self.drag_color.is_none() {
+                self.drag_color = defaults.drag_color.clone();
+            }
+        }
+        if self.shift_drag_tool == DragTool::Default {
+            self.shift_drag_tool = defaults.shift_drag_tool;
+            if self.shift_drag_color.is_none() {
+                self.shift_drag_color = defaults.shift_drag_color.clone();
+            }
+        }
+        if self.ctrl_drag_tool == DragTool::Default {
+            self.ctrl_drag_tool = defaults.ctrl_drag_tool;
+            if self.ctrl_drag_color.is_none() {
+                self.ctrl_drag_color = defaults.ctrl_drag_color.clone();
+            }
+        }
+        if self.ctrl_shift_drag_tool == DragTool::Default {
+            self.ctrl_shift_drag_tool = defaults.ctrl_shift_drag_tool;
+            if self.ctrl_shift_drag_color.is_none() {
+                self.ctrl_shift_drag_color = defaults.ctrl_shift_drag_color.clone();
+            }
+        }
+        if self.tab_drag_tool == DragTool::Default {
+            self.tab_drag_tool = defaults.tab_drag_tool;
+            if self.tab_drag_color.is_none() {
+                self.tab_drag_color = defaults.tab_drag_color.clone();
+            }
+        }
+    }
+}
+
+impl Default for DragButtonConfig {
+    fn default() -> Self {
+        Self::button_behavior()
+    }
+}
+
+impl DrawingConfig {
+    pub fn effective_drag_tools(&self) -> MouseDragToolsConfig {
+        match self.drag_tools.clone() {
+            Some(drag_tools) => {
+                let legacy_left = DragButtonConfig::from_legacy(
+                    self.drag_tool,
+                    self.shift_drag_tool,
+                    self.ctrl_drag_tool,
+                    self.ctrl_shift_drag_tool,
+                    self.tab_drag_tool,
+                );
+                drag_tools.resolve_with_left_defaults(&legacy_left)
+            }
+            None => MouseDragToolsConfig::from_buttons(
+                DragButtonConfig::from_legacy(
+                    self.drag_tool,
+                    self.shift_drag_tool,
+                    self.ctrl_drag_tool,
+                    self.ctrl_shift_drag_tool,
+                    self.tab_drag_tool,
+                ),
+                DragButtonConfig::button_behavior(),
+                DragButtonConfig::button_behavior(),
+            ),
         }
     }
 }
@@ -190,4 +452,22 @@ fn default_ctrl_shift_drag_tool() -> Tool {
 
 fn default_tab_drag_tool() -> Tool {
     Tool::Ellipse
+}
+
+fn default_button_behavior_drag_tool() -> DragTool {
+    DragTool::Default
+}
+
+fn default_left_drag_button() -> DragButtonConfig {
+    DragButtonConfig::from_legacy(
+        default_drag_tool(),
+        default_shift_drag_tool(),
+        default_ctrl_drag_tool(),
+        default_ctrl_shift_drag_tool(),
+        default_tab_drag_tool(),
+    )
+}
+
+fn default_button_behavior_drag_button() -> DragButtonConfig {
+    DragButtonConfig::button_behavior()
 }

--- a/src/config/types/mod.rs
+++ b/src/config/types/mod.rs
@@ -25,7 +25,7 @@ pub use boards::{BoardBackgroundConfig, BoardColorConfig, BoardItemConfig, Board
 pub use capture::CaptureConfig;
 pub use click_highlight::ClickHighlightConfig;
 pub use context_menu::ContextMenuUiConfig;
-pub use drawing::DrawingConfig;
+pub use drawing::{DragButtonConfig, DrawingConfig, MouseDragToolsConfig};
 pub use help_overlay::HelpOverlayStyle;
 pub use history::HistoryConfig;
 pub use performance::PerformanceConfig;

--- a/src/config/types/presets.rs
+++ b/src/config/types/presets.rs
@@ -1,4 +1,4 @@
-use crate::config::enums::ColorSpec;
+use crate::config::{MouseDragToolsConfig, enums::ColorSpec};
 use crate::draw::EraserKind;
 use crate::input::{EraserMode, Tool};
 use schemars::JsonSchema;
@@ -62,6 +62,10 @@ pub struct ToolPresetConfig {
     /// Optional status bar visibility override.
     #[serde(default)]
     pub show_status_bar: Option<bool>,
+
+    /// Optional per-button drag tool bindings to apply with this preset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drag_tools: Option<MouseDragToolsConfig>,
 }
 
 /// Preset slot configuration for quick tool switching.

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -28,8 +28,8 @@ pub use state::{
 #[cfg(tablet)]
 #[allow(unused_imports)]
 pub use tablet::TabletSettings;
-pub use tool::{EraserMode, Tool};
+pub use tool::{DragTool, EraserMode, Tool};
 
 // Re-export for public API (unused internally but part of public interface)
 #[allow(unused_imports)]
-pub use modifiers::{DragModifier, DragToolBindings, Modifiers};
+pub use modifiers::{DragBinding, DragButtonBindings, DragModifier, DragToolBindings, Modifiers};

--- a/src/input/modifiers.rs
+++ b/src/input/modifiers.rs
@@ -1,6 +1,10 @@
 //! Keyboard modifier state tracking.
 
-use super::tool::Tool;
+use crate::config::{DragButtonConfig, MouseDragToolsConfig, enums::ColorSpec};
+use crate::draw::Color;
+
+use super::tool::DragTool;
+use super::{events::MouseButton, tool::Tool};
 
 /// Active drag modifier combination used for tool mapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,30 +22,65 @@ impl DragModifier {
     }
 }
 
-/// Tool mapping for drag gestures with optional modifiers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DragToolBindings {
-    pub drag: Tool,
-    pub shift_drag: Tool,
-    pub ctrl_drag: Tool,
-    pub ctrl_shift_drag: Tool,
-    pub tab_drag: Tool,
+/// Tool mapping for a single drag gesture, optionally with a default color.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DragBinding {
+    pub tool: DragTool,
+    pub color: Option<Color>,
 }
 
-impl Default for DragToolBindings {
-    fn default() -> Self {
+impl DragBinding {
+    pub fn new(tool: DragTool, color: Option<Color>) -> Self {
+        Self { tool, color }
+    }
+
+    pub fn from_tool(tool: Tool) -> Self {
         Self {
-            drag: Tool::Pen,
-            shift_drag: Tool::Line,
-            ctrl_drag: Tool::Rect,
-            ctrl_shift_drag: Tool::Arrow,
-            tab_drag: Tool::Ellipse,
+            tool: DragTool::from_tool(tool),
+            color: None,
+        }
+    }
+
+    pub fn button_default() -> Self {
+        Self {
+            tool: DragTool::Default,
+            color: None,
         }
     }
 }
 
-impl DragToolBindings {
-    pub fn tool_for_modifier(self, modifier: DragModifier) -> Tool {
+/// Tool mapping for drag gestures with optional modifiers on one mouse button.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DragButtonBindings {
+    pub drag: DragBinding,
+    pub shift_drag: DragBinding,
+    pub ctrl_drag: DragBinding,
+    pub ctrl_shift_drag: DragBinding,
+    pub tab_drag: DragBinding,
+}
+
+impl DragButtonBindings {
+    pub fn legacy_left() -> Self {
+        Self {
+            drag: DragBinding::from_tool(Tool::Pen),
+            shift_drag: DragBinding::from_tool(Tool::Line),
+            ctrl_drag: DragBinding::from_tool(Tool::Rect),
+            ctrl_shift_drag: DragBinding::from_tool(Tool::Arrow),
+            tab_drag: DragBinding::from_tool(Tool::Ellipse),
+        }
+    }
+
+    pub fn button_default() -> Self {
+        Self {
+            drag: DragBinding::button_default(),
+            shift_drag: DragBinding::button_default(),
+            ctrl_drag: DragBinding::button_default(),
+            ctrl_shift_drag: DragBinding::button_default(),
+            tab_drag: DragBinding::button_default(),
+        }
+    }
+
+    pub fn binding_for_modifier(self, modifier: DragModifier) -> DragBinding {
         match modifier {
             DragModifier::None => self.drag,
             DragModifier::Shift => self.shift_drag,
@@ -49,6 +88,102 @@ impl DragToolBindings {
             DragModifier::CtrlShift => self.ctrl_shift_drag,
             DragModifier::Tab => self.tab_drag,
         }
+    }
+
+    pub fn from_config(config: &DragButtonConfig) -> Self {
+        Self {
+            drag: DragBinding::new(
+                config.drag_tool,
+                config.drag_color.as_ref().map(|c| c.to_color()),
+            ),
+            shift_drag: DragBinding::new(
+                config.shift_drag_tool,
+                config.shift_drag_color.as_ref().map(|c| c.to_color()),
+            ),
+            ctrl_drag: DragBinding::new(
+                config.ctrl_drag_tool,
+                config.ctrl_drag_color.as_ref().map(|c| c.to_color()),
+            ),
+            ctrl_shift_drag: DragBinding::new(
+                config.ctrl_shift_drag_tool,
+                config.ctrl_shift_drag_color.as_ref().map(|c| c.to_color()),
+            ),
+            tab_drag: DragBinding::new(
+                config.tab_drag_tool,
+                config.tab_drag_color.as_ref().map(|c| c.to_color()),
+            ),
+        }
+    }
+
+    pub fn to_config(self) -> DragButtonConfig {
+        DragButtonConfig {
+            drag_tool: self.drag.tool,
+            drag_color: self.drag.color.map(ColorSpec::from),
+            shift_drag_tool: self.shift_drag.tool,
+            shift_drag_color: self.shift_drag.color.map(ColorSpec::from),
+            ctrl_drag_tool: self.ctrl_drag.tool,
+            ctrl_drag_color: self.ctrl_drag.color.map(ColorSpec::from),
+            ctrl_shift_drag_tool: self.ctrl_shift_drag.tool,
+            ctrl_shift_drag_color: self.ctrl_shift_drag.color.map(ColorSpec::from),
+            tab_drag_tool: self.tab_drag.tool,
+            tab_drag_color: self.tab_drag.color.map(ColorSpec::from),
+        }
+    }
+}
+
+/// Tool mapping for drag gestures across mouse buttons.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DragToolBindings {
+    pub left: DragButtonBindings,
+    pub right: DragButtonBindings,
+    pub middle: DragButtonBindings,
+}
+
+impl Default for DragToolBindings {
+    fn default() -> Self {
+        Self {
+            left: DragButtonBindings::legacy_left(),
+            right: DragButtonBindings::button_default(),
+            middle: DragButtonBindings::button_default(),
+        }
+    }
+}
+
+impl DragToolBindings {
+    pub fn tool_for_modifier(self, modifier: DragModifier) -> Tool {
+        self.binding_for_button_modifier(MouseButton::Left, modifier)
+            .tool
+            .as_tool()
+            .unwrap_or(Tool::Select)
+    }
+
+    pub fn binding_for_button_modifier(
+        self,
+        button: MouseButton,
+        modifier: DragModifier,
+    ) -> DragBinding {
+        match button {
+            MouseButton::Left => self.left,
+            MouseButton::Right => self.right,
+            MouseButton::Middle => self.middle,
+        }
+        .binding_for_modifier(modifier)
+    }
+
+    pub fn from_config(config: &MouseDragToolsConfig) -> Self {
+        Self {
+            left: DragButtonBindings::from_config(&config.left),
+            right: DragButtonBindings::from_config(&config.right),
+            middle: DragButtonBindings::from_config(&config.middle),
+        }
+    }
+
+    pub fn to_config(self) -> MouseDragToolsConfig {
+        MouseDragToolsConfig::from_buttons(
+            self.left.to_config(),
+            self.right.to_config(),
+            self.middle.to_config(),
+        )
     }
 }
 

--- a/src/input/state/actions/action_core.rs
+++ b/src/input/state/actions/action_core.rs
@@ -46,6 +46,9 @@ impl InputState {
                         self.should_exit = true;
                     }
                 }
+                if matches!(self.state, DrawingState::Idle) {
+                    self.end_pointer_drag();
+                }
                 true
             }
             Action::EnterTextMode => {

--- a/src/input/state/actions/help_overlay.rs
+++ b/src/input/state/actions/help_overlay.rs
@@ -27,17 +27,14 @@ impl InputState {
                 self.toggle_help_overlay();
                 true
             }
-            Key::Backspace => {
-                if !self.help_overlay_search.is_empty() {
-                    self.help_overlay_search.pop();
-                    self.help_overlay_scroll = 0.0;
-                    self.dirty_tracker.mark_full();
-                    self.needs_redraw = true;
-                    true
-                } else {
-                    false
-                }
+            Key::Backspace if !self.help_overlay_search.is_empty() => {
+                self.help_overlay_search.pop();
+                self.help_overlay_scroll = 0.0;
+                self.dirty_tracker.mark_full();
+                self.needs_redraw = true;
+                true
             }
+            Key::Backspace => false,
             Key::Space => {
                 if search_active {
                     self.help_overlay_search.push(' ');
@@ -47,17 +44,14 @@ impl InputState {
                 }
                 true
             }
-            Key::Char(ch) => {
-                if !ch.is_control() {
-                    self.help_overlay_search.push(ch);
-                    self.help_overlay_scroll = 0.0;
-                    self.dirty_tracker.mark_full();
-                    self.needs_redraw = true;
-                    true
-                } else {
-                    false
-                }
+            Key::Char(ch) if !ch.is_control() => {
+                self.help_overlay_search.push(ch);
+                self.help_overlay_scroll = 0.0;
+                self.dirty_tracker.mark_full();
+                self.needs_redraw = true;
+                true
             }
+            Key::Char(_) => false,
             // Disable page navigation while search is active
             Key::Left | Key::Right | Key::PageUp | Key::PageDown | Key::Home | Key::End
                 if search_active =>
@@ -66,17 +60,14 @@ impl InputState {
             }
             Key::Left | Key::PageUp if !search_active => self.help_overlay_prev_page(),
             Key::Right | Key::PageDown if !search_active => self.help_overlay_next_page(),
-            Key::Home if !search_active => {
-                if self.help_overlay_page != 0 {
-                    self.help_overlay_page = 0;
-                    self.help_overlay_scroll = 0.0;
-                    self.dirty_tracker.mark_full();
-                    self.needs_redraw = true;
-                    true
-                } else {
-                    false
-                }
+            Key::Home if !search_active && self.help_overlay_page != 0 => {
+                self.help_overlay_page = 0;
+                self.help_overlay_scroll = 0.0;
+                self.dirty_tracker.mark_full();
+                self.needs_redraw = true;
+                true
             }
+            Key::Home if !search_active => false,
             Key::End if !search_active => {
                 // Use the max page constant; actual page count is computed during render
                 // and the page index will be clamped appropriately.

--- a/src/input/state/actions/key_press/mod.rs
+++ b/src/input/state/actions/key_press/mod.rs
@@ -128,6 +128,7 @@ impl InputState {
             && let Some(Action::Exit) = self.find_action("Escape")
         {
             self.state = DrawingState::Idle;
+            self.end_pointer_drag();
             self.needs_redraw = true;
             return;
         }

--- a/src/input/state/core/base/state/init.rs
+++ b/src/input/state/core/base/state/init.rs
@@ -93,6 +93,8 @@ impl InputState {
             step_marker_counter: 1,
             modifiers: Modifiers::new(),
             drag_tool_bindings: DragToolBindings::default(),
+            active_drag_button: None,
+            active_drag_color: None,
             state: DrawingState::Idle,
             should_exit: false,
             needs_redraw: true,

--- a/src/input/state/core/base/state/structs.rs
+++ b/src/input/state/core/base/state/structs.rs
@@ -27,6 +27,7 @@ use crate::input::BoardManager;
 use crate::input::boards::BoardState;
 use crate::input::state::highlight::ClickHighlightState;
 use crate::input::{
+    MouseButton,
     modifiers::{DragToolBindings, Modifiers},
     tool::{EraserMode, Tool},
 };
@@ -95,6 +96,10 @@ pub struct InputState {
     pub modifiers: Modifiers,
     /// Tool mapping for drag gestures with modifier keys
     pub drag_tool_bindings: DragToolBindings,
+    /// Mouse button that started the active pointer drag, if any.
+    pub(crate) active_drag_button: Option<MouseButton>,
+    /// Per-drag color override, if the current drag binding configured one.
+    pub(crate) active_drag_color: Option<Color>,
     /// Current drawing mode state machine
     pub state: DrawingState,
     /// Whether user requested to exit the overlay

--- a/src/input/state/core/base/types.rs
+++ b/src/input/state/core/base/types.rs
@@ -187,7 +187,7 @@ impl ToolbarDrawerTab {
 pub enum PresetAction {
     Save {
         slot: usize,
-        preset: ToolPresetConfig,
+        preset: Box<ToolPresetConfig>,
     },
     Clear {
         slot: usize,

--- a/src/input/state/core/index.rs
+++ b/src/input/state/core/index.rs
@@ -246,7 +246,7 @@ impl InputState {
                     .into_iter()
                     .filter_map(|id| index_map.get(&id).map(|&idx| (idx, id)))
                     .collect();
-                sorted_candidates.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+                sorted_candidates.sort_unstable_by_key(|candidate| std::cmp::Reverse(candidate.0));
 
                 for (_, id) in sorted_candidates {
                     if self.hit_test_by_id(id, x, y, tolerance) {

--- a/src/input/state/core/properties/apply_selection/actions/arrow.rs
+++ b/src/input/state/core/properties/apply_selection/actions/arrow.rs
@@ -27,13 +27,9 @@ impl InputState {
         let result = self.apply_selection_change(
             |shape| matches!(shape, Shape::Arrow { .. }),
             |shape| match shape {
-                Shape::Arrow { head_at_end, .. } => {
-                    if *head_at_end != target {
-                        *head_at_end = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::Arrow { head_at_end, .. } if *head_at_end != target => {
+                    *head_at_end = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/properties/apply_selection/actions/color.rs
+++ b/src/input/state/core/properties/apply_selection/actions/color.rs
@@ -30,13 +30,11 @@ impl InputState {
                 | Shape::Ellipse { color, .. }
                 | Shape::Arrow { color, .. }
                 | Shape::Text { color, .. }
-                | Shape::StepMarker { color, .. } => {
-                    if *color != target {
-                        *color = target;
-                        true
-                    } else {
-                        false
-                    }
+                | Shape::StepMarker { color, .. }
+                    if *color != target =>
+                {
+                    *color = target;
+                    true
                 }
                 Shape::MarkerStroke { color, .. } => {
                     let new_color = Color {
@@ -50,13 +48,9 @@ impl InputState {
                         false
                     }
                 }
-                Shape::StickyNote { background, .. } => {
-                    if *background != target {
-                        *background = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::StickyNote { background, .. } if *background != target => {
+                    *background = target;
+                    true
                 }
                 _ => false,
             },
@@ -99,13 +93,11 @@ impl InputState {
                 | Shape::Ellipse { color, .. }
                 | Shape::Arrow { color, .. }
                 | Shape::Text { color, .. }
-                | Shape::StepMarker { color, .. } => {
-                    if *color != target {
-                        *color = target;
-                        true
-                    } else {
-                        false
-                    }
+                | Shape::StepMarker { color, .. }
+                    if *color != target =>
+                {
+                    *color = target;
+                    true
                 }
                 Shape::MarkerStroke { color, .. } => {
                     let new_color = Color {
@@ -119,13 +111,9 @@ impl InputState {
                         false
                     }
                 }
-                Shape::StickyNote { background, .. } => {
-                    if *background != target {
-                        *background = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::StickyNote { background, .. } if *background != target => {
+                    *background = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/properties/apply_selection/actions/fill.rs
+++ b/src/input/state/core/properties/apply_selection/actions/fill.rs
@@ -23,13 +23,9 @@ impl InputState {
         let result = self.apply_selection_change(
             |shape| matches!(shape, Shape::Rect { .. } | Shape::Ellipse { .. }),
             |shape| match shape {
-                Shape::Rect { fill, .. } | Shape::Ellipse { fill, .. } => {
-                    if *fill != target {
-                        *fill = target;
-                        true
-                    } else {
-                        false
-                    }
+                Shape::Rect { fill, .. } | Shape::Ellipse { fill, .. } if *fill != target => {
+                    *fill = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/properties/apply_selection/actions/text.rs
+++ b/src/input/state/core/properties/apply_selection/actions/text.rs
@@ -54,13 +54,9 @@ impl InputState {
             |shape| match shape {
                 Shape::Text {
                     background_enabled, ..
-                } => {
-                    if *background_enabled != target {
-                        *background_enabled = target;
-                        true
-                    } else {
-                        false
-                    }
+                } if *background_enabled != target => {
+                    *background_enabled = target;
+                    true
                 }
                 _ => false,
             },

--- a/src/input/state/core/tool_controls/presets.rs
+++ b/src/input/state/core/tool_controls/presets.rs
@@ -108,6 +108,14 @@ impl InputState {
             self.needs_redraw = true;
             self.mark_session_dirty();
         }
+        if let Some(drag_tools) = preset.drag_tools.as_ref() {
+            let left_defaults = self.drag_tool_bindings.to_config().left;
+            let drag_tools = drag_tools
+                .clone()
+                .resolve_with_left_defaults(&left_defaults);
+            let _ = self
+                .set_drag_tool_bindings(crate::input::DragToolBindings::from_config(&drag_tools));
+        }
 
         self.active_preset_slot = Some(slot);
         self.set_preset_feedback(slot, PresetFeedbackKind::Apply);
@@ -235,6 +243,7 @@ impl InputState {
             arrow_angle: Some(self.arrow_angle),
             arrow_head_at_end: Some(self.arrow_head_at_end),
             show_status_bar: Some(self.show_status_bar),
+            drag_tools: Some(self.drag_tool_bindings.to_config()),
         }
     }
 }

--- a/src/input/state/core/tool_controls/presets.rs
+++ b/src/input/state/core/tool_controls/presets.rs
@@ -140,7 +140,10 @@ impl InputState {
             *slot_ref = Some(preset.clone());
         }
         self.set_preset_feedback(slot, PresetFeedbackKind::Save);
-        self.pending_preset_action = Some(super::super::base::PresetAction::Save { slot, preset });
+        self.pending_preset_action = Some(super::super::base::PresetAction::Save {
+            slot,
+            preset: Box::new(preset),
+        });
         self.dirty_tracker.mark_full();
         self.needs_redraw = true;
         true

--- a/src/input/state/core/tool_controls/settings.rs
+++ b/src/input/state/core/tool_controls/settings.rs
@@ -3,6 +3,7 @@ use super::super::base::{
 };
 use crate::draw::{Color, FontDescriptor};
 use crate::input::{
+    DragBinding, MouseButton,
     modifiers::DragToolBindings,
     tool::{EraserMode, Tool},
 };
@@ -37,6 +38,7 @@ impl InputState {
             DrawingState::Idle | DrawingState::TextInput { .. }
         ) {
             self.state = DrawingState::Idle;
+            self.end_pointer_drag();
         }
 
         self.dirty_tracker.mark_full();
@@ -72,6 +74,35 @@ impl InputState {
         self.dirty_tracker.mark_full();
         self.needs_redraw = true;
         true
+    }
+
+    pub fn drag_binding_for_button(&self, button: MouseButton) -> DragBinding {
+        self.drag_tool_bindings
+            .binding_for_button_modifier(button, self.modifiers.active_drag_modifier())
+    }
+
+    pub(crate) fn active_drag_color_or_current(&self) -> Color {
+        self.active_drag_color.unwrap_or(self.current_color)
+    }
+
+    pub(crate) fn marker_color_for(&self, color: Color) -> Color {
+        // Keep a minimum alpha so the marker remains visible even if a fully transparent color was set.
+        let alpha = (color.a * self.marker_opacity).clamp(0.05, 0.9);
+        Color { a: alpha, ..color }
+    }
+
+    pub(crate) fn begin_pointer_drag(&mut self, button: MouseButton, color: Option<Color>) {
+        self.active_drag_button = Some(button);
+        self.active_drag_color = color;
+    }
+
+    pub(crate) fn end_pointer_drag(&mut self) {
+        self.active_drag_button = None;
+        self.active_drag_color = None;
+    }
+
+    pub(crate) fn pointer_drag_button_matches(&self, button: MouseButton) -> bool {
+        self.active_drag_button == Some(button)
     }
 
     /// Sets thickness or eraser size depending on the active tool.

--- a/src/input/state/core/utility/interaction.rs
+++ b/src/input/state/core/utility/interaction.rs
@@ -170,6 +170,9 @@ impl InputState {
             }
             DrawingState::Idle => {}
         }
+        if matches!(self.state, DrawingState::Idle) {
+            self.end_pointer_drag();
+        }
     }
 
     /// Drains pending dirty rectangles for the current surface size.

--- a/src/input/state/mouse/press.rs
+++ b/src/input/state/mouse/press.rs
@@ -6,6 +6,14 @@ use std::sync::Arc;
 use super::super::core::MenuCommand;
 use super::super::{ContextMenuKind, DrawingState, InputState};
 
+#[derive(Clone, Copy)]
+struct PressCoords {
+    screen_x: i32,
+    screen_y: i32,
+    canvas_x: i32,
+    canvas_y: i32,
+}
+
 impl InputState {
     fn is_radial_menu_toggle_button(&self, button: MouseButton) -> bool {
         use crate::config::RadialMenuMouseBinding;
@@ -180,15 +188,13 @@ impl InputState {
 
         let binding = self.drag_binding_for_button(button);
         if let Some(tool) = self.tool_for_button_press(button, binding.tool) {
-            self.handle_tool_button_press(
-                button,
-                tool,
-                binding.color,
+            let coords = PressCoords {
                 screen_x,
                 screen_y,
                 canvas_x,
                 canvas_y,
-            );
+            };
+            self.handle_tool_button_press(button, tool, binding.color, coords);
             return;
         }
 
@@ -244,13 +250,12 @@ impl InputState {
             return Some(Tool::Highlight);
         }
 
-        if button == MouseButton::Left {
-            if let Some(override_tool) = self.tool_override()
-                && (matches!(override_tool, Tool::Highlight | Tool::Eraser)
-                    || !self.modifiers.active_drag_modifier().is_active())
-            {
-                return Some(self.active_tool());
-            }
+        if button == MouseButton::Left
+            && let Some(override_tool) = self.tool_override()
+            && (matches!(override_tool, Tool::Highlight | Tool::Eraser)
+                || !self.modifiers.active_drag_modifier().is_active())
+        {
+            return Some(self.active_tool());
         }
         configured_tool
     }
@@ -260,25 +265,27 @@ impl InputState {
         button: MouseButton,
         tool: Tool,
         color: Option<crate::draw::Color>,
-        screen_x: i32,
-        screen_y: i32,
-        canvas_x: i32,
-        canvas_y: i32,
+        coords: PressCoords,
     ) {
-        self.update_pointer_positions(screen_x, screen_y, canvas_x, canvas_y);
-        self.trigger_click_highlight(canvas_x, canvas_y);
+        self.update_pointer_positions(
+            coords.screen_x,
+            coords.screen_y,
+            coords.canvas_x,
+            coords.canvas_y,
+        );
+        self.trigger_click_highlight(coords.canvas_x, coords.canvas_y);
 
-        if self.handle_context_menu_press(screen_x, screen_y) {
+        if self.handle_context_menu_press(coords.screen_x, coords.screen_y) {
             return;
         }
 
         match &mut self.state {
             DrawingState::Idle => {
-                self.handle_idle_tool_click(button, tool, color, canvas_x, canvas_y)
+                self.handle_idle_tool_click(button, tool, color, coords.canvas_x, coords.canvas_y)
             }
             DrawingState::TextInput { x: tx, y: ty, .. } if button == MouseButton::Left => {
-                *tx = canvas_x;
-                *ty = canvas_y;
+                *tx = coords.canvas_x;
+                *ty = coords.canvas_y;
                 self.update_text_preview_dirty();
                 self.needs_redraw = true;
             }

--- a/src/input/state/mouse/press.rs
+++ b/src/input/state/mouse/press.rs
@@ -1,6 +1,6 @@
 use crate::draw::Shape;
 use crate::draw::frame::ShapeSnapshot;
-use crate::input::{Tool, events::MouseButton};
+use crate::input::{DragTool, Tool, events::MouseButton};
 use std::sync::Arc;
 
 use super::super::core::MenuCommand;
@@ -61,6 +61,7 @@ impl InputState {
                     self.needs_redraw = true;
                 }
             }
+            self.end_pointer_drag();
             return;
         }
         if self.zoom_active() {
@@ -168,7 +169,29 @@ impl InputState {
             return;
         }
 
+        if button == MouseButton::Left && self.is_context_menu_open() {
+            self.update_pointer_positions(screen_x, screen_y, canvas_x, canvas_y);
+            self.trigger_click_highlight(canvas_x, canvas_y);
+            self.handle_context_menu_press(screen_x, screen_y);
+            return;
+        }
+
         self.close_properties_panel();
+
+        let binding = self.drag_binding_for_button(button);
+        if let Some(tool) = self.tool_for_button_press(button, binding.tool) {
+            self.handle_tool_button_press(
+                button,
+                tool,
+                binding.color,
+                screen_x,
+                screen_y,
+                canvas_x,
+                canvas_y,
+            );
+            return;
+        }
+
         match button {
             MouseButton::Right => {
                 if self.should_toggle_radial_menu_from_mouse(MouseButton::Right) {
@@ -181,19 +204,12 @@ impl InputState {
                 self.update_pointer_positions(screen_x, screen_y, canvas_x, canvas_y);
                 self.trigger_click_highlight(canvas_x, canvas_y);
 
-                if self.is_context_menu_open() {
-                    self.last_text_click = None;
-                    if self.is_point_in_context_menu(screen_x, screen_y) {
-                        self.update_context_menu_hover_from_pointer(screen_x, screen_y);
-                    } else {
-                        self.close_context_menu();
-                        self.needs_redraw = true;
-                    }
+                if self.handle_context_menu_press(screen_x, screen_y) {
                     return;
                 }
 
                 match &mut self.state {
-                    DrawingState::Idle => self.handle_idle_left_click(canvas_x, canvas_y),
+                    DrawingState::Idle => {}
                     DrawingState::TextInput { x: tx, y: ty, .. } => {
                         *tx = canvas_x;
                         *ty = canvas_y;
@@ -216,8 +232,75 @@ impl InputState {
         }
     }
 
-    fn handle_idle_left_click(&mut self, x: i32, y: i32) {
-        let selection_click = self.modifiers.alt || self.active_tool() == Tool::Select;
+    fn tool_for_button_press(&self, button: MouseButton, binding_tool: DragTool) -> Option<Tool> {
+        let configured_tool = binding_tool.as_tool();
+        if configured_tool.is_some()
+            && self.presenter_mode
+            && matches!(
+                self.presenter_mode_config.tool_behavior,
+                crate::config::PresenterToolBehavior::ForceHighlightLocked
+            )
+        {
+            return Some(Tool::Highlight);
+        }
+
+        if button == MouseButton::Left {
+            if let Some(override_tool) = self.tool_override()
+                && (matches!(override_tool, Tool::Highlight | Tool::Eraser)
+                    || !self.modifiers.active_drag_modifier().is_active())
+            {
+                return Some(self.active_tool());
+            }
+        }
+        configured_tool
+    }
+
+    fn handle_tool_button_press(
+        &mut self,
+        button: MouseButton,
+        tool: Tool,
+        color: Option<crate::draw::Color>,
+        screen_x: i32,
+        screen_y: i32,
+        canvas_x: i32,
+        canvas_y: i32,
+    ) {
+        self.update_pointer_positions(screen_x, screen_y, canvas_x, canvas_y);
+        self.trigger_click_highlight(canvas_x, canvas_y);
+
+        if self.handle_context_menu_press(screen_x, screen_y) {
+            return;
+        }
+
+        match &mut self.state {
+            DrawingState::Idle => {
+                self.handle_idle_tool_click(button, tool, color, canvas_x, canvas_y)
+            }
+            DrawingState::TextInput { x: tx, y: ty, .. } if button == MouseButton::Left => {
+                *tx = canvas_x;
+                *ty = canvas_y;
+                self.update_text_preview_dirty();
+                self.needs_redraw = true;
+            }
+            DrawingState::TextInput { .. }
+            | DrawingState::Drawing { .. }
+            | DrawingState::MovingSelection { .. }
+            | DrawingState::Selecting { .. }
+            | DrawingState::PendingTextClick { .. }
+            | DrawingState::ResizingText { .. }
+            | DrawingState::ResizingSelection { .. } => {}
+        }
+    }
+
+    fn handle_idle_tool_click(
+        &mut self,
+        button: MouseButton,
+        tool: Tool,
+        color: Option<crate::draw::Color>,
+        x: i32,
+        y: i32,
+    ) {
+        let selection_click = self.modifiers.alt || tool == Tool::Select;
         let hit_id = self.hit_test_at(x, y);
 
         if let Some(shape_id) = self.hit_text_resize_handle(x, y) {
@@ -235,6 +318,7 @@ impl InputState {
                     _ => return,
                 };
                 self.last_text_click = None;
+                self.begin_pointer_drag(button, color);
                 self.state = DrawingState::ResizingText {
                     shape_id,
                     snapshot,
@@ -251,6 +335,7 @@ impl InputState {
             let snapshots = self.capture_resize_selection_snapshots();
             if !snapshots.is_empty() {
                 self.last_text_click = None;
+                self.begin_pointer_drag(button, color);
                 self.state = DrawingState::ResizingSelection {
                     handle,
                     original_bounds,
@@ -273,10 +358,11 @@ impl InputState {
                 })
                 .unwrap_or(false);
             if is_text {
+                self.begin_pointer_drag(button, color);
                 self.state = DrawingState::PendingTextClick {
                     x,
                     y,
-                    tool: self.active_tool(),
+                    tool,
                     shape_id: hit_id,
                 };
                 return;
@@ -296,6 +382,7 @@ impl InputState {
 
                 let snapshots = self.capture_movable_selection_snapshots();
                 if !snapshots.is_empty() {
+                    self.begin_pointer_drag(button, color);
                     self.state = DrawingState::MovingSelection {
                         last_x: x,
                         last_y: y,
@@ -305,6 +392,7 @@ impl InputState {
                     return;
                 }
             } else {
+                self.begin_pointer_drag(button, color);
                 self.state = DrawingState::Selecting {
                     start_x: x,
                     start_y: y,
@@ -317,11 +405,11 @@ impl InputState {
             }
         }
 
-        let tool = self.active_tool();
         if tool == Tool::Blur && !self.frozen_active() && !self.pending_frozen_toggle() {
             self.request_frozen_toggle();
         }
         if tool != Tool::Highlight && tool != Tool::Select {
+            self.begin_pointer_drag(button, color);
             self.state = DrawingState::Drawing {
                 tool,
                 start_x: x,
@@ -333,6 +421,21 @@ impl InputState {
             self.update_provisional_dirty(x, y);
             self.needs_redraw = true;
         }
+    }
+
+    fn handle_context_menu_press(&mut self, screen_x: i32, screen_y: i32) -> bool {
+        if !self.is_context_menu_open() {
+            return false;
+        }
+
+        self.last_text_click = None;
+        if self.is_point_in_context_menu(screen_x, screen_y) {
+            self.update_context_menu_hover_from_pointer(screen_x, screen_y);
+        } else {
+            self.close_context_menu();
+            self.needs_redraw = true;
+        }
+        true
     }
 
     fn handle_radial_menu_press(

--- a/src/input/state/mouse/release/drawing.rs
+++ b/src/input/state/mouse/release/drawing.rs
@@ -14,6 +14,7 @@ pub(super) struct DrawingRelease {
 }
 
 pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: DrawingRelease) {
+    let drawing_color = state.active_drag_color_or_current();
     let (start_x, start_y) = release.start;
     let (end_x, end_y) = release.end;
     let DrawingRelease {
@@ -57,12 +58,12 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
 
                 Shape::FreehandPressure {
                     points: points_with_pressure,
-                    color: state.current_color,
+                    color: drawing_color,
                 }
             } else {
                 Shape::Freehand {
                     points,
-                    color: state.current_color,
+                    color: drawing_color,
                     thick: state.current_thickness,
                 }
             }
@@ -72,7 +73,7 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
             y1: start_y,
             x2: end_x,
             y2: end_y,
-            color: state.current_color,
+            color: drawing_color,
             thick: state.current_thickness,
         },
         Tool::Rect => {
@@ -92,7 +93,7 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
                 w: width,
                 h: height,
                 fill: state.fill_enabled,
-                color: state.current_color,
+                color: drawing_color,
                 thick: state.current_thickness,
             }
         }
@@ -104,7 +105,7 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
                 rx,
                 ry,
                 fill: state.fill_enabled,
-                color: state.current_color,
+                color: drawing_color,
                 thick: state.current_thickness,
             }
         }
@@ -113,7 +114,7 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
             y1: start_y,
             x2: end_x,
             y2: end_y,
-            color: state.current_color,
+            color: drawing_color,
             thick: state.current_thickness,
             arrow_length: state.arrow_length,
             arrow_angle: state.arrow_angle,
@@ -141,13 +142,13 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
         }
         Tool::Marker => Shape::MarkerStroke {
             points,
-            color: state.marker_color(),
+            color: state.marker_color_for(drawing_color),
             thick: state.current_thickness,
         },
         Tool::StepMarker => Shape::StepMarker {
             x: end_x,
             y: end_y,
-            color: state.current_color,
+            color: drawing_color,
             label: step_label.unwrap_or_else(|| state.next_step_marker_label()),
         },
         Tool::Eraser => {

--- a/src/input/state/mouse/release/mod.rs
+++ b/src/input/state/mouse/release/mod.rs
@@ -56,7 +56,20 @@ impl InputState {
             }
         }
 
-        if button != MouseButton::Left {
+        if matches!(
+            self.state,
+            DrawingState::Drawing { .. }
+                | DrawingState::MovingSelection { .. }
+                | DrawingState::Selecting { .. }
+                | DrawingState::PendingTextClick { .. }
+                | DrawingState::ResizingText { .. }
+                | DrawingState::ResizingSelection { .. }
+        ) && !self.pointer_drag_button_matches(button)
+        {
+            return;
+        }
+
+        if button != MouseButton::Left && self.active_drag_button.is_none() {
             return;
         }
 
@@ -108,6 +121,9 @@ impl InputState {
             other_state => {
                 self.state = other_state;
             }
+        }
+        if matches!(self.state, DrawingState::Idle) {
+            self.end_pointer_drag();
         }
     }
 }

--- a/src/input/state/render.rs
+++ b/src/input/state/render.rs
@@ -21,6 +21,7 @@ impl InputState {
             ..
         } = &self.state
         {
+            let drawing_color = self.active_drag_color_or_current();
             match tool {
                 // Pen, Marker, Eraser are handled by render_provisional_shape() directly
                 // with borrowed rendering - never call this method for those tools.
@@ -30,7 +31,7 @@ impl InputState {
                     y1: *start_y,
                     x2: current_x,
                     y2: current_y,
-                    color: self.current_color,
+                    color: drawing_color,
                     thick: self.current_thickness,
                 }),
                 Tool::Rect => {
@@ -51,7 +52,7 @@ impl InputState {
                         w,
                         h,
                         fill: self.fill_enabled,
-                        color: self.current_color,
+                        color: drawing_color,
                         thick: self.current_thickness,
                     })
                 }
@@ -64,7 +65,7 @@ impl InputState {
                         rx,
                         ry,
                         fill: self.fill_enabled,
-                        color: self.current_color,
+                        color: drawing_color,
                         thick: self.current_thickness,
                     })
                 }
@@ -73,7 +74,7 @@ impl InputState {
                     y1: *start_y,
                     x2: current_x,
                     y2: current_y,
-                    color: self.current_color,
+                    color: drawing_color,
                     thick: self.current_thickness,
                     arrow_length: self.arrow_length,
                     arrow_angle: self.arrow_angle,
@@ -102,7 +103,7 @@ impl InputState {
                 Tool::StepMarker => Some(Shape::StepMarker {
                     x: current_x,
                     y: current_y,
-                    color: self.current_color,
+                    color: drawing_color,
                     label: self.next_step_marker_label(),
                 }),
             }
@@ -138,6 +139,7 @@ impl InputState {
                 point_thicknesses,
             } => match tool {
                 Tool::Pen => {
+                    let drawing_color = self.active_drag_color_or_current();
                     // Render freehand without cloning - just borrow the points
                     // Check if we have pressure data available for this stroke
                     let use_pressure =
@@ -150,13 +152,13 @@ impl InputState {
                             ctx,
                             points,
                             point_thicknesses,
-                            self.current_color,
+                            drawing_color,
                         );
                     } else {
                         render_freehand_borrowed(
                             ctx,
                             points,
-                            self.current_color,
+                            drawing_color,
                             self.current_thickness,
                         );
                     }
@@ -167,7 +169,7 @@ impl InputState {
                     render_marker_stroke_borrowed(
                         ctx,
                         points,
-                        self.marker_color(),
+                        self.marker_color_for(self.active_drag_color_or_current()),
                         self.current_thickness,
                     );
                     true
@@ -224,15 +226,6 @@ impl InputState {
                 true
             }
             _ => false,
-        }
-    }
-
-    pub(crate) fn marker_color(&self) -> Color {
-        // Keep a minimum alpha so the marker remains visible even if a fully transparent color was set.
-        let alpha = (self.current_color.a * self.marker_opacity).clamp(0.05, 0.9);
-        Color {
-            a: alpha,
-            ..self.current_color
         }
     }
 }

--- a/src/input/state/tests/basics.rs
+++ b/src/input/state/tests/basics.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::config::{DragButtonConfig, MouseDragToolsConfig};
+use crate::input::{DragBinding, DragTool, DragToolBindings};
 
 #[test]
 fn test_adjust_font_size_increase() {
@@ -29,6 +31,7 @@ fn apply_preset_updates_tool_and_settings() {
         arrow_angle: Some(45.0),
         arrow_head_at_end: Some(true),
         show_status_bar: Some(false),
+        drag_tools: None,
     });
 
     assert!(state.apply_preset(1));
@@ -48,6 +51,57 @@ fn apply_preset_updates_tool_and_settings() {
     assert_eq!(state.eraser_kind, EraserKind::Rect);
     assert_eq!(state.eraser_mode, EraserMode::Stroke);
     assert!(!state.show_status_bar);
+}
+
+#[test]
+fn apply_preset_merges_partial_left_drag_tool_bindings() {
+    let mut state = create_test_input_state();
+    state.preset_slot_count = 3;
+
+    let mut existing_bindings = DragToolBindings::default();
+    existing_bindings.left.shift_drag = DragBinding::from_tool(Tool::Eraser);
+    assert!(state.set_drag_tool_bindings(existing_bindings));
+
+    let mut left = DragButtonConfig::button_behavior();
+    left.drag_tool = DragTool::Marker;
+
+    state.presets[0] = Some(ToolPresetConfig {
+        name: None,
+        tool: Tool::Marker,
+        color: ColorSpec::Name("blue".to_string()),
+        size: 12.0,
+        eraser_kind: None,
+        eraser_mode: None,
+        marker_opacity: None,
+        fill_enabled: None,
+        font_size: None,
+        text_background_enabled: None,
+        arrow_length: None,
+        arrow_angle: None,
+        arrow_head_at_end: None,
+        show_status_bar: None,
+        drag_tools: Some(MouseDragToolsConfig::from_buttons(
+            left,
+            DragButtonConfig::button_behavior(),
+            DragButtonConfig::button_behavior(),
+        )),
+    });
+
+    assert!(state.apply_preset(1));
+    assert_eq!(state.drag_tool_bindings.left.drag.tool, DragTool::Marker);
+    assert_eq!(
+        state.drag_tool_bindings.left.shift_drag.tool,
+        DragTool::Eraser
+    );
+    assert_eq!(state.drag_tool_bindings.left.ctrl_drag.tool, DragTool::Rect);
+    assert_eq!(
+        state.drag_tool_bindings.left.ctrl_shift_drag.tool,
+        DragTool::Arrow
+    );
+    assert_eq!(
+        state.drag_tool_bindings.left.tab_drag.tool,
+        DragTool::Ellipse
+    );
 }
 
 #[test]

--- a/src/input/state/tests/drawing.rs
+++ b/src/input/state/tests/drawing.rs
@@ -1,5 +1,25 @@
 use super::*;
-use crate::input::DragToolBindings;
+use crate::input::{DragBinding, DragButtonBindings, DragToolBindings};
+
+fn left_drag_bindings(
+    drag: Tool,
+    shift_drag: Tool,
+    ctrl_drag: Tool,
+    ctrl_shift_drag: Tool,
+    tab_drag: Tool,
+) -> DragToolBindings {
+    DragToolBindings {
+        left: DragButtonBindings {
+            drag: DragBinding::from_tool(drag),
+            shift_drag: DragBinding::from_tool(shift_drag),
+            ctrl_drag: DragBinding::from_tool(ctrl_drag),
+            ctrl_shift_drag: DragBinding::from_tool(ctrl_shift_drag),
+            tab_drag: DragBinding::from_tool(tab_drag),
+        },
+        right: DragButtonBindings::button_default(),
+        middle: DragButtonBindings::button_default(),
+    }
+}
 
 #[test]
 fn mouse_drag_creates_shapes_for_each_tool() {
@@ -47,13 +67,13 @@ fn mouse_drag_creates_shapes_for_each_tool() {
 #[test]
 fn custom_drag_bindings_remap_default_and_modifier_tools() {
     let mut state = create_test_input_state();
-    assert!(state.set_drag_tool_bindings(DragToolBindings {
-        drag: Tool::Arrow,
-        shift_drag: Tool::Eraser,
-        ctrl_drag: Tool::Pen,
-        ctrl_shift_drag: Tool::Rect,
-        tab_drag: Tool::Ellipse,
-    }));
+    assert!(state.set_drag_tool_bindings(left_drag_bindings(
+        Tool::Arrow,
+        Tool::Eraser,
+        Tool::Pen,
+        Tool::Rect,
+        Tool::Ellipse,
+    )));
 
     assert_eq!(state.active_tool(), Tool::Arrow);
     assert!(state.set_tool_override(Some(Tool::Arrow)));
@@ -73,13 +93,13 @@ fn custom_drag_bindings_remap_default_and_modifier_tools() {
 #[test]
 fn blur_drag_requests_frozen_capture_on_press() {
     let mut state = create_test_input_state();
-    assert!(state.set_drag_tool_bindings(DragToolBindings {
-        drag: Tool::Blur,
-        shift_drag: Tool::Line,
-        ctrl_drag: Tool::Rect,
-        ctrl_shift_drag: Tool::Arrow,
-        tab_drag: Tool::Ellipse,
-    }));
+    assert!(state.set_drag_tool_bindings(left_drag_bindings(
+        Tool::Blur,
+        Tool::Line,
+        Tool::Rect,
+        Tool::Arrow,
+        Tool::Ellipse,
+    )));
 
     state.on_mouse_press(MouseButton::Left, 12, 14);
 
@@ -96,13 +116,13 @@ fn blur_drag_requests_frozen_capture_on_press() {
 #[test]
 fn drag_mapped_highlight_reports_highlight_active() {
     let mut state = create_test_input_state();
-    assert!(state.set_drag_tool_bindings(DragToolBindings {
-        drag: Tool::Highlight,
-        shift_drag: Tool::Line,
-        ctrl_drag: Tool::Rect,
-        ctrl_shift_drag: Tool::Arrow,
-        tab_drag: Tool::Ellipse,
-    }));
+    assert!(state.set_drag_tool_bindings(left_drag_bindings(
+        Tool::Highlight,
+        Tool::Line,
+        Tool::Rect,
+        Tool::Arrow,
+        Tool::Ellipse,
+    )));
 
     assert_eq!(state.active_tool(), Tool::Highlight);
     assert!(state.highlight_tool_active());
@@ -110,6 +130,72 @@ fn drag_mapped_highlight_reports_highlight_active() {
     state.modifiers.shift = true;
     assert_eq!(state.active_tool(), Tool::Line);
     assert!(!state.highlight_tool_active());
+}
+
+#[test]
+fn right_button_drag_uses_configured_tool() {
+    let mut state = create_test_input_state();
+    let mut bindings = DragToolBindings::default();
+    bindings.right.drag = DragBinding::from_tool(Tool::Line);
+    assert!(state.set_drag_tool_bindings(bindings));
+
+    state.on_mouse_press(MouseButton::Right, 10, 20);
+    assert!(matches!(
+        state.state,
+        DrawingState::Drawing {
+            tool: Tool::Line,
+            ..
+        }
+    ));
+    state.on_mouse_release(MouseButton::Right, 30, 40);
+
+    assert_eq!(state.boards.active_frame().shapes.len(), 1);
+    assert!(matches!(
+        state.boards.active_frame().shapes[0].shape,
+        Shape::Line { .. }
+    ));
+}
+
+#[test]
+fn configured_non_left_drag_closes_context_menu_before_drawing() {
+    let mut state = create_test_input_state();
+    let mut bindings = DragToolBindings::default();
+    bindings.right.drag = DragBinding::from_tool(Tool::Pen);
+    assert!(state.set_drag_tool_bindings(bindings));
+    state.open_context_menu((0, 0), Vec::new(), ContextMenuKind::Canvas, None);
+
+    state.on_mouse_press(MouseButton::Right, 300, 300);
+    state.on_mouse_motion(320, 320);
+    state.on_mouse_release(MouseButton::Right, 320, 320);
+
+    assert!(!state.is_context_menu_open());
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.boards.active_frame().shapes.is_empty());
+}
+
+#[test]
+fn drag_binding_color_overrides_stroke_without_changing_current_color() {
+    let mut state = create_test_input_state();
+    let original_color = state.current_color;
+    let blue = Color {
+        r: 0.0,
+        g: 0.0,
+        b: 1.0,
+        a: 1.0,
+    };
+    let mut bindings = DragToolBindings::default();
+    bindings.right.drag = DragBinding::new(crate::input::DragTool::Pen, Some(blue));
+    assert!(state.set_drag_tool_bindings(bindings));
+
+    state.on_mouse_press(MouseButton::Right, 0, 0);
+    state.on_mouse_motion(10, 10);
+    state.on_mouse_release(MouseButton::Right, 10, 10);
+
+    assert_eq!(state.current_color, original_color);
+    match &state.boards.active_frame().shapes[0].shape {
+        Shape::Freehand { color, .. } => assert_eq!(*color, blue),
+        other => panic!("expected freehand shape, got {other:?}"),
+    }
 }
 
 #[test]

--- a/src/input/state/tests/presenter_mode.rs
+++ b/src/input/state/tests/presenter_mode.rs
@@ -1,6 +1,6 @@
 use super::create_test_input_state;
-use crate::config::{ColorSpec, ToolPresetConfig};
-use crate::input::Tool;
+use crate::config::{ColorSpec, PresenterToolBehavior, ToolPresetConfig};
+use crate::input::{DragBinding, DragToolBindings, MouseButton, Tool};
 use crate::ui::toolbar::ToolbarEvent;
 
 #[test]
@@ -37,6 +37,7 @@ fn presenter_mode_blocks_preset_status_bar_toggle() {
         arrow_angle: None,
         arrow_head_at_end: None,
         show_status_bar: Some(true),
+        drag_tools: None,
     };
     state.presets[0] = Some(preset);
 
@@ -69,6 +70,23 @@ fn presenter_mode_closes_help_overlay_and_switches_to_highlight_tool() {
 
     assert!(state.presenter_mode);
     assert!(!state.show_help);
+    assert_eq!(state.tool_override(), Some(Tool::Highlight));
+}
+
+#[test]
+fn presenter_locked_mode_blocks_non_left_drag_bindings() {
+    let mut state = create_test_input_state();
+    let mut bindings = DragToolBindings::default();
+    bindings.right.drag = DragBinding::from_tool(Tool::Pen);
+    assert!(state.set_drag_tool_bindings(bindings));
+    state.presenter_mode_config.tool_behavior = PresenterToolBehavior::ForceHighlightLocked;
+
+    state.toggle_presenter_mode();
+    state.on_mouse_press(MouseButton::Right, 0, 0);
+    state.on_mouse_motion(10, 10);
+    state.on_mouse_release(MouseButton::Right, 10, 10);
+
+    assert!(state.boards.active_frame().shapes.is_empty());
     assert_eq!(state.tool_override(), Some(Tool::Highlight));
 }
 

--- a/src/input/tool.rs
+++ b/src/input/tool.rs
@@ -35,6 +35,74 @@ pub enum Tool {
     // Note: Text mode uses DrawingState::TextInput instead of Tool::Text
 }
 
+/// Tool/action selected by a drag binding.
+///
+/// `Default` preserves a mouse button's built-in behavior, such as right-click
+/// context menus or middle-click radial menu toggles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum DragTool {
+    /// Preserve the button's built-in behavior.
+    Default,
+    /// Select/cursor tool.
+    Select,
+    /// Freehand drawing.
+    Pen,
+    /// Straight line.
+    Line,
+    /// Rectangle outline.
+    Rect,
+    /// Ellipse/circle outline.
+    Ellipse,
+    /// Arrow with directional head.
+    Arrow,
+    /// Privacy blur rectangle.
+    Blur,
+    /// Semi-transparent marker stroke.
+    Marker,
+    /// Highlight-only tool.
+    Highlight,
+    /// Numbered step marker tool.
+    StepMarker,
+    /// Eraser brush.
+    Eraser,
+}
+
+impl DragTool {
+    pub fn from_tool(tool: Tool) -> Self {
+        match tool {
+            Tool::Select => Self::Select,
+            Tool::Pen => Self::Pen,
+            Tool::Line => Self::Line,
+            Tool::Rect => Self::Rect,
+            Tool::Ellipse => Self::Ellipse,
+            Tool::Arrow => Self::Arrow,
+            Tool::Blur => Self::Blur,
+            Tool::Marker => Self::Marker,
+            Tool::Highlight => Self::Highlight,
+            Tool::StepMarker => Self::StepMarker,
+            Tool::Eraser => Self::Eraser,
+        }
+    }
+
+    pub fn as_tool(self) -> Option<Tool> {
+        match self {
+            Self::Default => None,
+            Self::Select => Some(Tool::Select),
+            Self::Pen => Some(Tool::Pen),
+            Self::Line => Some(Tool::Line),
+            Self::Rect => Some(Tool::Rect),
+            Self::Ellipse => Some(Tool::Ellipse),
+            Self::Arrow => Some(Tool::Arrow),
+            Self::Blur => Some(Tool::Blur),
+            Self::Marker => Some(Tool::Marker),
+            Self::Highlight => Some(Tool::Highlight),
+            Self::StepMarker => Some(Tool::StepMarker),
+            Self::Eraser => Some(Tool::Eraser),
+        }
+    }
+}
+
 /// Eraser behavior mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "kebab-case")]


### PR DESCRIPTION
## Summary
- allow drag tools to be configured per mouse button
- preserve existing left-button defaults and legacy drag tool behavior
- add configurator and validation support for the new bindings

Fixes #179