### PR TITLE
Stop runtime drawing changes from rewriting config

### DIFF
--- a/src/backend/wayland/handlers/keyboard/mod.rs
+++ b/src/backend/wayland/handlers/keyboard/mod.rs
@@ -290,15 +290,6 @@ impl WaylandState {
     fn apply_input_key(&mut self, key: Key) {
         #[cfg(tablet)]
         let prev_thickness = self.input_state.current_thickness;
-        let prefs_before = (
-            self.input_state.current_color,
-            self.input_state.current_thickness,
-            self.input_state.eraser_mode,
-            self.input_state.marker_opacity,
-            self.input_state.current_font_size,
-            self.input_state.font_descriptor.clone(),
-            self.input_state.fill_enabled,
-        );
         let highlight_before = (
             self.input_state.click_highlight_enabled(),
             self.input_state.highlight_tool_ring_enabled(),
@@ -306,16 +297,6 @@ impl WaylandState {
         );
         self.input_state.on_key_press(key);
         self.input_state.needs_redraw = true;
-        let prefs_changed = prefs_before.0 != self.input_state.current_color
-            || (prefs_before.1 - self.input_state.current_thickness).abs() > f64::EPSILON
-            || prefs_before.2 != self.input_state.eraser_mode
-            || (prefs_before.3 - self.input_state.marker_opacity).abs() > f64::EPSILON
-            || (prefs_before.4 - self.input_state.current_font_size).abs() > f64::EPSILON
-            || prefs_before.5 != self.input_state.font_descriptor
-            || prefs_before.6 != self.input_state.fill_enabled;
-        if prefs_changed {
-            self.save_drawing_preferences();
-        }
         let highlight_after = (
             self.input_state.click_highlight_enabled(),
             self.input_state.highlight_tool_ring_enabled(),

--- a/src/backend/wayland/handlers/pointer/axis.rs
+++ b/src/backend/wayland/handlers/pointer/axis.rs
@@ -100,26 +100,18 @@ impl WaylandState {
 
         match scroll_direction.cmp(&0) {
             std::cmp::Ordering::Greater if self.input_state.modifiers.shift => {
-                let prev_font_size = self.input_state.current_font_size;
                 self.input_state.adjust_font_size(-2.0);
                 debug!(
                     "Font size decreased: {:.1}px",
                     self.input_state.current_font_size
                 );
-                if (self.input_state.current_font_size - prev_font_size).abs() > f64::EPSILON {
-                    self.save_drawing_preferences();
-                }
             }
             std::cmp::Ordering::Less if self.input_state.modifiers.shift => {
-                let prev_font_size = self.input_state.current_font_size;
                 self.input_state.adjust_font_size(2.0);
                 debug!(
                     "Font size increased: {:.1}px",
                     self.input_state.current_font_size
                 );
-                if (self.input_state.current_font_size - prev_font_size).abs() > f64::EPSILON {
-                    self.save_drawing_preferences();
-                }
             }
             std::cmp::Ordering::Greater | std::cmp::Ordering::Less => {
                 let delta = if scroll_direction > 0 { -1.0 } else { 1.0 };
@@ -154,7 +146,6 @@ impl WaylandState {
                     "Thickness adjusted: {:.0}px",
                     self.input_state.current_thickness
                 );
-                self.save_drawing_preferences();
             }
         }
 

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -49,7 +49,7 @@ use crate::{
         file::{FileSaveConfig, expand_tilde},
         types::CaptureType,
     },
-    config::{Action, ColorSpec, Config},
+    config::{Action, Config},
     input::{DrawingState, EraserMode, InputState, Tool, ZoomAction},
     session::SessionOptions,
     ui::toolbar::{ToolbarBindingHints, ToolbarEvent, ToolbarSnapshot},

--- a/src/backend/wayland/state/color_picker.rs
+++ b/src/backend/wayland/state/color_picker.rs
@@ -106,7 +106,6 @@ impl WaylandState {
             let hex = color_to_hex(color);
             self.input_state
                 .set_ui_toast(UiToastKind::Info, format!("Pasted {}", hex));
-            self.save_drawing_preferences();
         } else {
             self.input_state.set_ui_toast(
                 UiToastKind::Warning,

--- a/src/backend/wayland/state/toolbar/events.rs
+++ b/src/backend/wayland/state/toolbar/events.rs
@@ -1,5 +1,36 @@
 use super::*;
 
+fn toolbar_event_saves_config(event: &ToolbarEvent) -> bool {
+    matches!(
+        event,
+        ToolbarEvent::PinTopToolbar(_)
+            | ToolbarEvent::PinSideToolbar(_)
+            | ToolbarEvent::ToggleIconMode(_)
+            | ToolbarEvent::ToggleMoreColors(_)
+            | ToolbarEvent::ToggleActionsSection(_)
+            | ToolbarEvent::ToggleActionsAdvanced(_)
+            | ToolbarEvent::ToggleZoomActions(_)
+            | ToolbarEvent::TogglePagesSection(_)
+            | ToolbarEvent::ToggleBoardsSection(_)
+            | ToolbarEvent::TogglePresets(_)
+            | ToolbarEvent::ToggleStepSection(_)
+            | ToolbarEvent::ToggleTextControls(_)
+            | ToolbarEvent::ToggleContextAwareUi(_)
+            | ToolbarEvent::TogglePresetToasts(_)
+            | ToolbarEvent::ToggleToolPreview(_)
+            | ToolbarEvent::ToggleDelaySliders(_)
+            | ToolbarEvent::ToggleCustomSection(_)
+            | ToolbarEvent::SetToolbarLayoutMode(_)
+    )
+}
+
+fn toolbar_event_saves_click_highlight_config(event: &ToolbarEvent) -> bool {
+    matches!(
+        event,
+        ToolbarEvent::ToggleAllHighlight(_) | ToolbarEvent::ToggleHighlightToolRing(_)
+    )
+}
+
 impl WaylandState {
     /// Returns a snapshot of the current input state for toolbar UI consumption.
     pub(in crate::backend::wayland) fn toolbar_snapshot(&self) -> ToolbarSnapshot {
@@ -65,44 +96,8 @@ impl WaylandState {
             ToolbarEvent::SetThickness(_) | ToolbarEvent::NudgeThickness(_)
         );
 
-        // Check if this is a toolbar config event that needs saving
-        let needs_config_save = matches!(
-            event,
-            ToolbarEvent::PinTopToolbar(_)
-                | ToolbarEvent::PinSideToolbar(_)
-                | ToolbarEvent::ToggleIconMode(_)
-                | ToolbarEvent::ToggleMoreColors(_)
-                | ToolbarEvent::ToggleActionsSection(_)
-                | ToolbarEvent::ToggleActionsAdvanced(_)
-                | ToolbarEvent::ToggleZoomActions(_)
-                | ToolbarEvent::TogglePagesSection(_)
-                | ToolbarEvent::ToggleBoardsSection(_)
-                | ToolbarEvent::TogglePresets(_)
-                | ToolbarEvent::ToggleStepSection(_)
-                | ToolbarEvent::ToggleTextControls(_)
-                | ToolbarEvent::ToggleContextAwareUi(_)
-                | ToolbarEvent::TogglePresetToasts(_)
-                | ToolbarEvent::ToggleToolPreview(_)
-                | ToolbarEvent::ToggleDelaySliders(_)
-                | ToolbarEvent::ToggleCustomSection(_)
-                | ToolbarEvent::SetToolbarLayoutMode(_)
-        );
-
-        let persist_drawing = matches!(
-            event,
-            ToolbarEvent::SetColor(_)
-                | ToolbarEvent::SetThickness(_)
-                | ToolbarEvent::SetMarkerOpacity(_)
-                | ToolbarEvent::SetEraserMode(_)
-                | ToolbarEvent::SetFont(_)
-                | ToolbarEvent::SetFontSize(_)
-                | ToolbarEvent::ToggleFill(_)
-                | ToolbarEvent::ApplyPreset(_)
-        );
-        let persist_click_highlight = matches!(
-            event,
-            ToolbarEvent::ToggleAllHighlight(_) | ToolbarEvent::ToggleHighlightToolRing(_)
-        );
+        let needs_config_save = toolbar_event_saves_config(&event);
+        let persist_click_highlight = toolbar_event_saves_click_highlight_config(&event);
 
         if self.input_state.apply_toolbar_event(event) {
             self.toolbar.mark_dirty();
@@ -121,10 +116,6 @@ impl WaylandState {
             // Save config when pin state changes
             if needs_config_save {
                 self.save_toolbar_pin_config();
-            }
-
-            if persist_drawing {
-                self.save_drawing_preferences();
             }
 
             if persist_click_highlight {
@@ -188,6 +179,7 @@ impl WaylandState {
         self.config.ui.toolbar.show_marker_opacity_section =
             self.input_state.show_marker_opacity_section;
         self.config.ui.toolbar.show_preset_toasts = self.input_state.show_preset_toasts;
+        self.config.ui.toolbar.show_tool_preview = self.input_state.show_tool_preview;
         self.config.ui.toolbar.top_offset = self.data.toolbar_top_offset;
         self.config.ui.toolbar.top_offset_y = self.data.toolbar_top_offset_y;
         self.config.ui.toolbar.side_offset = self.data.toolbar_side_offset;
@@ -199,24 +191,6 @@ impl WaylandState {
             log::warn!("Failed to save toolbar config: {}", err);
         } else {
             log::debug!("Saved toolbar config");
-        }
-    }
-
-    pub(in crate::backend::wayland) fn save_drawing_preferences(&mut self) {
-        self.config.drawing.default_color =
-            ColorSpec::from(self.input_state.color_for_tool(crate::input::Tool::Pen));
-        self.config.drawing.default_thickness =
-            self.input_state.thickness_for_tool(crate::input::Tool::Pen);
-        self.config.drawing.default_eraser_mode = self.input_state.eraser_mode;
-        self.config.drawing.default_fill_enabled = self.input_state.fill_enabled;
-        self.config.drawing.default_font_size = self.input_state.current_font_size;
-        self.config.drawing.font_family = self.input_state.font_descriptor.family.clone();
-        self.config.drawing.font_weight = self.input_state.font_descriptor.weight.clone();
-        self.config.drawing.font_style = self.input_state.font_descriptor.style.clone();
-        self.config.drawing.marker_opacity = self.input_state.marker_opacity;
-
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to persist drawing preferences: {}", err);
         }
     }
 
@@ -253,6 +227,105 @@ impl WaylandState {
                     log::warn!("Failed to clear preset slot {}: {}", slot, err);
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ToolbarLayoutMode;
+    use crate::draw::{Color, FontDescriptor};
+    use crate::input::{EraserMode, Tool};
+
+    #[test]
+    fn runtime_toolbar_events_do_not_save_static_config() {
+        let events = vec![
+            ToolbarEvent::SelectTool(Tool::Line),
+            ToolbarEvent::SetColor(Color {
+                r: 0.1,
+                g: 0.2,
+                b: 0.3,
+                a: 1.0,
+            }),
+            ToolbarEvent::SetThickness(8.0),
+            ToolbarEvent::NudgeThickness(1.0),
+            ToolbarEvent::SetMarkerOpacity(0.5),
+            ToolbarEvent::NudgeMarkerOpacity(0.1),
+            ToolbarEvent::SetEraserMode(EraserMode::Stroke),
+            ToolbarEvent::SetFont(FontDescriptor::new(
+                "Monospace".to_string(),
+                "normal".to_string(),
+                "italic".to_string(),
+            )),
+            ToolbarEvent::SetFontSize(44.0),
+            ToolbarEvent::ToggleFill(true),
+            ToolbarEvent::ApplyPreset(1),
+        ];
+
+        for event in events {
+            assert!(
+                !toolbar_event_saves_config(&event),
+                "{event:?} should not save toolbar config"
+            );
+            assert!(
+                !toolbar_event_saves_click_highlight_config(&event),
+                "{event:?} should not save click-highlight config"
+            );
+        }
+    }
+
+    #[test]
+    fn toolbar_preference_events_save_static_config() {
+        let events = vec![
+            ToolbarEvent::PinTopToolbar(true),
+            ToolbarEvent::PinSideToolbar(true),
+            ToolbarEvent::ToggleIconMode(true),
+            ToolbarEvent::ToggleMoreColors(true),
+            ToolbarEvent::ToggleActionsSection(true),
+            ToolbarEvent::ToggleActionsAdvanced(true),
+            ToolbarEvent::ToggleZoomActions(true),
+            ToolbarEvent::TogglePagesSection(true),
+            ToolbarEvent::ToggleBoardsSection(true),
+            ToolbarEvent::TogglePresets(true),
+            ToolbarEvent::ToggleStepSection(true),
+            ToolbarEvent::ToggleTextControls(true),
+            ToolbarEvent::ToggleContextAwareUi(true),
+            ToolbarEvent::TogglePresetToasts(true),
+            ToolbarEvent::ToggleToolPreview(true),
+            ToolbarEvent::ToggleDelaySliders(true),
+            ToolbarEvent::ToggleCustomSection(true),
+            ToolbarEvent::SetToolbarLayoutMode(ToolbarLayoutMode::Advanced),
+        ];
+
+        for event in events {
+            assert!(
+                toolbar_event_saves_config(&event),
+                "{event:?} should save toolbar config"
+            );
+            assert!(
+                !toolbar_event_saves_click_highlight_config(&event),
+                "{event:?} should not save click-highlight config"
+            );
+        }
+    }
+
+    #[test]
+    fn click_highlight_toolbar_events_are_explicit_config_exceptions() {
+        let events = vec![
+            ToolbarEvent::ToggleAllHighlight(true),
+            ToolbarEvent::ToggleHighlightToolRing(true),
+        ];
+
+        for event in events {
+            assert!(
+                !toolbar_event_saves_config(&event),
+                "{event:?} should not save toolbar config"
+            );
+            assert!(
+                toolbar_event_saves_click_highlight_config(&event),
+                "{event:?} should save click-highlight config"
+            );
         }
     }
 }

--- a/src/backend/wayland/state/toolbar/events.rs
+++ b/src/backend/wayland/state/toolbar/events.rs
@@ -31,6 +31,10 @@ fn toolbar_event_saves_click_highlight_config(event: &ToolbarEvent) -> bool {
     )
 }
 
+fn persisted_tool_preview_value(current: bool, presenter_restore: Option<bool>) -> bool {
+    presenter_restore.unwrap_or(current)
+}
+
 impl WaylandState {
     /// Returns a snapshot of the current input state for toolbar UI consumption.
     pub(in crate::backend::wayland) fn toolbar_snapshot(&self) -> ToolbarSnapshot {
@@ -179,7 +183,13 @@ impl WaylandState {
         self.config.ui.toolbar.show_marker_opacity_section =
             self.input_state.show_marker_opacity_section;
         self.config.ui.toolbar.show_preset_toasts = self.input_state.show_preset_toasts;
-        self.config.ui.toolbar.show_tool_preview = self.input_state.show_tool_preview;
+        self.config.ui.toolbar.show_tool_preview = persisted_tool_preview_value(
+            self.input_state.show_tool_preview,
+            self.input_state
+                .presenter_restore
+                .as_ref()
+                .and_then(|restore| restore.show_tool_preview),
+        );
         self.config.ui.toolbar.top_offset = self.data.toolbar_top_offset;
         self.config.ui.toolbar.top_offset_y = self.data.toolbar_top_offset_y;
         self.config.ui.toolbar.side_offset = self.data.toolbar_side_offset;
@@ -327,5 +337,13 @@ mod tests {
                 "{event:?} should save click-highlight config"
             );
         }
+    }
+
+    #[test]
+    fn tool_preview_config_preserves_presenter_mode_restore_value() {
+        assert!(persisted_tool_preview_value(false, Some(true)));
+        assert!(!persisted_tool_preview_value(false, Some(false)));
+        assert!(persisted_tool_preview_value(true, None));
+        assert!(!persisted_tool_preview_value(false, None));
     }
 }

--- a/src/input/state/tests/tool_controls.rs
+++ b/src/input/state/tests/tool_controls.rs
@@ -769,6 +769,29 @@ fn set_font_size_clamps_and_reports_noop_after_reaching_target() {
 }
 
 #[test]
+fn set_font_descriptor_marks_session_dirty_and_reports_noop_when_unchanged() {
+    let mut state = create_test_input_state();
+    let font = FontDescriptor::new(
+        "Monospace".to_string(),
+        "normal".to_string(),
+        "italic".to_string(),
+    );
+    state.needs_redraw = false;
+    state.session_dirty = false;
+
+    assert!(state.set_font_descriptor(font.clone()));
+    assert_eq!(state.font_descriptor, font);
+    assert!(state.needs_redraw);
+    assert!(state.session_dirty);
+
+    state.needs_redraw = false;
+    state.session_dirty = false;
+    assert!(!state.set_font_descriptor(font));
+    assert!(!state.needs_redraw);
+    assert!(!state.session_dirty);
+}
+
+#[test]
 fn set_marker_opacity_clamps_and_reports_noop_after_reaching_target() {
     let mut state = create_test_input_state();
     state.needs_redraw = false;

--- a/src/session/snapshot/apply.rs
+++ b/src/session/snapshot/apply.rs
@@ -80,6 +80,9 @@ pub fn apply_snapshot(input: &mut InputState, snapshot: SessionSnapshot, options
                 let _ = input.set_fill_enabled(fill_enabled);
             }
             let _ = input.set_tool_override(tool_state.tool_override);
+            if let Some(font_descriptor) = tool_state.font_descriptor {
+                let _ = input.set_font_descriptor(font_descriptor);
+            }
             let _ = input.set_font_size(tool_state.current_font_size.clamp(8.0, 72.0));
             input.text_background_enabled = tool_state.text_background_enabled;
             input.arrow_length = tool_state.arrow_length.clamp(5.0, 50.0);

--- a/src/session/snapshot/types.rs
+++ b/src/session/snapshot/types.rs
@@ -1,4 +1,4 @@
-use crate::draw::{Color, EraserKind, Frame};
+use crate::draw::{Color, EraserKind, FontDescriptor, Frame};
 use crate::input::{EraserMode, InputState, PerToolDrawingSettings, Tool};
 use serde::{Deserialize, Serialize};
 
@@ -59,6 +59,8 @@ pub struct ToolStateSnapshot {
     #[serde(default)]
     pub tool_override: Option<Tool>,
     pub current_font_size: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_descriptor: Option<FontDescriptor>,
     pub text_background_enabled: bool,
     pub arrow_length: f64,
     pub arrow_angle: f64,
@@ -84,6 +86,7 @@ impl ToolStateSnapshot {
             fill_enabled: Some(input.fill_enabled),
             tool_override: input.tool_override(),
             current_font_size: input.current_font_size,
+            font_descriptor: Some(input.font_descriptor.clone()),
             text_background_enabled: input.text_background_enabled,
             arrow_length: input.arrow_length,
             arrow_angle: input.arrow_angle,

--- a/src/session/storage/tests.rs
+++ b/src/session/storage/tests.rs
@@ -1,5 +1,5 @@
 use super::{clear_session, inspect_session};
-use crate::draw::{Color, Frame, Shape};
+use crate::draw::{Color, FontDescriptor, Frame, Shape};
 use crate::session::snapshot::{BoardPagesSnapshot, BoardSnapshot};
 use crate::session::{
     CompressionMode, SessionOptions, SessionSnapshot, ToolStateSnapshot, save_snapshot,
@@ -103,6 +103,7 @@ fn inspect_session_reports_counts_and_flags() {
             fill_enabled: Some(false),
             tool_override: None,
             current_font_size: 24.0,
+            font_descriptor: Some(FontDescriptor::default()),
             text_background_enabled: false,
             arrow_length: 20.0,
             arrow_angle: 30.0,

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::helpers::dummy_input_state;
-use crate::draw::{Color, Shape};
+use crate::draw::{Color, FontDescriptor, Shape};
 use crate::input::EraserMode;
 use std::fs;
 
@@ -34,6 +34,7 @@ fn save_snapshot_skips_when_payload_exceeds_max_file_size() {
             fill_enabled: Some(false),
             tool_override: None,
             current_font_size: 24.0,
+            font_descriptor: Some(FontDescriptor::default()),
             text_background_enabled: false,
             arrow_length: 20.0,
             arrow_angle: 30.0,

--- a/src/session/tests/snapshot.rs
+++ b/src/session/tests/snapshot.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::helpers::dummy_input_state;
-use crate::draw::{Color, Frame, Shape};
+use crate::draw::{Color, FontDescriptor, Frame, Shape};
 use crate::input::state::{MAX_STROKE_THICKNESS, MIN_STROKE_THICKNESS};
 use crate::input::{EraserMode, PerToolDrawingSettings, Tool};
 use std::path::PathBuf;
@@ -68,6 +68,12 @@ fn apply_snapshot_restores_tool_state() {
     let _ = input.set_eraser_mode(EraserMode::Stroke);
     let _ = input.set_marker_opacity(0.55);
     let _ = input.set_fill_enabled(true);
+    let desired_font = FontDescriptor::new(
+        "Monospace".to_string(),
+        "normal".to_string(),
+        "italic".to_string(),
+    );
+    let _ = input.set_font_descriptor(desired_font.clone());
     let _ = input.set_font_size(48.0);
     input.text_background_enabled = true;
     input.arrow_length = 40.0;
@@ -83,6 +89,13 @@ fn apply_snapshot_restores_tool_state() {
     input.show_status_bar = false;
 
     let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
+    assert_eq!(
+        snapshot
+            .tool_state
+            .as_ref()
+            .and_then(|state| state.font_descriptor.as_ref()),
+        Some(&desired_font)
+    );
 
     let mut restored = dummy_input_state();
     apply_snapshot(&mut restored, snapshot, &options);
@@ -93,6 +106,7 @@ fn apply_snapshot_restores_tool_state() {
     assert_eq!(restored.eraser_mode, EraserMode::Stroke);
     assert_eq!(restored.marker_opacity, 0.55);
     assert!(restored.fill_enabled);
+    assert_eq!(restored.font_descriptor, desired_font);
     assert_eq!(restored.current_font_size, 48.0);
     assert_eq!(restored.tool_override(), Some(Tool::Rect));
     assert!(restored.text_background_enabled);
@@ -110,6 +124,55 @@ fn apply_snapshot_restores_tool_state() {
         })
     );
     assert!(!restored.show_status_bar);
+}
+
+#[test]
+fn apply_legacy_snapshot_preserves_config_initialized_font_descriptor() {
+    let mut options = SessionOptions::new(PathBuf::from("/tmp"), "display-legacy-font");
+    options.restore_tool_state = true;
+
+    let config_font = FontDescriptor::new(
+        "JetBrains Mono".to_string(),
+        "medium".to_string(),
+        "normal".to_string(),
+    );
+    let snapshot = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: vec![],
+        tool_state: Some(ToolStateSnapshot {
+            current_color: Color {
+                r: 0.0,
+                g: 1.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            current_thickness: 4.0,
+            eraser_size: 12.0,
+            eraser_kind: crate::draw::EraserKind::Circle,
+            eraser_mode: EraserMode::Brush,
+            marker_opacity: Some(0.32),
+            fill_enabled: Some(false),
+            tool_override: None,
+            current_font_size: 40.0,
+            font_descriptor: None,
+            text_background_enabled: false,
+            arrow_length: 20.0,
+            arrow_angle: 30.0,
+            arrow_head_at_end: Some(false),
+            arrow_label_enabled: Some(false),
+            board_previous_color: None,
+            show_status_bar: true,
+            tool_settings: None,
+        }),
+    };
+
+    let mut restored = dummy_input_state();
+    let _ = restored.set_font_descriptor(config_font.clone());
+
+    apply_snapshot(&mut restored, snapshot, &options);
+
+    assert_eq!(restored.font_descriptor, config_font);
+    assert_eq!(restored.current_font_size, 40.0);
 }
 
 #[test]
@@ -140,6 +203,7 @@ fn apply_snapshot_clamps_restored_per_tool_thicknesses() {
             fill_enabled: Some(false),
             tool_override: Some(Tool::Pen),
             current_font_size: 32.0,
+            font_descriptor: Some(FontDescriptor::default()),
             text_background_enabled: false,
             arrow_length: 20.0,
             arrow_angle: 30.0,
@@ -185,6 +249,7 @@ fn apply_legacy_snapshot_uses_font_derived_step_marker_size() {
             fill_enabled: Some(false),
             tool_override: Some(Tool::StepMarker),
             current_font_size: 48.0,
+            font_descriptor: None,
             text_background_enabled: false,
             arrow_length: 20.0,
             arrow_angle: 30.0,


### PR DESCRIPTION
Resolves #187 

  - Stop runtime drawing-state changes from rewriting `config.toml`
  - Persist font family/style/weight through session tool state
  - Keep explicit config writes for toolbar preferences, preset save/clear, board config, and click-
  highlight settings