### PR TITLE
 Refactor input and toolbar architecture around board transitions and tool profiles

### DIFF
--- a/src/backend/wayland/toolbar/layout/side/actions.rs
+++ b/src/backend/wayland/toolbar/layout/side/actions.rs
@@ -1,246 +1,135 @@
-use super::{
-    HitKind, HitRegion, SideLayoutContext, ToolbarEvent, ToolbarLayoutSpec, format_binding_label,
-};
+use super::{HitKind, HitRegion, SideLayoutContext, ToolbarLayoutSpec, format_binding_label};
 use crate::backend::wayland::toolbar::rows::{centered_grid_layout, grid_layout, row_item_width};
-use crate::config::{Action, action_label, action_short_label};
-use crate::input::ToolbarDrawerTab;
-use crate::ui::toolbar::bindings::action_for_event;
+use crate::ui::toolbar::model::{
+    ToolbarActionsModel, ToolbarCommandGroup, ToolbarCommandGroupKind,
+};
 
 pub(super) fn push_actions_hits(
     ctx: &SideLayoutContext<'_>,
     y: f64,
     hits: &mut Vec<HitRegion>,
 ) -> f64 {
-    let show_drawer_view =
-        ctx.snapshot.drawer_open && ctx.snapshot.drawer_tab == ToolbarDrawerTab::View;
-    let show_advanced = ctx.snapshot.show_actions_advanced && show_drawer_view;
-    let show_view_actions = show_drawer_view
-        && ctx.snapshot.show_zoom_actions
-        && (ctx.snapshot.show_actions_section || ctx.snapshot.show_actions_advanced);
-    let show_actions = ctx.snapshot.show_actions_section || show_advanced;
-    if !show_actions {
+    let Some(model) = ToolbarActionsModel::from_snapshot(ctx.snapshot) else {
         return y;
-    }
+    };
 
-    let mut actions_snapshot = ctx.snapshot.clone();
-    actions_snapshot.show_actions_advanced = show_advanced;
-    let actions_card_h = ctx.spec.side_actions_height(&actions_snapshot);
+    let actions_card_h = ctx.spec.side_actions_height(ctx.snapshot);
     let mut action_y = y + ToolbarLayoutSpec::SIDE_SECTION_TOGGLE_OFFSET_Y;
-    let basic_actions = [
-        ToolbarEvent::Undo,
-        ToolbarEvent::Redo,
-        ToolbarEvent::ClearCanvas,
-    ];
-    let view_actions = [
-        ToolbarEvent::ZoomIn,
-        ToolbarEvent::ZoomOut,
-        ToolbarEvent::ResetZoom,
-        ToolbarEvent::ToggleZoomLock,
-    ];
-    let mut advanced_actions = Vec::new();
-    advanced_actions.push(ToolbarEvent::UndoAll);
-    advanced_actions.push(ToolbarEvent::RedoAll);
-    if ctx.snapshot.delay_actions_enabled {
-        advanced_actions.push(ToolbarEvent::UndoAllDelayed);
-        advanced_actions.push(ToolbarEvent::RedoAllDelayed);
-    }
-    advanced_actions.push(ToolbarEvent::ToggleFreeze);
-
-    if ctx.snapshot.show_actions_section {
-        if ctx.use_icons {
-            let icon_btn = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_ICON;
-            let icon_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-            let layout = centered_grid_layout(
-                ctx.x,
-                ctx.content_width,
-                action_y,
-                icon_btn,
-                icon_gap,
-                basic_actions.len(),
-                basic_actions.len(),
-            );
-            for (item, evt) in layout.items.iter().zip(basic_actions.iter()) {
-                hits.push(HitRegion {
-                    rect: (item.x, item.y, item.w, item.h),
-                    event: evt.clone(),
-                    kind: HitKind::Click,
-                    tooltip: Some(format_binding_label(
-                        event_label(evt, ctx.snapshot),
-                        ctx.snapshot.binding_hints.binding_for_event(evt),
-                    )),
-                });
-            }
-            action_y += layout.height;
-        } else {
-            let action_h = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT;
-            let action_gap = ToolbarLayoutSpec::SIDE_ACTION_CONTENT_GAP_TEXT;
-            let layout = grid_layout(
-                ctx.x,
-                action_y,
-                ctx.content_width,
-                action_h,
-                0.0,
-                action_gap,
-                1,
-                basic_actions.len(),
-            );
-            for (item, evt) in layout.items.iter().zip(basic_actions.iter()) {
-                hits.push(HitRegion {
-                    rect: (item.x, item.y, item.w, item.h),
-                    event: evt.clone(),
-                    kind: HitKind::Click,
-                    tooltip: Some(format_binding_label(
-                        event_label(evt, ctx.snapshot),
-                        ctx.snapshot.binding_hints.binding_for_event(evt),
-                    )),
-                });
-            }
-            action_y += layout.height;
-        }
-    }
-
-    let mut has_group = ctx.snapshot.show_actions_section;
-
-    if show_view_actions {
+    let mut has_group = false;
+    for group in model.groups() {
         if has_group {
             action_y += ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
         }
-        if ctx.use_icons {
-            let icon_btn = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_ICON;
-            let icon_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-            let layout = centered_grid_layout(
-                ctx.x,
-                ctx.content_width,
-                action_y,
-                icon_btn,
-                icon_gap,
-                5,
-                view_actions.len(),
-            );
-            for (item, evt) in layout.items.iter().zip(view_actions.iter()) {
-                hits.push(HitRegion {
-                    rect: (item.x, item.y, item.w, item.h),
-                    event: evt.clone(),
-                    kind: HitKind::Click,
-                    tooltip: Some(format_binding_label(
-                        event_label(evt, ctx.snapshot),
-                        ctx.snapshot.binding_hints.binding_for_event(evt),
-                    )),
-                });
-            }
-            if layout.rows > 0 {
-                action_y += layout.height;
-            }
-        } else {
-            let action_h = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT;
-            let action_gap = ToolbarLayoutSpec::SIDE_ACTION_CONTENT_GAP_TEXT;
-            let action_col_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-            let action_w = row_item_width(ctx.content_width, 2, action_col_gap);
-            let layout = grid_layout(
-                ctx.x,
-                action_y,
-                action_w,
-                action_h,
-                action_col_gap,
-                action_gap,
-                2,
-                view_actions.len(),
-            );
-            for (item, evt) in layout.items.iter().zip(view_actions.iter()) {
-                hits.push(HitRegion {
-                    rect: (item.x, item.y, item.w, item.h),
-                    event: evt.clone(),
-                    kind: HitKind::Click,
-                    tooltip: Some(format_binding_label(
-                        event_label(evt, ctx.snapshot),
-                        ctx.snapshot.binding_hints.binding_for_event(evt),
-                    )),
-                });
-            }
-            if layout.rows > 0 {
-                action_y += layout.height;
-            }
-        }
-        has_group = true;
-    }
 
-    if show_advanced {
-        if has_group {
-            action_y += ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-        }
-        if ctx.use_icons {
-            let icon_btn = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_ICON;
-            let icon_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-            let layout = centered_grid_layout(
-                ctx.x,
-                ctx.content_width,
-                action_y,
-                icon_btn,
-                icon_gap,
-                5,
-                advanced_actions.len(),
-            );
-            for (item, evt) in layout.items.iter().zip(advanced_actions.iter()) {
-                hits.push(HitRegion {
-                    rect: (item.x, item.y, item.w, item.h),
-                    event: evt.clone(),
-                    kind: HitKind::Click,
-                    tooltip: Some(format_binding_label(
-                        event_label(evt, ctx.snapshot),
-                        ctx.snapshot.binding_hints.binding_for_event(evt),
-                    )),
-                });
-            }
+        let (next_y, has_rows) = if ctx.use_icons {
+            push_icon_group_hits(ctx, action_y, hits, group)
         } else {
-            let action_h = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT;
-            let action_gap = ToolbarLayoutSpec::SIDE_ACTION_CONTENT_GAP_TEXT;
-            let action_col_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-            let action_w = row_item_width(ctx.content_width, 2, action_col_gap);
-            let layout = grid_layout(
-                ctx.x,
-                action_y,
-                action_w,
-                action_h,
-                action_col_gap,
-                action_gap,
-                2,
-                advanced_actions.len(),
-            );
-            for (item, evt) in layout.items.iter().zip(advanced_actions.iter()) {
-                hits.push(HitRegion {
-                    rect: (item.x, item.y, item.w, item.h),
-                    event: evt.clone(),
-                    kind: HitKind::Click,
-                    tooltip: Some(format_binding_label(
-                        event_label(evt, ctx.snapshot),
-                        ctx.snapshot.binding_hints.binding_for_event(evt),
-                    )),
-                });
-            }
+            push_text_group_hits(ctx, action_y, hits, group)
+        };
+
+        if has_rows {
+            action_y = next_y;
+            has_group = true;
         }
     }
 
     y + actions_card_h + ctx.section_gap
 }
 
-fn event_label(event: &ToolbarEvent, snapshot: &super::ToolbarSnapshot) -> &'static str {
-    match event {
-        ToolbarEvent::ToggleFreeze => {
-            if snapshot.frozen_active {
-                "Unfreeze"
-            } else {
-                action_short_label(Action::ToggleFrozenMode)
-            }
-        }
-        ToolbarEvent::ToggleZoomLock => {
-            if snapshot.zoom_locked {
-                "Unlock Zoom"
-            } else {
-                action_label(Action::ToggleZoomLock)
-            }
-        }
-        _ => action_for_event(event)
-            .map(action_label)
-            .unwrap_or("Action"),
+fn push_icon_group_hits(
+    ctx: &SideLayoutContext<'_>,
+    action_y: f64,
+    hits: &mut Vec<HitRegion>,
+    group: &ToolbarCommandGroup,
+) -> (f64, bool) {
+    let icon_btn = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_ICON;
+    let icon_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
+    let columns = match group.kind {
+        ToolbarCommandGroupKind::BasicActions => group.buttons.len(),
+        ToolbarCommandGroupKind::ViewActions | ToolbarCommandGroupKind::AdvancedActions => 5,
+        ToolbarCommandGroupKind::Pages | ToolbarCommandGroupKind::Boards => group.buttons.len(),
+    };
+    let layout = centered_grid_layout(
+        ctx.x,
+        ctx.content_width,
+        action_y,
+        icon_btn,
+        icon_gap,
+        columns,
+        group.buttons.len(),
+    );
+    for (item, button) in layout.items.iter().zip(group.buttons.iter()) {
+        push_button_hit(ctx, hits, item.x, item.y, item.w, item.h, button);
     }
+
+    if layout.rows > 0 {
+        (action_y + layout.height, true)
+    } else {
+        (action_y, false)
+    }
+}
+
+fn push_text_group_hits(
+    ctx: &SideLayoutContext<'_>,
+    action_y: f64,
+    hits: &mut Vec<HitRegion>,
+    group: &ToolbarCommandGroup,
+) -> (f64, bool) {
+    let action_h = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT;
+    let action_gap = ToolbarLayoutSpec::SIDE_ACTION_CONTENT_GAP_TEXT;
+    let action_col_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
+    let (action_w, columns, column_gap) = match group.kind {
+        ToolbarCommandGroupKind::BasicActions => (ctx.content_width, 1, 0.0),
+        ToolbarCommandGroupKind::ViewActions | ToolbarCommandGroupKind::AdvancedActions => (
+            row_item_width(ctx.content_width, 2, action_col_gap),
+            2,
+            action_col_gap,
+        ),
+        ToolbarCommandGroupKind::Pages | ToolbarCommandGroupKind::Boards => {
+            (ctx.content_width, group.buttons.len().max(1), 0.0)
+        }
+    };
+    let layout = grid_layout(
+        ctx.x,
+        action_y,
+        action_w,
+        action_h,
+        column_gap,
+        action_gap,
+        columns,
+        group.buttons.len(),
+    );
+    for (item, button) in layout.items.iter().zip(group.buttons.iter()) {
+        push_button_hit(ctx, hits, item.x, item.y, item.w, item.h, button);
+    }
+
+    if layout.rows > 0 {
+        (action_y + layout.height, true)
+    } else {
+        (action_y, false)
+    }
+}
+
+fn push_button_hit(
+    ctx: &SideLayoutContext<'_>,
+    hits: &mut Vec<HitRegion>,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    button: &crate::ui::toolbar::model::ToolbarButtonModel,
+) {
+    if !button.enabled {
+        return;
+    }
+
+    hits.push(HitRegion {
+        rect: (x, y, w, h),
+        event: button.event.clone(),
+        kind: HitKind::Click,
+        tooltip: Some(format_binding_label(
+            button.tooltip_label(ctx.snapshot, "Action"),
+            button.binding_hint(ctx.snapshot),
+        )),
+    });
 }

--- a/src/backend/wayland/toolbar/layout/side/arrow.rs
+++ b/src/backend/wayland/toolbar/layout/side/arrow.rs
@@ -1,11 +1,9 @@
 use super::{SideLayoutContext, ToolbarLayoutSpec};
-use crate::input::Tool;
+use crate::ui::toolbar::ToolContext;
 
 // Arrow hit regions are built in render to avoid duplicate registrations.
 pub(super) fn advance_arrow_section(ctx: &SideLayoutContext<'_>, y: f64) -> f64 {
-    let show_arrow_controls =
-        ctx.snapshot.active_tool == Tool::Arrow || ctx.snapshot.arrow_label_enabled;
-    if !show_arrow_controls {
+    if !ToolContext::from_snapshot(ctx.snapshot).show_arrow_labels {
         return y;
     }
 

--- a/src/backend/wayland/toolbar/layout/side/boards.rs
+++ b/src/backend/wayland/toolbar/layout/side/boards.rs
@@ -19,7 +19,7 @@ pub(super) fn push_boards_hits(
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let cols = model.buttons.len().min(5).max(1);
+    let cols = model.buttons.len().clamp(1, 5);
     let btn_w = row_item_width(ctx.content_width, cols, btn_gap);
     let layout = grid_layout(
         ctx.x,

--- a/src/backend/wayland/toolbar/layout/side/boards.rs
+++ b/src/backend/wayland/toolbar/layout/side/boards.rs
@@ -1,22 +1,15 @@
-use super::{
-    HitKind, HitRegion, SideLayoutContext, ToolbarEvent, ToolbarLayoutSpec, format_binding_label,
-};
+use super::{HitKind, HitRegion, SideLayoutContext, ToolbarLayoutSpec, format_binding_label};
 use crate::backend::wayland::toolbar::rows::{grid_layout, row_item_width};
-use crate::config::action_label;
-use crate::input::ToolbarDrawerTab;
-use crate::ui::toolbar::bindings::action_for_event;
+use crate::ui::toolbar::model::toolbar_boards_model;
 
 pub(super) fn push_boards_hits(
     ctx: &SideLayoutContext<'_>,
     y: f64,
     hits: &mut Vec<HitRegion>,
 ) -> f64 {
-    if !ctx.snapshot.show_boards_section
-        || !ctx.snapshot.drawer_open
-        || ctx.snapshot.drawer_tab != ToolbarDrawerTab::View
-    {
+    let Some(model) = toolbar_boards_model(ctx.snapshot) else {
         return y;
-    }
+    };
 
     let boards_card_h = ctx.spec.side_boards_height(ctx.snapshot);
     let boards_y = y + ToolbarLayoutSpec::SIDE_SECTION_TOGGLE_OFFSET_Y;
@@ -26,13 +19,8 @@ pub(super) fn push_boards_hits(
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let buttons = [
-        ToolbarEvent::BoardPrev,
-        ToolbarEvent::BoardNext,
-        ToolbarEvent::BoardNew,
-        ToolbarEvent::BoardDelete,
-    ];
-    let btn_w = row_item_width(ctx.content_width, buttons.len(), btn_gap);
+    let cols = model.buttons.len().min(5).max(1);
+    let btn_w = row_item_width(ctx.content_width, cols, btn_gap);
     let layout = grid_layout(
         ctx.x,
         boards_y,
@@ -40,25 +28,24 @@ pub(super) fn push_boards_hits(
         btn_h,
         btn_gap,
         0.0,
-        buttons.len(),
-        buttons.len(),
+        model.buttons.len(),
+        cols,
     );
-    for (item, evt) in layout.items.iter().zip(buttons.iter()) {
-        let tooltip_label = tooltip_label(evt);
+    for (item, button) in layout.items.iter().zip(model.buttons.iter()) {
+        if !button.enabled {
+            continue;
+        }
+
         hits.push(HitRegion {
             rect: (item.x, item.y, item.w, item.h),
-            event: evt.clone(),
+            event: button.event.clone(),
             kind: HitKind::Click,
             tooltip: Some(format_binding_label(
-                tooltip_label,
-                ctx.snapshot.binding_hints.binding_for_event(evt),
+                button.tooltip_label(ctx.snapshot, "Board"),
+                button.binding_hint(ctx.snapshot),
             )),
         });
     }
 
     y + boards_card_h + ctx.section_gap
-}
-
-fn tooltip_label(event: &ToolbarEvent) -> &'static str {
-    action_for_event(event).map(action_label).unwrap_or("Board")
 }

--- a/src/backend/wayland/toolbar/layout/side/boards.rs
+++ b/src/backend/wayland/toolbar/layout/side/boards.rs
@@ -1,5 +1,5 @@
 use super::{HitKind, HitRegion, SideLayoutContext, ToolbarLayoutSpec, format_binding_label};
-use crate::backend::wayland::toolbar::rows::{grid_layout, row_item_width};
+use crate::backend::wayland::toolbar::rows::{capped_grid_columns, grid_layout, row_item_width};
 use crate::ui::toolbar::model::toolbar_boards_model;
 
 pub(super) fn push_boards_hits(
@@ -19,7 +19,7 @@ pub(super) fn push_boards_hits(
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let cols = model.buttons.len().clamp(1, 5);
+    let cols = capped_grid_columns(model.buttons.len(), 5);
     let btn_w = row_item_width(ctx.content_width, cols, btn_gap);
     let layout = grid_layout(
         ctx.x,

--- a/src/backend/wayland/toolbar/layout/side/mod.rs
+++ b/src/backend/wayland/toolbar/layout/side/mod.rs
@@ -44,7 +44,7 @@ pub fn build_side_hits(
     if tool_context.needs_thickness {
         y = sliders::push_thickness_hits(&ctx, y, hits);
 
-        if snapshot.thickness_targets_eraser {
+        if tool_context.show_eraser_mode {
             y += ToolbarLayoutSpec::SIDE_ERASER_MODE_CARD_HEIGHT + ctx.section_gap;
         }
     }

--- a/src/backend/wayland/toolbar/layout/side/pages.rs
+++ b/src/backend/wayland/toolbar/layout/side/pages.rs
@@ -1,22 +1,15 @@
-use super::{
-    HitKind, HitRegion, SideLayoutContext, ToolbarEvent, ToolbarLayoutSpec, format_binding_label,
-};
+use super::{HitKind, HitRegion, SideLayoutContext, ToolbarLayoutSpec, format_binding_label};
 use crate::backend::wayland::toolbar::rows::{grid_layout, row_item_width};
-use crate::config::action_label;
-use crate::input::ToolbarDrawerTab;
-use crate::ui::toolbar::bindings::action_for_event;
+use crate::ui::toolbar::model::toolbar_pages_model;
 
 pub(super) fn push_pages_hits(
     ctx: &SideLayoutContext<'_>,
     y: f64,
     hits: &mut Vec<HitRegion>,
 ) -> f64 {
-    if !ctx.snapshot.show_pages_section
-        || !ctx.snapshot.drawer_open
-        || ctx.snapshot.drawer_tab != ToolbarDrawerTab::View
-    {
+    let Some(model) = toolbar_pages_model(ctx.snapshot) else {
         return y;
-    }
+    };
 
     let pages_card_h = ctx.spec.side_pages_height(ctx.snapshot);
     let pages_y = y + ToolbarLayoutSpec::SIDE_SECTION_TOGGLE_OFFSET_Y;
@@ -26,14 +19,7 @@ pub(super) fn push_pages_hits(
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let buttons = [
-        ToolbarEvent::PagePrev,
-        ToolbarEvent::PageNext,
-        ToolbarEvent::PageNew,
-        ToolbarEvent::PageDuplicate,
-        ToolbarEvent::PageDelete,
-    ];
-    let btn_w = row_item_width(ctx.content_width, buttons.len(), btn_gap);
+    let btn_w = row_item_width(ctx.content_width, model.buttons.len(), btn_gap);
     let layout = grid_layout(
         ctx.x,
         pages_y,
@@ -41,25 +27,24 @@ pub(super) fn push_pages_hits(
         btn_h,
         btn_gap,
         0.0,
-        buttons.len(),
-        buttons.len(),
+        model.buttons.len(),
+        model.buttons.len(),
     );
-    for (item, evt) in layout.items.iter().zip(buttons.iter()) {
-        let tooltip_label = tooltip_label(evt);
+    for (item, button) in layout.items.iter().zip(model.buttons.iter()) {
+        if !button.enabled {
+            continue;
+        }
+
         hits.push(HitRegion {
             rect: (item.x, item.y, item.w, item.h),
-            event: evt.clone(),
+            event: button.event.clone(),
             kind: HitKind::Click,
             tooltip: Some(format_binding_label(
-                tooltip_label,
-                ctx.snapshot.binding_hints.binding_for_event(evt),
+                button.tooltip_label(ctx.snapshot, "Page"),
+                button.binding_hint(ctx.snapshot),
             )),
         });
     }
 
     y + pages_card_h + ctx.section_gap
-}
-
-fn tooltip_label(event: &ToolbarEvent) -> &'static str {
-    action_for_event(event).map(action_label).unwrap_or("Page")
 }

--- a/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
+++ b/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
@@ -47,7 +47,7 @@ impl ToolbarLayoutSpec {
         // Thickness/size slider: only when tool needs it
         if tool_context.needs_thickness {
             add_section(Self::SIDE_SLIDER_CARD_HEIGHT, &mut height);
-            if snapshot.thickness_targets_eraser {
+            if tool_context.show_eraser_mode {
                 add_section(Self::SIDE_ERASER_MODE_CARD_HEIGHT, &mut height);
             }
         }

--- a/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
+++ b/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
@@ -258,7 +258,7 @@ impl ToolbarLayoutSpec {
         } else {
             Self::SIDE_ACTION_BUTTON_HEIGHT_TEXT
         };
-        let columns = boards.buttons.len().min(5).max(1);
+        let columns = boards.buttons.len().clamp(1, 5);
         let rows = boards.buttons.len().div_ceil(columns);
         Self::SIDE_SECTION_TOGGLE_OFFSET_Y
             + btn_h * rows as f64

--- a/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
+++ b/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
@@ -1,5 +1,8 @@
 use crate::config::ToolbarLayoutMode;
 use crate::ui::toolbar::ToolbarSnapshot;
+use crate::ui::toolbar::model::{
+    ToolbarActionsModel, ToolbarCommandGroupKind, toolbar_boards_model, toolbar_pages_model,
+};
 use crate::ui::toolbar::snapshot::ToolContext;
 
 use super::super::ToolbarLayoutSpec;
@@ -12,16 +15,9 @@ impl ToolbarLayoutSpec {
         let base_height = self.side_content_start_y();
         let tool_context = ToolContext::from_snapshot(snapshot);
 
-        let show_drawer_view =
-            snapshot.drawer_open && snapshot.drawer_tab == crate::input::ToolbarDrawerTab::View;
-        let show_advanced = snapshot.show_actions_advanced && show_drawer_view;
-        let show_actions = snapshot.show_actions_section || show_advanced;
-        let show_pages = snapshot.show_pages_section
-            && snapshot.drawer_open
-            && snapshot.drawer_tab == crate::input::ToolbarDrawerTab::View;
-        let show_boards = snapshot.show_boards_section
-            && snapshot.drawer_open
-            && snapshot.drawer_tab == crate::input::ToolbarDrawerTab::View;
+        let show_actions = ToolbarActionsModel::from_snapshot(snapshot).is_some();
+        let show_pages = toolbar_pages_model(snapshot).is_some();
+        let show_boards = toolbar_boards_model(snapshot).is_some();
         let show_presets =
             snapshot.show_presets && snapshot.preset_slot_count.min(snapshot.presets.len()) > 0;
         let show_step_section = snapshot.show_step_section
@@ -88,9 +84,7 @@ impl ToolbarLayoutSpec {
         }
 
         if show_actions {
-            let mut actions_snapshot = snapshot.clone();
-            actions_snapshot.show_actions_advanced = show_advanced;
-            let actions_card_h = self.side_actions_height(&actions_snapshot);
+            let actions_card_h = self.side_actions_height(snapshot);
             add_section(actions_card_h, &mut height);
         }
 
@@ -154,24 +148,8 @@ impl ToolbarLayoutSpec {
         &self,
         snapshot: &ToolbarSnapshot,
     ) -> f64 {
-        let show_drawer_view =
-            snapshot.drawer_open && snapshot.drawer_tab == crate::input::ToolbarDrawerTab::View;
-        let show_actions_section = snapshot.show_actions_section;
-        let show_actions_advanced = snapshot.show_actions_advanced && show_drawer_view;
-        let show_view_actions = show_drawer_view
-            && snapshot.show_zoom_actions
-            && (show_actions_section || snapshot.show_actions_advanced);
-        if !show_actions_section && !show_actions_advanced {
+        let Some(model) = ToolbarActionsModel::from_snapshot(snapshot) else {
             return 0.0;
-        }
-
-        let basic_count: usize = if show_actions_section { 3 } else { 0 };
-        let view_count: usize = if show_view_actions { 4 } else { 0 };
-        let show_delay_actions = snapshot.delay_actions_enabled;
-        let advanced_count: usize = if show_actions_advanced {
-            if show_delay_actions { 5 } else { 3 }
-        } else {
-            0
         };
 
         if self.use_icons {
@@ -179,24 +157,24 @@ impl ToolbarLayoutSpec {
             let icon_gap = Self::SIDE_ACTION_BUTTON_GAP;
             let mut height = 0.0;
             let mut has_group = false;
-            if basic_count > 0 {
-                height += icon_btn;
-                has_group = true;
-            }
-            if view_count > 0 {
+            for group in model.groups() {
+                if group.buttons.is_empty() {
+                    continue;
+                }
                 if has_group {
                     height += icon_gap;
                 }
-                let rows = view_count.div_ceil(5);
+                let columns = match group.kind {
+                    ToolbarCommandGroupKind::BasicActions => group.buttons.len(),
+                    ToolbarCommandGroupKind::ViewActions
+                    | ToolbarCommandGroupKind::AdvancedActions => 5,
+                    ToolbarCommandGroupKind::Pages | ToolbarCommandGroupKind::Boards => {
+                        group.buttons.len()
+                    }
+                };
+                let rows = group.buttons.len().div_ceil(columns);
                 height += icon_btn * rows as f64 + icon_gap * (rows as f64 - 1.0);
                 has_group = true;
-            }
-            if advanced_count > 0 {
-                if has_group {
-                    height += icon_gap;
-                }
-                let rows = advanced_count.div_ceil(5);
-                height += icon_btn * rows as f64 + icon_gap * (rows as f64 - 1.0);
             }
             height
         } else {
@@ -204,24 +182,24 @@ impl ToolbarLayoutSpec {
             let action_gap = Self::SIDE_ACTION_CONTENT_GAP_TEXT;
             let mut height = 0.0;
             let mut has_group = false;
-            if basic_count > 0 {
-                height += action_h * basic_count as f64 + action_gap * (basic_count as f64 - 1.0);
-                has_group = true;
-            }
-            if view_count > 0 {
+            for group in model.groups() {
+                if group.buttons.is_empty() {
+                    continue;
+                }
                 if has_group {
                     height += Self::SIDE_ACTION_BUTTON_GAP;
                 }
-                let rows = view_count.div_ceil(2);
+                let columns = match group.kind {
+                    ToolbarCommandGroupKind::BasicActions => 1,
+                    ToolbarCommandGroupKind::ViewActions
+                    | ToolbarCommandGroupKind::AdvancedActions => 2,
+                    ToolbarCommandGroupKind::Pages | ToolbarCommandGroupKind::Boards => {
+                        group.buttons.len().max(1)
+                    }
+                };
+                let rows = group.buttons.len().div_ceil(columns);
                 height += action_h * rows as f64 + action_gap * (rows as f64 - 1.0);
                 has_group = true;
-            }
-            if advanced_count > 0 {
-                if has_group {
-                    height += Self::SIDE_ACTION_BUTTON_GAP;
-                }
-                let rows = advanced_count.div_ceil(2);
-                height += action_h * rows as f64 + action_gap * (rows as f64 - 1.0);
             }
             height
         }
@@ -253,30 +231,38 @@ impl ToolbarLayoutSpec {
         &self,
         snapshot: &ToolbarSnapshot,
     ) -> f64 {
-        if !snapshot.show_pages_section {
+        let Some(pages) = toolbar_pages_model(snapshot) else {
             return 0.0;
-        }
+        };
         let btn_h = if self.use_icons {
             Self::SIDE_ACTION_BUTTON_HEIGHT_ICON
         } else {
             Self::SIDE_ACTION_BUTTON_HEIGHT_TEXT
         };
-        Self::SIDE_SECTION_TOGGLE_OFFSET_Y + btn_h + Self::SIDE_ACTION_BUTTON_GAP
+        let columns = pages.buttons.len().max(1);
+        let rows = pages.buttons.len().div_ceil(columns);
+        Self::SIDE_SECTION_TOGGLE_OFFSET_Y
+            + btn_h * rows as f64
+            + Self::SIDE_ACTION_BUTTON_GAP * rows as f64
     }
 
     pub(in crate::backend::wayland::toolbar) fn side_boards_height(
         &self,
         snapshot: &ToolbarSnapshot,
     ) -> f64 {
-        if !snapshot.show_boards_section {
+        let Some(boards) = toolbar_boards_model(snapshot) else {
             return 0.0;
-        }
+        };
         let btn_h = if self.use_icons {
             Self::SIDE_ACTION_BUTTON_HEIGHT_ICON
         } else {
             Self::SIDE_ACTION_BUTTON_HEIGHT_TEXT
         };
-        Self::SIDE_SECTION_TOGGLE_OFFSET_Y + btn_h + Self::SIDE_ACTION_BUTTON_GAP
+        let columns = boards.buttons.len().min(5).max(1);
+        let rows = boards.buttons.len().div_ceil(columns);
+        Self::SIDE_SECTION_TOGGLE_OFFSET_Y
+            + btn_h * rows as f64
+            + Self::SIDE_ACTION_BUTTON_GAP * rows as f64
     }
 
     pub(in crate::backend::wayland::toolbar) fn side_step_height(

--- a/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
+++ b/src/backend/wayland/toolbar/layout/spec/side/sizes.rs
@@ -1,3 +1,4 @@
+use crate::backend::wayland::toolbar::rows::capped_grid_columns;
 use crate::config::ToolbarLayoutMode;
 use crate::ui::toolbar::ToolbarSnapshot;
 use crate::ui::toolbar::model::{
@@ -258,7 +259,7 @@ impl ToolbarLayoutSpec {
         } else {
             Self::SIDE_ACTION_BUTTON_HEIGHT_TEXT
         };
-        let columns = boards.buttons.len().clamp(1, 5);
+        let columns = capped_grid_columns(boards.buttons.len(), 5);
         let rows = boards.buttons.len().div_ceil(columns);
         Self::SIDE_SECTION_TOGGLE_OFFSET_Y
             + btn_h * rows as f64

--- a/src/backend/wayland/toolbar/render/side_palette/actions.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/actions.rs
@@ -4,10 +4,12 @@ use super::SidePaletteLayout;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
 use crate::backend::wayland::toolbar::rows::row_item_width;
-use crate::input::ToolbarDrawerTab;
 use crate::toolbar_icons;
 use crate::ui::toolbar::ToolbarEvent;
 use crate::ui::toolbar::ToolbarSnapshot;
+use crate::ui::toolbar::model::{
+    ToolbarActionsModel, ToolbarButtonModel, ToolbarCommandGroup, ToolbarCommandGroupKind,
+};
 use crate::ui_text::UiTextStyle;
 
 use super::super::widgets::constants::{FONT_FAMILY_DEFAULT, FONT_SIZE_LABEL};
@@ -36,19 +38,11 @@ pub(super) fn draw_actions_section(layout: &mut SidePaletteLayout, y: &mut f64) 
         size: FONT_SIZE_LABEL,
     };
 
-    let show_drawer_view = snapshot.drawer_open && snapshot.drawer_tab == ToolbarDrawerTab::View;
-    let show_advanced = snapshot.show_actions_advanced && show_drawer_view;
-    let show_view_actions = show_drawer_view
-        && snapshot.show_zoom_actions
-        && (snapshot.show_actions_section || snapshot.show_actions_advanced);
-    let show_actions = snapshot.show_actions_section || show_advanced;
-    if !show_actions {
+    let Some(model) = ToolbarActionsModel::from_snapshot(snapshot) else {
         return;
-    }
+    };
 
-    let mut actions_snapshot = snapshot.clone();
-    actions_snapshot.show_actions_advanced = show_advanced;
-    let actions_card_h = layout.spec.side_actions_height(&actions_snapshot);
+    let actions_card_h = layout.spec.side_actions_height(snapshot);
     draw_group_card(ctx, card_x, *y, card_w, actions_card_h);
     draw_section_label(
         ctx,
@@ -59,10 +53,6 @@ pub(super) fn draw_actions_section(layout: &mut SidePaletteLayout, y: &mut f64) 
     );
 
     let actions_y = *y + ToolbarLayoutSpec::SIDE_SECTION_TOGGLE_OFFSET_Y;
-    let basic_actions = build_basic_action_buttons(snapshot);
-    let view_actions = build_view_action_buttons(snapshot);
-    let show_delay_actions = show_advanced && snapshot.delay_actions_enabled;
-    let advanced_actions = build_advanced_action_buttons(snapshot, show_delay_actions);
 
     if use_icons {
         render_icon_action_sections(
@@ -73,11 +63,7 @@ pub(super) fn draw_actions_section(layout: &mut SidePaletteLayout, y: &mut f64) 
             actions_y,
             x,
             content_width,
-            &basic_actions,
-            &view_actions,
-            &advanced_actions,
-            show_view_actions,
-            show_advanced,
+            &model,
         );
     } else {
         render_text_action_sections(
@@ -89,11 +75,7 @@ pub(super) fn draw_actions_section(layout: &mut SidePaletteLayout, y: &mut f64) 
             x,
             content_width,
             label_style,
-            &basic_actions,
-            &view_actions,
-            &advanced_actions,
-            show_view_actions,
-            show_advanced,
+            &model,
         );
     }
 
@@ -109,38 +91,15 @@ fn render_icon_action_sections(
     start_y: f64,
     x: f64,
     content_width: f64,
-    basic_actions: &[ActionButton],
-    view_actions: &[ActionButton],
-    advanced_actions: &[ActionButton],
-    show_view_actions: bool,
-    show_advanced: bool,
+    model: &ToolbarActionsModel,
 ) {
     let icon_btn_size = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_ICON;
     let icon_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
     let icon_size = ToolbarLayoutSpec::SIDE_ACTION_ICON_SIZE;
-    let (action_y, has_group) = if snapshot.show_actions_section {
-        render_icon_action_group(
-            ctx,
-            hits,
-            hover,
-            snapshot,
-            IconActionLayout {
-                x,
-                content_width,
-                start_y,
-                button_size: icon_btn_size,
-                icon_size,
-                gap: icon_gap,
-                columns: basic_actions.len(),
-                add_gap: false,
-            },
-            basic_actions,
-        )
-    } else {
-        (start_y, false)
-    };
-
-    let (action_y, has_group) = if show_view_actions {
+    let mut action_y = start_y;
+    let mut has_group = false;
+    for group in model.groups() {
+        let actions = build_action_buttons(snapshot, group);
         let (next_y, has_rows) = render_icon_action_group(
             ctx,
             hits,
@@ -153,34 +112,15 @@ fn render_icon_action_sections(
                 button_size: icon_btn_size,
                 icon_size,
                 gap: icon_gap,
-                columns: 5,
+                columns: icon_group_columns(group),
                 add_gap: has_group,
             },
-            view_actions,
+            &actions,
         );
-        (next_y, has_group || has_rows)
-    } else {
-        (action_y, has_group)
-    };
-
-    if show_advanced {
-        let _ = render_icon_action_group(
-            ctx,
-            hits,
-            hover,
-            snapshot,
-            IconActionLayout {
-                x,
-                content_width,
-                start_y: action_y,
-                button_size: icon_btn_size,
-                icon_size,
-                gap: icon_gap,
-                columns: 5,
-                add_gap: has_group,
-            },
-            advanced_actions,
-        );
+        if has_rows {
+            action_y = next_y;
+            has_group = true;
+        }
     }
 }
 
@@ -194,43 +134,18 @@ fn render_text_action_sections(
     x: f64,
     content_width: f64,
     label_style: UiTextStyle<'static>,
-    basic_actions: &[ActionButton],
-    view_actions: &[ActionButton],
-    advanced_actions: &[ActionButton],
-    show_view_actions: bool,
-    show_advanced: bool,
+    model: &ToolbarActionsModel,
 ) {
     let action_h = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT;
     let action_row_gap = ToolbarLayoutSpec::SIDE_ACTION_CONTENT_GAP_TEXT;
     let action_group_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
     let action_col_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let action_w = row_item_width(content_width, 2, action_col_gap);
-    let (action_y, has_group) = if snapshot.show_actions_section {
-        render_text_action_group(
-            ctx,
-            hits,
-            hover,
-            snapshot,
-            TextActionLayout {
-                x,
-                start_y,
-                width: content_width,
-                height: action_h,
-                column_gap: 0.0,
-                group_gap: action_group_gap,
-                row_gap: action_row_gap,
-                columns: 1,
-                add_gap: false,
-                label_style,
-                enabled_style: false,
-            },
-            basic_actions,
-        )
-    } else {
-        (start_y, false)
-    };
-
-    let (action_y, has_group) = if show_view_actions {
+    let mut action_y = start_y;
+    let mut has_group = false;
+    for group in model.groups() {
+        let actions = build_action_buttons(snapshot, group);
+        let (action_w, columns, column_gap, enabled_style) =
+            text_group_layout(content_width, action_col_gap, group.kind);
         let (next_y, has_rows) = render_text_action_group(
             ctx,
             hits,
@@ -241,133 +156,97 @@ fn render_text_action_sections(
                 start_y: action_y,
                 width: action_w,
                 height: action_h,
-                column_gap: action_col_gap,
+                column_gap,
                 group_gap: action_group_gap,
                 row_gap: action_row_gap,
-                columns: 2,
+                columns,
                 add_gap: has_group,
                 label_style,
-                enabled_style: true,
+                enabled_style,
             },
-            view_actions,
+            &actions,
         );
-        (next_y, has_group || has_rows)
-    } else {
-        (action_y, has_group)
-    };
-
-    if show_advanced {
-        let _ = render_text_action_group(
-            ctx,
-            hits,
-            hover,
-            snapshot,
-            TextActionLayout {
-                x,
-                start_y: action_y,
-                width: action_w,
-                height: action_h,
-                column_gap: action_col_gap,
-                group_gap: action_group_gap,
-                row_gap: action_row_gap,
-                columns: 2,
-                add_gap: has_group,
-                label_style,
-                enabled_style: false,
-            },
-            advanced_actions,
-        );
+        if has_rows {
+            action_y = next_y;
+            has_group = true;
+        }
     }
 }
 
-fn build_basic_action_buttons(snapshot: &ToolbarSnapshot) -> [ActionButton; 3] {
-    [
-        ActionButton {
-            event: ToolbarEvent::Undo,
-            icon_fn: toolbar_icons::draw_icon_undo as ActionIconFn,
-            enabled: snapshot.undo_available,
-        },
-        ActionButton {
-            event: ToolbarEvent::Redo,
-            icon_fn: toolbar_icons::draw_icon_redo as ActionIconFn,
-            enabled: snapshot.redo_available,
-        },
-        ActionButton {
-            event: ToolbarEvent::ClearCanvas,
-            icon_fn: toolbar_icons::draw_icon_clear as ActionIconFn,
-            enabled: true,
-        },
-    ]
+fn build_action_buttons(
+    snapshot: &ToolbarSnapshot,
+    group: &ToolbarCommandGroup,
+) -> Vec<ActionButton> {
+    group
+        .buttons
+        .iter()
+        .map(|button| ActionButton {
+            event: button.event.clone(),
+            icon_fn: icon_for_button(snapshot, button),
+            enabled: button.enabled,
+        })
+        .collect()
 }
 
-fn build_view_action_buttons(snapshot: &ToolbarSnapshot) -> [ActionButton; 4] {
-    [
-        ActionButton {
-            event: ToolbarEvent::ZoomIn,
-            icon_fn: toolbar_icons::draw_icon_zoom_in as ActionIconFn,
-            enabled: true,
-        },
-        ActionButton {
-            event: ToolbarEvent::ZoomOut,
-            icon_fn: toolbar_icons::draw_icon_zoom_out as ActionIconFn,
-            enabled: true,
-        },
-        ActionButton {
-            event: ToolbarEvent::ResetZoom,
-            icon_fn: toolbar_icons::draw_icon_zoom_reset as ActionIconFn,
-            enabled: snapshot.zoom_active,
-        },
-        ActionButton {
-            event: ToolbarEvent::ToggleZoomLock,
-            icon_fn: if snapshot.zoom_locked {
+fn icon_group_columns(group: &ToolbarCommandGroup) -> usize {
+    match group.kind {
+        ToolbarCommandGroupKind::BasicActions => group.buttons.len(),
+        ToolbarCommandGroupKind::ViewActions | ToolbarCommandGroupKind::AdvancedActions => 5,
+        ToolbarCommandGroupKind::Pages | ToolbarCommandGroupKind::Boards => group.buttons.len(),
+    }
+}
+
+fn text_group_layout(
+    content_width: f64,
+    action_col_gap: f64,
+    kind: ToolbarCommandGroupKind,
+) -> (f64, usize, f64, bool) {
+    match kind {
+        ToolbarCommandGroupKind::BasicActions => (content_width, 1, 0.0, false),
+        ToolbarCommandGroupKind::ViewActions => (
+            row_item_width(content_width, 2, action_col_gap),
+            2,
+            action_col_gap,
+            true,
+        ),
+        ToolbarCommandGroupKind::AdvancedActions => (
+            row_item_width(content_width, 2, action_col_gap),
+            2,
+            action_col_gap,
+            false,
+        ),
+        ToolbarCommandGroupKind::Pages | ToolbarCommandGroupKind::Boards => {
+            (content_width, 1, 0.0, false)
+        }
+    }
+}
+
+fn icon_for_button(snapshot: &ToolbarSnapshot, button: &ToolbarButtonModel) -> ActionIconFn {
+    match &button.event {
+        ToolbarEvent::Undo => toolbar_icons::draw_icon_undo as ActionIconFn,
+        ToolbarEvent::Redo => toolbar_icons::draw_icon_redo as ActionIconFn,
+        ToolbarEvent::ClearCanvas => toolbar_icons::draw_icon_clear as ActionIconFn,
+        ToolbarEvent::ZoomIn => toolbar_icons::draw_icon_zoom_in as ActionIconFn,
+        ToolbarEvent::ZoomOut => toolbar_icons::draw_icon_zoom_out as ActionIconFn,
+        ToolbarEvent::ResetZoom => toolbar_icons::draw_icon_zoom_reset as ActionIconFn,
+        ToolbarEvent::ToggleZoomLock => {
+            if snapshot.zoom_locked {
                 toolbar_icons::draw_icon_lock as ActionIconFn
             } else {
                 toolbar_icons::draw_icon_unlock as ActionIconFn
-            },
-            enabled: snapshot.zoom_active,
-        },
-    ]
-}
-
-fn build_advanced_action_buttons(
-    snapshot: &ToolbarSnapshot,
-    show_delay_actions: bool,
-) -> Vec<ActionButton> {
-    let mut actions = Vec::with_capacity(6);
-
-    actions.push(ActionButton {
-        event: ToolbarEvent::UndoAll,
-        icon_fn: toolbar_icons::draw_icon_undo_all as ActionIconFn,
-        enabled: snapshot.undo_available,
-    });
-    actions.push(ActionButton {
-        event: ToolbarEvent::RedoAll,
-        icon_fn: toolbar_icons::draw_icon_redo_all as ActionIconFn,
-        enabled: snapshot.redo_available,
-    });
-
-    if show_delay_actions {
-        actions.push(ActionButton {
-            event: ToolbarEvent::UndoAllDelayed,
-            icon_fn: toolbar_icons::draw_icon_undo_all_delay as ActionIconFn,
-            enabled: snapshot.undo_available,
-        });
-        actions.push(ActionButton {
-            event: ToolbarEvent::RedoAllDelayed,
-            icon_fn: toolbar_icons::draw_icon_redo_all_delay as ActionIconFn,
-            enabled: snapshot.redo_available,
-        });
+            }
+        }
+        ToolbarEvent::UndoAll => toolbar_icons::draw_icon_undo_all as ActionIconFn,
+        ToolbarEvent::RedoAll => toolbar_icons::draw_icon_redo_all as ActionIconFn,
+        ToolbarEvent::UndoAllDelayed => toolbar_icons::draw_icon_undo_all_delay as ActionIconFn,
+        ToolbarEvent::RedoAllDelayed => toolbar_icons::draw_icon_redo_all_delay as ActionIconFn,
+        ToolbarEvent::ToggleFreeze => {
+            if snapshot.frozen_active {
+                toolbar_icons::draw_icon_unfreeze as ActionIconFn
+            } else {
+                toolbar_icons::draw_icon_freeze as ActionIconFn
+            }
+        }
+        _ => toolbar_icons::draw_icon_clear as ActionIconFn,
     }
-
-    actions.push(ActionButton {
-        event: ToolbarEvent::ToggleFreeze,
-        icon_fn: if snapshot.frozen_active {
-            toolbar_icons::draw_icon_unfreeze as ActionIconFn
-        } else {
-            toolbar_icons::draw_icon_freeze as ActionIconFn
-        },
-        enabled: true,
-    });
-
-    actions
 }

--- a/src/backend/wayland/toolbar/render/side_palette/actions/helpers.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/actions/helpers.rs
@@ -2,8 +2,6 @@ use crate::backend::wayland::toolbar::events::HitKind;
 use crate::backend::wayland::toolbar::format_binding_label;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::rows::{centered_grid_layout, grid_layout};
-use crate::config::{Action, action_label, action_short_label};
-use crate::ui::toolbar::bindings::action_for_event;
 use crate::ui::toolbar::{ToolbarEvent, ToolbarSnapshot};
 use crate::ui_text::UiTextStyle;
 
@@ -169,47 +167,11 @@ pub(super) fn render_text_action_group(
 }
 
 pub(super) fn button_label(event: &ToolbarEvent, snapshot: &ToolbarSnapshot) -> &'static str {
-    match event {
-        ToolbarEvent::ToggleFreeze => {
-            if snapshot.frozen_active {
-                "Unfreeze"
-            } else {
-                action_short_label(Action::ToggleFrozenMode)
-            }
-        }
-        ToolbarEvent::ToggleZoomLock => {
-            if snapshot.zoom_locked {
-                "Unlock Zoom"
-            } else {
-                action_short_label(Action::ToggleZoomLock)
-            }
-        }
-        _ => action_for_event(event)
-            .map(action_short_label)
-            .unwrap_or("Action"),
-    }
+    event.short_label(snapshot, "Action")
 }
 
 fn tooltip_label(event: &ToolbarEvent, snapshot: &ToolbarSnapshot) -> &'static str {
-    match event {
-        ToolbarEvent::ToggleFreeze => {
-            if snapshot.frozen_active {
-                "Unfreeze"
-            } else {
-                action_label(Action::ToggleFrozenMode)
-            }
-        }
-        ToolbarEvent::ToggleZoomLock => {
-            if snapshot.zoom_locked {
-                "Unlock Zoom"
-            } else {
-                action_label(Action::ToggleZoomLock)
-            }
-        }
-        _ => action_for_event(event)
-            .map(action_label)
-            .unwrap_or("Action"),
-    }
+    event.tooltip_label(snapshot, "Action")
 }
 
 fn render_icon_action_button(

--- a/src/backend/wayland/toolbar/render/side_palette/arrow.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/arrow.rs
@@ -6,8 +6,7 @@ use super::SidePaletteLayout;
 use crate::backend::wayland::toolbar::events::HitKind;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
-use crate::input::Tool;
-use crate::ui::toolbar::ToolbarEvent;
+use crate::ui::toolbar::{ToolContext, ToolbarEvent};
 use crate::ui_text::{UiTextStyle, text_layout};
 
 pub(super) fn draw_arrow_section(layout: &mut SidePaletteLayout, y: &mut f64) {
@@ -33,8 +32,7 @@ pub(super) fn draw_arrow_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         size: FONT_SIZE_SMALL,
     };
 
-    let show_arrow_controls = snapshot.active_tool == Tool::Arrow || snapshot.arrow_label_enabled;
-    if !show_arrow_controls {
+    if !ToolContext::from_snapshot(snapshot).show_arrow_labels {
         return;
     }
 

--- a/src/backend/wayland/toolbar/render/side_palette/boards.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/boards.rs
@@ -4,11 +4,9 @@ use crate::backend::wayland::toolbar::format_binding_label;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
 use crate::backend::wayland::toolbar::rows::{grid_layout, row_item_width};
-use crate::config::{action_label, action_short_label};
-use crate::input::ToolbarDrawerTab;
 use crate::toolbar_icons;
 use crate::ui::toolbar::ToolbarEvent;
-use crate::ui::toolbar::bindings::action_for_event;
+use crate::ui::toolbar::model::toolbar_boards_model;
 use crate::ui_text::UiTextStyle;
 
 use super::super::widgets::constants::{FONT_FAMILY_DEFAULT, FONT_SIZE_LABEL};
@@ -32,12 +30,9 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         size: FONT_SIZE_LABEL,
     };
 
-    if !snapshot.show_boards_section
-        || !snapshot.drawer_open
-        || snapshot.drawer_tab != ToolbarDrawerTab::View
-    {
+    let Some(model) = toolbar_boards_model(snapshot) else {
         return;
-    }
+    };
 
     let boards_card_h = layout.spec.side_boards_height(snapshot);
     draw_group_card(ctx, card_x, *y, card_w, boards_card_h);
@@ -71,37 +66,7 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let can_cycle = snapshot.board_count > 1;
-    let can_duplicate = !snapshot.is_transparent;
-    let buttons = [
-        (
-            ToolbarEvent::BoardPrev,
-            toolbar_icons::draw_icon_chevron_left as fn(&cairo::Context, f64, f64, f64),
-            can_cycle,
-        ),
-        (
-            ToolbarEvent::BoardNext,
-            toolbar_icons::draw_icon_chevron_right as fn(&cairo::Context, f64, f64, f64),
-            can_cycle,
-        ),
-        (
-            ToolbarEvent::BoardNew,
-            toolbar_icons::draw_icon_plus as fn(&cairo::Context, f64, f64, f64),
-            true,
-        ),
-        (
-            ToolbarEvent::BoardDuplicate,
-            toolbar_icons::draw_icon_copy as fn(&cairo::Context, f64, f64, f64),
-            can_duplicate,
-        ),
-        (
-            ToolbarEvent::BoardDelete,
-            toolbar_icons::draw_icon_clear as fn(&cairo::Context, f64, f64, f64),
-            true,
-        ),
-    ];
-
-    let cols = buttons.len().min(5);
+    let cols = model.buttons.len().min(5).max(1);
     let btn_w = row_item_width(content_width, cols, btn_gap);
     let layout = grid_layout(
         x,
@@ -110,19 +75,19 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         btn_h,
         btn_gap,
         btn_gap,
-        buttons.len(),
+        model.buttons.len(),
         cols,
     );
-    for (item, (evt, icon_fn, enabled)) in layout.items.iter().zip(buttons.iter()) {
-        let label = button_label(evt);
+    for (item, button) in layout.items.iter().zip(model.buttons.iter()) {
+        let label = button.short_label(snapshot, "Board");
         let bx = item.x;
         let by = item.y;
         let is_hover = hover
             .map(|(hx, hy)| point_in_rect(hx, hy, bx, by, btn_w, btn_h))
             .unwrap_or(false);
-        draw_button(ctx, bx, by, btn_w, btn_h, *enabled, is_hover);
+        draw_button(ctx, bx, by, btn_w, btn_h, button.enabled, is_hover);
         if use_icons {
-            if *enabled {
+            if button.enabled {
                 set_icon_color(ctx, is_hover);
             } else {
                 ctx.set_source_rgba(0.5, 0.5, 0.55, 0.5);
@@ -130,18 +95,18 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
             let icon_size = ToolbarLayoutSpec::SIDE_ACTION_ICON_SIZE;
             let icon_x = bx + (btn_w - icon_size) / 2.0;
             let icon_y = by + (btn_h - icon_size) / 2.0;
-            icon_fn(ctx, icon_x, icon_y, icon_size);
+            board_icon(&button.event)(ctx, icon_x, icon_y, icon_size);
         } else {
             draw_label_center(ctx, label_style, bx, by, btn_w, btn_h, label);
         }
-        if *enabled {
+        if button.enabled {
             hits.push(HitRegion {
                 rect: (bx, by, btn_w, btn_h),
-                event: evt.clone(),
+                event: button.event.clone(),
                 kind: HitKind::Click,
                 tooltip: Some(format_binding_label(
-                    tooltip_label(evt),
-                    snapshot.binding_hints.binding_for_event(evt),
+                    button.tooltip_label(snapshot, "Board"),
+                    button.binding_hint(snapshot),
                 )),
             });
         }
@@ -150,12 +115,13 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
     *y += boards_card_h + section_gap;
 }
 
-fn button_label(event: &ToolbarEvent) -> &'static str {
-    action_for_event(event)
-        .map(action_short_label)
-        .unwrap_or("Board")
-}
-
-fn tooltip_label(event: &ToolbarEvent) -> &'static str {
-    action_for_event(event).map(action_label).unwrap_or("Board")
+fn board_icon(event: &ToolbarEvent) -> fn(&cairo::Context, f64, f64, f64) {
+    match event {
+        ToolbarEvent::BoardPrev => toolbar_icons::draw_icon_chevron_left,
+        ToolbarEvent::BoardNext => toolbar_icons::draw_icon_chevron_right,
+        ToolbarEvent::BoardNew => toolbar_icons::draw_icon_plus,
+        ToolbarEvent::BoardDuplicate => toolbar_icons::draw_icon_copy,
+        ToolbarEvent::BoardDelete => toolbar_icons::draw_icon_clear,
+        _ => toolbar_icons::draw_icon_clear,
+    }
 }

--- a/src/backend/wayland/toolbar/render/side_palette/boards.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/boards.rs
@@ -3,7 +3,7 @@ use crate::backend::wayland::toolbar::events::HitKind;
 use crate::backend::wayland::toolbar::format_binding_label;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
-use crate::backend::wayland::toolbar::rows::{grid_layout, row_item_width};
+use crate::backend::wayland::toolbar::rows::{capped_grid_columns, grid_layout, row_item_width};
 use crate::toolbar_icons;
 use crate::ui::toolbar::ToolbarEvent;
 use crate::ui::toolbar::model::toolbar_boards_model;
@@ -66,7 +66,7 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let cols = model.buttons.len().clamp(1, 5);
+    let cols = capped_grid_columns(model.buttons.len(), 5);
     let btn_w = row_item_width(content_width, cols, btn_gap);
     let layout = grid_layout(
         x,

--- a/src/backend/wayland/toolbar/render/side_palette/boards.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/boards.rs
@@ -66,7 +66,7 @@ pub(super) fn draw_boards_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let cols = model.buttons.len().min(5).max(1);
+    let cols = model.buttons.len().clamp(1, 5);
     let btn_w = row_item_width(content_width, cols, btn_gap);
     let layout = grid_layout(
         x,

--- a/src/backend/wayland/toolbar/render/side_palette/marker.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/marker.rs
@@ -8,7 +8,7 @@ use crate::backend::wayland::toolbar::events::HitKind;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
 use crate::toolbar_icons;
-use crate::ui::toolbar::ToolbarEvent;
+use crate::ui::toolbar::{ToolContext, ToolbarEvent};
 use crate::ui_text::UiTextStyle;
 
 pub(super) fn draw_marker_opacity_section(layout: &mut SidePaletteLayout, y: &mut f64) {
@@ -28,9 +28,7 @@ pub(super) fn draw_marker_opacity_section(layout: &mut SidePaletteLayout, y: &mu
         size: FONT_SIZE_LABEL,
     };
 
-    let show_marker_opacity =
-        snapshot.show_marker_opacity_section || snapshot.thickness_targets_marker;
-    if !show_marker_opacity {
+    if !ToolContext::from_snapshot(snapshot).show_marker_opacity {
         return;
     }
 

--- a/src/backend/wayland/toolbar/render/side_palette/pages.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/pages.rs
@@ -4,11 +4,9 @@ use crate::backend::wayland::toolbar::format_binding_label;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
 use crate::backend::wayland::toolbar::rows::{grid_layout, row_item_width};
-use crate::config::{action_label, action_short_label};
-use crate::input::ToolbarDrawerTab;
 use crate::toolbar_icons;
 use crate::ui::toolbar::ToolbarEvent;
-use crate::ui::toolbar::bindings::action_for_event;
+use crate::ui::toolbar::model::toolbar_pages_model;
 use crate::ui_text::UiTextStyle;
 
 use super::super::widgets::constants::{FONT_FAMILY_DEFAULT, FONT_SIZE_LABEL};
@@ -32,12 +30,9 @@ pub(super) fn draw_pages_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         size: FONT_SIZE_LABEL,
     };
 
-    if !snapshot.show_pages_section
-        || !snapshot.drawer_open
-        || snapshot.drawer_tab != ToolbarDrawerTab::View
-    {
+    let Some(model) = toolbar_pages_model(snapshot) else {
         return;
-    }
+    };
 
     let pages_card_h = layout.spec.side_pages_height(snapshot);
     draw_group_card(ctx, card_x, *y, card_w, pages_card_h);
@@ -56,37 +51,7 @@ pub(super) fn draw_pages_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         ToolbarLayoutSpec::SIDE_ACTION_BUTTON_HEIGHT_TEXT
     };
     let btn_gap = ToolbarLayoutSpec::SIDE_ACTION_BUTTON_GAP;
-    let can_prev = snapshot.page_index > 0;
-    let can_next = snapshot.page_index + 1 < snapshot.page_count;
-    let buttons = [
-        (
-            ToolbarEvent::PagePrev,
-            toolbar_icons::draw_icon_chevron_left as fn(&cairo::Context, f64, f64, f64),
-            can_prev,
-        ),
-        (
-            ToolbarEvent::PageNext,
-            toolbar_icons::draw_icon_chevron_right as fn(&cairo::Context, f64, f64, f64),
-            can_next,
-        ),
-        (
-            ToolbarEvent::PageNew,
-            toolbar_icons::draw_icon_plus as fn(&cairo::Context, f64, f64, f64),
-            true,
-        ),
-        (
-            ToolbarEvent::PageDuplicate,
-            toolbar_icons::draw_icon_copy as fn(&cairo::Context, f64, f64, f64),
-            true,
-        ),
-        (
-            ToolbarEvent::PageDelete,
-            toolbar_icons::draw_icon_clear as fn(&cairo::Context, f64, f64, f64),
-            true,
-        ),
-    ];
-
-    let btn_w = row_item_width(content_width, buttons.len(), btn_gap);
+    let btn_w = row_item_width(content_width, model.buttons.len(), btn_gap);
     let layout = grid_layout(
         x,
         pages_y,
@@ -94,19 +59,19 @@ pub(super) fn draw_pages_section(layout: &mut SidePaletteLayout, y: &mut f64) {
         btn_h,
         btn_gap,
         0.0,
-        buttons.len(),
-        buttons.len(),
+        model.buttons.len(),
+        model.buttons.len(),
     );
-    for (item, (evt, icon_fn, enabled)) in layout.items.iter().zip(buttons.iter()) {
-        let label = button_label(evt);
+    for (item, button) in layout.items.iter().zip(model.buttons.iter()) {
+        let label = button.short_label(snapshot, "Page");
         let bx = item.x;
         let by = item.y;
         let is_hover = hover
             .map(|(hx, hy)| point_in_rect(hx, hy, bx, by, btn_w, btn_h))
             .unwrap_or(false);
-        draw_button(ctx, bx, by, btn_w, btn_h, *enabled, is_hover);
+        draw_button(ctx, bx, by, btn_w, btn_h, button.enabled, is_hover);
         if use_icons {
-            if *enabled {
+            if button.enabled {
                 set_icon_color(ctx, is_hover);
             } else {
                 ctx.set_source_rgba(0.5, 0.5, 0.55, 0.5);
@@ -114,18 +79,18 @@ pub(super) fn draw_pages_section(layout: &mut SidePaletteLayout, y: &mut f64) {
             let icon_size = ToolbarLayoutSpec::SIDE_ACTION_ICON_SIZE;
             let icon_x = bx + (btn_w - icon_size) / 2.0;
             let icon_y = by + (btn_h - icon_size) / 2.0;
-            icon_fn(ctx, icon_x, icon_y, icon_size);
+            page_icon(&button.event)(ctx, icon_x, icon_y, icon_size);
         } else {
             draw_label_center(ctx, label_style, bx, by, btn_w, btn_h, label);
         }
-        if *enabled {
+        if button.enabled {
             hits.push(HitRegion {
                 rect: (bx, by, btn_w, btn_h),
-                event: evt.clone(),
+                event: button.event.clone(),
                 kind: HitKind::Click,
                 tooltip: Some(format_binding_label(
-                    tooltip_label(evt),
-                    snapshot.binding_hints.binding_for_event(evt),
+                    button.tooltip_label(snapshot, "Page"),
+                    button.binding_hint(snapshot),
                 )),
             });
         }
@@ -134,12 +99,13 @@ pub(super) fn draw_pages_section(layout: &mut SidePaletteLayout, y: &mut f64) {
     *y += pages_card_h + section_gap;
 }
 
-fn button_label(event: &ToolbarEvent) -> &'static str {
-    action_for_event(event)
-        .map(action_short_label)
-        .unwrap_or("Page")
-}
-
-fn tooltip_label(event: &ToolbarEvent) -> &'static str {
-    action_for_event(event).map(action_label).unwrap_or("Page")
+fn page_icon(event: &ToolbarEvent) -> fn(&cairo::Context, f64, f64, f64) {
+    match event {
+        ToolbarEvent::PagePrev => toolbar_icons::draw_icon_chevron_left,
+        ToolbarEvent::PageNext => toolbar_icons::draw_icon_chevron_right,
+        ToolbarEvent::PageNew => toolbar_icons::draw_icon_plus,
+        ToolbarEvent::PageDuplicate => toolbar_icons::draw_icon_copy,
+        ToolbarEvent::PageDelete => toolbar_icons::draw_icon_clear,
+        _ => toolbar_icons::draw_icon_clear,
+    }
 }

--- a/src/backend/wayland/toolbar/render/side_palette/step_marker.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/step_marker.rs
@@ -6,8 +6,7 @@ use super::SidePaletteLayout;
 use crate::backend::wayland::toolbar::events::HitKind;
 use crate::backend::wayland::toolbar::hit::HitRegion;
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
-use crate::input::Tool;
-use crate::ui::toolbar::ToolbarEvent;
+use crate::ui::toolbar::{ToolContext, ToolbarEvent};
 use crate::ui_text::{UiTextStyle, text_layout};
 
 pub(super) fn draw_step_marker_section(layout: &mut SidePaletteLayout, y: &mut f64) {
@@ -33,7 +32,7 @@ pub(super) fn draw_step_marker_section(layout: &mut SidePaletteLayout, y: &mut f
         size: FONT_SIZE_SMALL,
     };
 
-    if snapshot.active_tool != Tool::StepMarker {
+    if !ToolContext::from_snapshot(snapshot).show_step_counter {
         return;
     }
 

--- a/src/backend/wayland/toolbar/render/side_palette/thickness.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/thickness.rs
@@ -11,7 +11,7 @@ use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
 use crate::config::Action;
 use crate::input::EraserMode;
 use crate::toolbar_icons;
-use crate::ui::toolbar::ToolbarEvent;
+use crate::ui::toolbar::{ToolContext, ToolbarEvent};
 use crate::ui_text::UiTextStyle;
 
 pub(super) fn draw_thickness_section(layout: &mut SidePaletteLayout, y: &mut f64) {
@@ -31,14 +31,11 @@ pub(super) fn draw_thickness_section(layout: &mut SidePaletteLayout, y: &mut f64
         weight: cairo::FontWeight::Bold,
         size: FONT_SIZE_LABEL,
     };
+    let tool_context = ToolContext::from_snapshot(snapshot);
 
     let slider_card_h = ToolbarLayoutSpec::SIDE_SLIDER_CARD_HEIGHT;
     draw_group_card(ctx, card_x, *y, card_w, slider_card_h);
-    let thickness_label = if snapshot.thickness_targets_eraser {
-        "Eraser size"
-    } else {
-        "Thickness"
-    };
+    let thickness_label = tool_context.thickness_label;
     draw_section_label(
         ctx,
         label_style,
@@ -151,7 +148,7 @@ pub(super) fn draw_thickness_section(layout: &mut SidePaletteLayout, y: &mut f64
     );
     *y += slider_card_h + section_gap;
 
-    if snapshot.thickness_targets_eraser {
+    if tool_context.show_eraser_mode {
         let eraser_card_h = ToolbarLayoutSpec::SIDE_ERASER_MODE_CARD_HEIGHT;
         let toggle_h = ToolbarLayoutSpec::SIDE_TOGGLE_HEIGHT;
         let toggle_w = content_width;

--- a/src/backend/wayland/toolbar/rows.rs
+++ b/src/backend/wayland/toolbar/rows.rs
@@ -24,6 +24,13 @@ pub(in crate::backend::wayland::toolbar) fn row_item_width(
     (content_width - gap * (columns as f64 - 1.0)) / columns as f64
 }
 
+pub(in crate::backend::wayland::toolbar) fn capped_grid_columns(
+    item_count: usize,
+    max_columns: usize,
+) -> usize {
+    item_count.clamp(1, max_columns.max(1))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(in crate::backend::wayland::toolbar) fn grid_layout(
     start_x: f64,
@@ -128,6 +135,14 @@ mod tests {
         assert_eq!(layout.rows, 3);
         assert_eq!(layout.items.len(), 7);
         assert!((layout.height - 36.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn capped_grid_columns_stays_between_one_and_limit() {
+        assert_eq!(capped_grid_columns(0, 5), 1);
+        assert_eq!(capped_grid_columns(1, 5), 1);
+        assert_eq!(capped_grid_columns(5, 5), 5);
+        assert_eq!(capped_grid_columns(6, 5), 5);
     }
 
     #[test]

--- a/src/config/types/presets.rs
+++ b/src/config/types/presets.rs
@@ -2,7 +2,7 @@ use crate::config::{MouseDragToolsConfig, enums::ColorSpec};
 use crate::draw::{Color, EraserKind};
 use crate::input::{
     EraserMode, Tool,
-    tool::{PerToolDrawingSettings, ToolDrawingSettings},
+    tool::{PerToolDrawingSettings, ToolDrawingSettings, ToolSettingsSlot, ToolSizeSource},
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -158,71 +158,52 @@ impl PresetToolStatesConfig {
     }
 
     pub fn color_spec_for_tool(&self, tool: Tool) -> ColorSpec {
-        match tool {
-            Tool::Pen | Tool::Select | Tool::Highlight | Tool::Eraser => self.pen.color.clone(),
-            Tool::Line => self.line.color.clone(),
-            Tool::Rect => self.rect.color.clone(),
-            Tool::Ellipse => self.ellipse.color.clone(),
-            Tool::Arrow => self.arrow.color.clone(),
-            Tool::Blur => self.blur.color.clone(),
-            Tool::Marker => self.marker.color.clone(),
-            Tool::StepMarker => self.step_marker.color.clone(),
-        }
+        self.setting_for_slot(tool.settings_slot()).color.clone()
     }
 
     pub fn size_for_tool(&self, tool: Tool) -> f64 {
-        match tool {
-            Tool::Eraser => self.eraser_size,
-            Tool::Pen | Tool::Select | Tool::Highlight => self.pen.size,
-            Tool::Line => self.line.size,
-            Tool::Rect => self.rect.size,
-            Tool::Ellipse => self.ellipse.size,
-            Tool::Arrow => self.arrow.size,
-            Tool::Blur => self.blur.size,
-            Tool::Marker => self.marker.size,
-            Tool::StepMarker => self.step_marker.size,
+        let profile = tool.profile();
+        match profile.size_source {
+            ToolSizeSource::EraserSize => self.eraser_size,
+            ToolSizeSource::DrawingThickness => self.setting_for_slot(profile.settings_slot).size,
         }
     }
 
     #[allow(dead_code)]
     pub fn set_preview_tool(&mut self, tool: Tool, color: ColorSpec, size: f64) {
-        match tool {
-            Tool::Eraser => {
-                self.pen.color = color;
-                self.eraser_size = size;
+        let profile = tool.profile();
+        self.setting_for_slot_mut(profile.settings_slot).color = color;
+        match profile.size_source {
+            ToolSizeSource::EraserSize => self.eraser_size = size,
+            ToolSizeSource::DrawingThickness => {
+                self.setting_for_slot_mut(profile.settings_slot).size = size;
             }
-            Tool::Pen | Tool::Select | Tool::Highlight => {
-                self.pen.color = color;
-                self.pen.size = size;
-            }
-            Tool::Line => {
-                self.line.color = color;
-                self.line.size = size;
-            }
-            Tool::Rect => {
-                self.rect.color = color;
-                self.rect.size = size;
-            }
-            Tool::Ellipse => {
-                self.ellipse.color = color;
-                self.ellipse.size = size;
-            }
-            Tool::Arrow => {
-                self.arrow.color = color;
-                self.arrow.size = size;
-            }
-            Tool::Blur => {
-                self.blur.color = color;
-                self.blur.size = size;
-            }
-            Tool::Marker => {
-                self.marker.color = color;
-                self.marker.size = size;
-            }
-            Tool::StepMarker => {
-                self.step_marker.color = color;
-                self.step_marker.size = size;
-            }
+        }
+    }
+
+    fn setting_for_slot(&self, slot: ToolSettingsSlot) -> &PresetToolSettingConfig {
+        match slot {
+            ToolSettingsSlot::Pen => &self.pen,
+            ToolSettingsSlot::Line => &self.line,
+            ToolSettingsSlot::Rect => &self.rect,
+            ToolSettingsSlot::Ellipse => &self.ellipse,
+            ToolSettingsSlot::Arrow => &self.arrow,
+            ToolSettingsSlot::Blur => &self.blur,
+            ToolSettingsSlot::Marker => &self.marker,
+            ToolSettingsSlot::StepMarker => &self.step_marker,
+        }
+    }
+
+    fn setting_for_slot_mut(&mut self, slot: ToolSettingsSlot) -> &mut PresetToolSettingConfig {
+        match slot {
+            ToolSettingsSlot::Pen => &mut self.pen,
+            ToolSettingsSlot::Line => &mut self.line,
+            ToolSettingsSlot::Rect => &mut self.rect,
+            ToolSettingsSlot::Ellipse => &mut self.ellipse,
+            ToolSettingsSlot::Arrow => &mut self.arrow,
+            ToolSettingsSlot::Blur => &mut self.blur,
+            ToolSettingsSlot::Marker => &mut self.marker,
+            ToolSettingsSlot::StepMarker => &mut self.step_marker,
         }
     }
 }

--- a/src/input/boards/core.rs
+++ b/src/input/boards/core.rs
@@ -195,10 +195,11 @@ impl BoardManager {
 
     /// Insert a board at the given index.
     /// Returns true if successful, false if the board limit is reached.
-    pub fn insert_board(&mut self, index: usize, board: BoardState) -> bool {
+    pub fn insert_board(&mut self, index: usize, mut board: BoardState) -> bool {
         if self.boards.len() >= self.max_count {
             return false;
         }
+        board.spec.id = self.unique_board_id(board.spec.id.clone());
         let insert_at = index.min(self.boards.len());
         self.boards.insert(insert_at, board);
         self.active_index = insert_at;

--- a/src/input/boards/naming.rs
+++ b/src/input/boards/naming.rs
@@ -1,6 +1,11 @@
 use super::{BOARD_ID_TRANSPARENT, BoardBackground, BoardManager, BoardSpec, BoardState};
 
 impl BoardManager {
+    pub fn can_switch_to_id(&self, id: &str) -> bool {
+        self.switch_to_id_target_index(id)
+            .is_some_and(|index| index != self.active_index)
+    }
+
     pub fn switch_to_id(&mut self, id: &str) -> bool {
         if let Some(index) = self.boards.iter().position(|board| board.spec.id == id) {
             self.active_index = index;
@@ -15,6 +20,11 @@ impl BoardManager {
             return false;
         };
         self.switch_to_slot(desired_slot)
+    }
+
+    pub fn can_switch_to_slot(&self, slot: usize) -> bool {
+        self.switch_to_slot_target_index(slot)
+            .is_some_and(|index| index != self.active_index)
     }
 
     pub fn switch_to_slot(&mut self, slot: usize) -> bool {
@@ -41,6 +51,29 @@ impl BoardManager {
 
         self.active_index = slot;
         true
+    }
+
+    fn switch_to_id_target_index(&self, id: &str) -> Option<usize> {
+        if let Some(index) = self.boards.iter().position(|board| board.spec.id == id) {
+            return Some(index);
+        }
+
+        if !self.auto_create {
+            return None;
+        }
+
+        self.switch_to_slot_target_index(parse_board_slot(id)?)
+    }
+
+    fn switch_to_slot_target_index(&self, slot: usize) -> Option<usize> {
+        if slot >= self.max_count {
+            return None;
+        }
+        if slot < self.boards.len() || self.auto_create {
+            Some(slot)
+        } else {
+            None
+        }
     }
 
     pub fn ensure_board(&mut self, id: &str) -> Option<&mut BoardState> {

--- a/src/input/boards/naming.rs
+++ b/src/input/boards/naming.rs
@@ -139,7 +139,7 @@ impl BoardManager {
         Some(new_spec.id)
     }
 
-    fn unique_board_id(&self, base: String) -> String {
+    pub(super) fn unique_board_id(&self, base: String) -> String {
         if !self.boards.iter().any(|board| board.spec.id == base) {
             return base;
         }

--- a/src/input/state/actions/action_core.rs
+++ b/src/input/state/actions/action_core.rs
@@ -6,50 +6,13 @@ impl InputState {
     pub(super) fn handle_core_action(&mut self, action: Action) -> bool {
         match action {
             Action::Exit => {
-                // Exit drawing mode or cancel current action
-                match &self.state {
-                    DrawingState::TextInput { .. } => {
-                        self.cancel_text_input();
-                    }
-                    DrawingState::PendingTextClick { .. } => {
-                        self.state = DrawingState::Idle;
-                    }
-                    DrawingState::Drawing { .. } => {
-                        self.clear_provisional_dirty();
-                        self.last_provisional_bounds = None;
-                        self.state = DrawingState::Idle;
-                        self.needs_redraw = true;
-                    }
-                    DrawingState::MovingSelection { snapshots, .. } => {
-                        self.restore_selection_from_snapshots(snapshots.clone());
-                        self.state = DrawingState::Idle;
-                    }
-                    DrawingState::Selecting { .. } => {
-                        self.clear_provisional_dirty();
-                        self.last_provisional_bounds = None;
-                        self.state = DrawingState::Idle;
-                        self.needs_redraw = true;
-                    }
-                    DrawingState::ResizingText {
-                        shape_id, snapshot, ..
-                    } => {
-                        self.restore_selection_from_snapshots(vec![(*shape_id, snapshot.clone())]);
-                        self.state = DrawingState::Idle;
-                    }
-                    DrawingState::ResizingSelection { snapshots, .. } => {
-                        let snapshots = snapshots.clone();
-                        self.restore_resize_from_snapshots(snapshots.as_ref());
-                        self.state = DrawingState::Idle;
-                    }
-                    DrawingState::Idle => {
-                        // Exit application
-                        self.should_exit = true;
-                    }
-                }
-                if matches!(self.state, DrawingState::Idle) {
+                if self.try_cancel_active_interaction() {
+                    true
+                } else {
+                    self.should_exit = true;
                     self.end_pointer_drag();
+                    true
                 }
-                true
             }
             Action::EnterTextMode => {
                 if matches!(self.state, DrawingState::Idle) {

--- a/src/input/state/actions/key_press/mod.rs
+++ b/src/input/state/actions/key_press/mod.rs
@@ -130,9 +130,7 @@ impl InputState {
             && let DrawingState::Drawing { .. } = &self.state
             && let Some(Action::Exit) = self.find_action("Escape")
         {
-            self.state = DrawingState::Idle;
-            self.end_pointer_drag();
-            self.needs_redraw = true;
+            self.try_cancel_active_interaction();
             return;
         }
 

--- a/src/input/state/core/board/delete_restore.rs
+++ b/src/input/state/core/board/delete_restore.rs
@@ -76,11 +76,17 @@ impl InputState {
         }
         self.pending_board_delete = None;
 
-        // Save board state before deletion for potential undo
+        self.cancel_active_interaction();
+
+        // Save board state after cancellation for potential undo.
         let deleted_board = self.boards.active_board().clone();
         let deleted_name = deleted_board.spec.name.clone();
 
-        if self.switch_board_with(|boards| boards.remove_active_board(), &current_id) {
+        if self.switch_board_with(
+            |boards| boards.board_count() > 1,
+            |boards| boards.remove_active_board(),
+            &current_id,
+        ) {
             self.remove_board_recent(&current_id);
             self.queue_board_config_save();
 
@@ -102,7 +108,7 @@ impl InputState {
         // Expire old entries first
         self.expire_deleted_boards();
 
-        let Some((board, _timestamp)) = self.deleted_boards.pop() else {
+        let Some((board, timestamp)) = self.deleted_boards.pop() else {
             self.set_ui_toast(UiToastKind::Info, "No deleted board to restore.");
             return;
         };
@@ -111,12 +117,14 @@ impl InputState {
         let current_id = self.boards.active_board_id().to_string();
 
         if self.switch_board_with(
-            |boards| boards.insert_board(boards.board_count(), board),
+            |boards| boards.board_count() < boards.max_count(),
+            |boards| boards.insert_board(boards.board_count(), board.clone()),
             &current_id,
         ) {
             self.queue_board_config_save();
             self.set_ui_toast(UiToastKind::Info, format!("Board restored: {name}"));
         } else {
+            self.deleted_boards.push((board, timestamp));
             self.set_ui_toast(UiToastKind::Warning, "Board limit reached; cannot restore.");
         }
     }
@@ -135,6 +143,7 @@ impl InputState {
         board_index: usize,
         page_index: usize,
     ) -> crate::draw::PageDeleteOutcome {
+        let is_active_board = self.boards.active_index() == board_index;
         let Some(board) = self.boards.board_state_mut(board_index) else {
             return crate::draw::PageDeleteOutcome::Pending;
         };
@@ -146,13 +155,17 @@ impl InputState {
         let board_id = board.spec.id.clone();
 
         if page_count <= 1 {
+            if is_active_board {
+                self.cancel_active_interaction();
+            }
+            let Some(board) = self.boards.board_state_mut(board_index) else {
+                return crate::draw::PageDeleteOutcome::Pending;
+            };
             let outcome = board.pages.delete_page_at(page_index);
-            if self.boards.active_index() == board_index {
+            if is_active_board {
                 self.prepare_page_switch();
             } else {
-                self.dirty_tracker.mark_full();
-                self.needs_redraw = true;
-                self.mark_session_dirty();
+                self.mark_board_surface_changed();
             }
             self.set_ui_toast(
                 UiToastKind::Info,
@@ -193,15 +206,19 @@ impl InputState {
         }
 
         self.pending_page_delete = None;
+        if is_active_board {
+            self.cancel_active_interaction();
+        }
+        let Some(board) = self.boards.board_state_mut(board_index) else {
+            return crate::draw::PageDeleteOutcome::Pending;
+        };
         let outcome = board.pages.delete_page_at(page_index);
         let new_page_num = board.pages.active_index() + 1;
         let new_page_count = board.pages.page_count();
-        if self.boards.active_index() == board_index {
+        if is_active_board {
             self.prepare_page_switch();
         } else {
-            self.dirty_tracker.mark_full();
-            self.needs_redraw = true;
-            self.mark_session_dirty();
+            self.mark_board_surface_changed();
         }
         if matches!(outcome, crate::draw::PageDeleteOutcome::Removed) {
             self.set_ui_toast(
@@ -221,6 +238,7 @@ impl InputState {
 
         // If this is the last page, skip confirmation (just clears)
         if page_count <= 1 {
+            self.cancel_active_interaction();
             let outcome = self.boards.delete_page();
             self.prepare_page_switch();
             self.set_ui_toast(UiToastKind::Info, "Page cleared (last page)");
@@ -269,7 +287,9 @@ impl InputState {
         // Confirmed: proceed with deletion
         self.pending_page_delete = None;
 
-        // Save page before deletion for undo
+        self.cancel_active_interaction();
+
+        // Save page after cancellation for undo.
         let deleted_page = self.boards.active_pages().active_frame().clone();
 
         let outcome = self.boards.delete_page();
@@ -312,6 +332,7 @@ impl InputState {
 
         if let Some(idx) = position {
             let (_, page, _) = self.deleted_pages.remove(idx);
+            self.cancel_active_interaction();
             self.boards.insert_page(page);
             self.prepare_page_switch();
             let page_num = self.boards.active_page_index() + 1;

--- a/src/input/state/core/board/pages.rs
+++ b/src/input/state/core/board/pages.rs
@@ -11,9 +11,7 @@ impl InputState {
             return false;
         }
         self.sync_canvas_pointer_to_current_transform();
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
-        self.mark_session_dirty();
+        self.mark_board_surface_changed();
         self.set_ui_toast(UiToastKind::Info, "Canvas position reset.");
         true
     }
@@ -32,8 +30,7 @@ impl InputState {
         }
         board.spec.name = trimmed.to_string();
         self.queue_board_config_save();
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
+        self.mark_board_surface_dirty();
         true
     }
 
@@ -61,8 +58,7 @@ impl InputState {
             self.set_pen_color_from_board(color);
         }
         self.queue_board_config_save();
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
+        self.mark_board_surface_dirty();
         true
     }
 
@@ -72,8 +68,7 @@ impl InputState {
         };
         board.spec.pinned = !board.spec.pinned;
         self.queue_board_config_save();
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
+        self.mark_board_surface_dirty();
         true
     }
 
@@ -82,8 +77,7 @@ impl InputState {
             return false;
         }
         self.queue_board_config_save();
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
+        self.mark_board_surface_dirty();
         true
     }
 
@@ -102,9 +96,7 @@ impl InputState {
         if self.boards.active_index() == board_index {
             self.prepare_page_switch();
         } else {
-            self.dirty_tracker.mark_full();
-            self.needs_redraw = true;
-            self.mark_session_dirty();
+            self.mark_board_surface_changed();
         }
         true
     }
@@ -121,9 +113,7 @@ impl InputState {
         if self.boards.active_index() == board_index {
             self.prepare_page_switch();
         } else {
-            self.dirty_tracker.mark_full();
-            self.needs_redraw = true;
-            self.mark_session_dirty();
+            self.mark_board_surface_changed();
         }
         self.set_ui_toast(
             UiToastKind::Info,
@@ -150,9 +140,7 @@ impl InputState {
         if self.boards.active_index() == board_index {
             self.prepare_page_switch();
         } else {
-            self.dirty_tracker.mark_full();
-            self.needs_redraw = true;
-            self.mark_session_dirty();
+            self.mark_board_surface_changed();
         }
         self.set_ui_toast(
             UiToastKind::Info,
@@ -176,9 +164,7 @@ impl InputState {
         if self.boards.active_index() == board_index {
             self.prepare_page_switch();
         } else {
-            self.dirty_tracker.mark_full();
-            self.needs_redraw = true;
-            self.mark_session_dirty();
+            self.mark_board_surface_changed();
         }
         self.set_ui_toast(UiToastKind::Info, "Page renamed.");
         true

--- a/src/input/state/core/board/switch.rs
+++ b/src/input/state/core/board/switch.rs
@@ -47,12 +47,20 @@ impl InputState {
             return;
         }
 
-        self.switch_board_with(|boards| boards.switch_to_id(&target_id), &current_id);
+        self.switch_board_with(
+            |boards| boards.can_switch_to_id(&target_id),
+            |boards| boards.switch_to_id(&target_id),
+            &current_id,
+        );
     }
 
     pub fn create_board(&mut self) -> bool {
         let current_id = self.boards.active_board_id().to_string();
-        let created = self.switch_board_with(|boards| boards.create_board(), &current_id);
+        let created = self.switch_board_with(
+            |boards| boards.board_count() < boards.max_count(),
+            |boards| boards.create_board(),
+            &current_id,
+        );
         if created {
             let name = self.boards.active_board_name().to_string();
             self.queue_board_config_save();
@@ -63,17 +71,29 @@ impl InputState {
 
     pub fn switch_board_slot(&mut self, slot: usize) {
         let current_id = self.boards.active_board_id().to_string();
-        self.switch_board_with(|boards| boards.switch_to_slot(slot), &current_id);
+        self.switch_board_with(
+            |boards| boards.can_switch_to_slot(slot),
+            |boards| boards.switch_to_slot(slot),
+            &current_id,
+        );
     }
 
     pub fn switch_board_next(&mut self) {
         let current_id = self.boards.active_board_id().to_string();
-        self.switch_board_with(|boards| boards.next_board(), &current_id);
+        self.switch_board_with(
+            |boards| boards.board_count() > 1,
+            |boards| boards.next_board(),
+            &current_id,
+        );
     }
 
     pub fn switch_board_prev(&mut self) {
         let current_id = self.boards.active_board_id().to_string();
-        self.switch_board_with(|boards| boards.prev_board(), &current_id);
+        self.switch_board_with(
+            |boards| boards.board_count() > 1,
+            |boards| boards.prev_board(),
+            &current_id,
+        );
     }
 
     /// Duplicate the active board.
@@ -84,6 +104,12 @@ impl InputState {
         }
 
         let current_id = self.boards.active_board_id().to_string();
+        if self.boards.board_count() >= self.boards.max_count() {
+            self.set_ui_toast(UiToastKind::Info, "Board limit reached.");
+            return;
+        }
+
+        self.cancel_active_interaction();
         if let Some(new_id) = self.boards.duplicate_active_board() {
             self.record_board_recent(&new_id);
             self.queue_board_config_save();
@@ -98,11 +124,7 @@ impl InputState {
                 self.set_pen_color_from_board(default_color);
             }
 
-            // Reset drawing state
-            self.state = super::super::base::DrawingState::Idle;
-            self.dirty_tracker.mark_full();
-            self.needs_redraw = true;
-            self.mark_session_dirty();
+            self.finish_active_board_transition();
 
             log::info!("Duplicated board '{}' to '{}'", current_id, new_id);
         } else {
@@ -129,16 +151,25 @@ impl InputState {
 
     pub(super) fn switch_board_with(
         &mut self,
+        can_switch: impl FnOnce(&crate::input::BoardManager) -> bool,
         switch: impl FnOnce(&mut crate::input::BoardManager) -> bool,
         current_id: &str,
     ) -> bool {
+        if !can_switch(&self.boards) {
+            return false;
+        }
+
         let current_spec = self.boards.active_board().spec.clone();
         let prev_count = self.boards.board_count();
-        if !switch(&mut self.boards) {
+        self.cancel_active_interaction();
+        let switched = switch(&mut self.boards);
+        debug_assert!(switched, "preflighted board transition failed on apply");
+        if !switched {
             return false;
         }
 
         let target_spec = self.boards.active_board().spec.clone();
+        debug_assert_ne!(target_spec.id, current_id);
         if target_spec.id == current_id {
             return false;
         }
@@ -184,14 +215,7 @@ impl InputState {
             }
         }
 
-        // Reset drawing state to prevent partial shapes crossing modes
-        self.state = super::super::base::DrawingState::Idle;
-        self.sync_canvas_pointer_to_current_transform();
-
-        // Trigger redraw
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
-        self.mark_session_dirty();
+        self.finish_active_board_transition();
 
         log::info!(
             "Switched from '{}' to '{}' board",
@@ -213,6 +237,21 @@ impl InputState {
         self.board_recent.retain(|id| id != board_id);
     }
 
+    pub(super) fn mark_board_surface_dirty(&mut self) {
+        self.dirty_tracker.mark_full();
+        self.needs_redraw = true;
+    }
+
+    pub(super) fn mark_board_surface_changed(&mut self) {
+        self.mark_board_surface_dirty();
+        self.mark_session_dirty();
+    }
+
+    fn finish_active_board_transition(&mut self) {
+        self.sync_canvas_pointer_to_current_transform();
+        self.mark_board_surface_changed();
+    }
+
     pub(crate) fn queue_board_config_save(&mut self) {
         if !self.boards.persist_customizations() {
             return;
@@ -226,8 +265,6 @@ impl InputState {
         self.close_context_menu();
         self.invalidate_hit_cache();
         self.sync_canvas_pointer_to_current_transform();
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
-        self.mark_session_dirty();
+        self.mark_board_surface_changed();
     }
 }

--- a/src/input/state/core/tool_controls/presets.rs
+++ b/src/input/state/core/tool_controls/presets.rs
@@ -45,7 +45,7 @@ impl InputState {
         } else {
             self.activate_preset_tool(preset.tool);
             let _ = self.set_color(preset.color.to_color());
-            if preset.tool == Tool::Eraser {
+            if preset.tool.uses_eraser_size() {
                 let _ = self.set_eraser_size(preset.size);
             } else if !legacy_step_marker_preset {
                 let _ = self.set_thickness(preset.size);

--- a/src/input/state/core/tool_controls/settings.rs
+++ b/src/input/state/core/tool_controls/settings.rs
@@ -21,9 +21,10 @@ impl InputState {
 
     /// Returns the stored size for a tool, using eraser size for the eraser.
     pub fn thickness_for_tool(&self, tool: Tool) -> f64 {
-        match tool {
-            Tool::Eraser => self.eraser_size,
-            _ => self.tool_settings.get(tool).thickness,
+        if tool.uses_eraser_size() {
+            self.eraser_size
+        } else {
+            self.tool_settings.get(tool).thickness
         }
     }
 
@@ -43,24 +44,21 @@ impl InputState {
     pub(crate) fn sync_current_settings_from_active_tool(&mut self) {
         let tool = self.active_tool();
         self.current_color = self.color_for_tool(tool);
-        if tool != Tool::Eraser {
+        if tool.uses_drawing_thickness() {
             self.current_thickness = self.thickness_for_tool(tool);
         }
     }
 
     pub(crate) fn sync_current_settings_for_tool(&mut self, tool: Tool) {
         self.current_color = self.color_for_tool(tool);
-        if tool != Tool::Eraser {
+        if tool.uses_drawing_thickness() {
             self.current_thickness = self.thickness_for_tool(tool);
         }
     }
 
     pub(crate) fn set_pen_color_from_board(&mut self, color: Color) {
         self.tool_settings.pen.color = color;
-        if matches!(
-            self.active_tool(),
-            Tool::Pen | Tool::Select | Tool::Highlight | Tool::Eraser
-        ) {
+        if PerToolDrawingSettings::settings_tool(self.active_tool()) == Tool::Pen {
             self.current_color = color;
         }
         self.sync_highlight_color();
@@ -71,9 +69,7 @@ impl InputState {
             return false;
         }
         self.tool_settings.get_mut(tool).color = color;
-        if PerToolDrawingSettings::settings_tool(self.active_tool())
-            == PerToolDrawingSettings::settings_tool(tool)
-        {
+        if self.active_tool().settings_slot() == tool.settings_slot() {
             self.current_color = color;
         }
         self.dirty_tracker.mark_full();
@@ -87,7 +83,7 @@ impl InputState {
     pub(crate) fn set_pressure_thickness_for_active_tool(&mut self, thickness: f64) -> f64 {
         let clamped = thickness.clamp(MIN_STROKE_THICKNESS, MAX_STROKE_THICKNESS);
         let tool = self.active_tool();
-        if tool != Tool::Eraser {
+        if tool.uses_drawing_thickness() {
             self.tool_settings.get_mut(tool).thickness = clamped;
         }
         self.current_thickness = clamped;
@@ -200,17 +196,20 @@ impl InputState {
 
     /// Sets thickness or eraser size depending on the active tool.
     pub fn set_thickness_for_active_tool(&mut self, value: f64) -> bool {
-        match self.active_tool() {
-            Tool::Eraser => self.set_eraser_size(value),
-            _ => self.set_thickness(value),
+        if self.active_tool().uses_eraser_size() {
+            self.set_eraser_size(value)
+        } else {
+            self.set_thickness(value)
         }
     }
 
     /// Nudges thickness or eraser size depending on the active tool.
     pub fn nudge_thickness_for_active_tool(&mut self, delta: f64) -> bool {
-        match self.active_tool() {
-            Tool::Eraser => self.set_eraser_size(self.eraser_size + delta),
-            tool => self.set_thickness(self.thickness_for_tool(tool) + delta),
+        let tool = self.active_tool();
+        if tool.uses_eraser_size() {
+            self.set_eraser_size(self.eraser_size + delta)
+        } else {
+            self.set_thickness(self.thickness_for_tool(tool) + delta)
         }
     }
 

--- a/src/input/state/core/utility/interaction.rs
+++ b/src/input/state/core/utility/interaction.rs
@@ -132,6 +132,18 @@ impl InputState {
         self.needs_redraw = true;
     }
 
+    /// Cancels the current interaction when one is active.
+    ///
+    /// Returns `true` when an active interaction consumed the caller's event.
+    pub(crate) fn try_cancel_active_interaction(&mut self) -> bool {
+        if matches!(self.state, DrawingState::Idle) {
+            return false;
+        }
+
+        self.cancel_active_interaction();
+        true
+    }
+
     /// Cancels any in-progress interaction without exiting the application.
     pub(crate) fn cancel_active_interaction(&mut self) {
         match &self.state {
@@ -187,8 +199,9 @@ impl InputState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::input::BOARD_ID_WHITEBOARD;
+    use crate::input::events::MouseButton;
     use crate::input::state::test_support::make_test_input_state;
+    use crate::input::{BOARD_ID_WHITEBOARD, Tool};
 
     #[test]
     fn update_pointer_position_synthetic_updates_pointer_without_redraw() {
@@ -270,6 +283,37 @@ mod tests {
 
         assert!(matches!(state.state, DrawingState::Idle));
         assert!(state.text_wrap_width.is_none());
+        assert!(state.needs_redraw);
+    }
+
+    #[test]
+    fn try_cancel_active_interaction_reports_false_when_idle() {
+        let mut state = make_test_input_state();
+        state.needs_redraw = false;
+
+        assert!(!state.try_cancel_active_interaction());
+
+        assert!(matches!(state.state, DrawingState::Idle));
+        assert!(!state.needs_redraw);
+    }
+
+    #[test]
+    fn try_cancel_active_interaction_cancels_drawing_and_ends_drag() {
+        let mut state = make_test_input_state();
+        state.state = DrawingState::Drawing {
+            tool: Tool::Pen,
+            start_x: 10,
+            start_y: 20,
+            points: vec![(10, 20), (30, 40)],
+            point_thicknesses: vec![1.0, 1.0],
+        };
+        state.begin_pointer_drag(MouseButton::Left, None);
+        state.needs_redraw = false;
+
+        assert!(state.try_cancel_active_interaction());
+
+        assert!(matches!(state.state, DrawingState::Idle));
+        assert!(state.active_drag_button.is_none());
         assert!(state.needs_redraw);
     }
 

--- a/src/input/state/mouse/press.rs
+++ b/src/input/state/mouse/press.rs
@@ -33,43 +33,7 @@ impl InputState {
     fn handle_right_click(&mut self, screen_x: i32, screen_y: i32, canvas_x: i32, canvas_y: i32) {
         self.update_pointer_positions(screen_x, screen_y, canvas_x, canvas_y);
         self.last_text_click = None;
-        if !matches!(self.state, DrawingState::Idle) {
-            match &self.state {
-                DrawingState::TextInput { .. } => {
-                    self.cancel_text_input();
-                }
-                DrawingState::MovingSelection { snapshots, .. } => {
-                    self.restore_selection_from_snapshots(snapshots.clone());
-                    self.state = DrawingState::Idle;
-                }
-                DrawingState::Selecting { .. } => {
-                    self.clear_provisional_dirty();
-                    self.last_provisional_bounds = None;
-                    self.state = DrawingState::Idle;
-                    self.needs_redraw = true;
-                }
-                DrawingState::ResizingText {
-                    shape_id, snapshot, ..
-                } => {
-                    self.restore_selection_from_snapshots(vec![(*shape_id, snapshot.clone())]);
-                    self.state = DrawingState::Idle;
-                }
-                DrawingState::ResizingSelection { snapshots, .. } => {
-                    let snapshots = snapshots.clone();
-                    self.restore_resize_from_snapshots(snapshots.as_ref());
-                    self.state = DrawingState::Idle;
-                }
-                DrawingState::PendingTextClick { .. } => {
-                    self.state = DrawingState::Idle;
-                }
-                _ => {
-                    self.clear_provisional_dirty();
-                    self.last_provisional_bounds = None;
-                    self.state = DrawingState::Idle;
-                    self.needs_redraw = true;
-                }
-            }
-            self.end_pointer_drag();
+        if self.try_cancel_active_interaction() {
             return;
         }
         if self.zoom_active() {

--- a/src/input/state/tests/boards.rs
+++ b/src/input/state/tests/boards.rs
@@ -1,6 +1,35 @@
 use super::*;
+use crate::draw::ShapeId;
 use crate::input::state::core::board_picker::BoardPickerState;
-use crate::input::{BOARD_ID_TRANSPARENT, BOARD_ID_WHITEBOARD};
+use crate::input::{BOARD_ID_TRANSPARENT, BOARD_ID_WHITEBOARD, BoardManager};
+
+fn board_index(state: &InputState, id: &str) -> usize {
+    state
+        .boards
+        .board_states()
+        .iter()
+        .position(|board| board.spec.id == id)
+        .expect("board index")
+}
+
+fn assert_board_text(state: &InputState, board_id: &str, shape_id: ShapeId, expected: &str) {
+    let index = board_index(state, board_id);
+    let shape = state.boards.board_states()[index]
+        .pages
+        .active_frame()
+        .shape(shape_id)
+        .expect("text shape");
+    match &shape.shape {
+        Shape::Text { text, .. } => assert_eq!(text, expected),
+        _ => panic!("Expected text shape"),
+    }
+}
+
+fn disable_board_auto_create(state: &mut InputState) {
+    let mut config = state.boards.to_config();
+    config.auto_create = false;
+    state.boards = BoardManager::from_config(config);
+}
 
 #[test]
 fn switch_board_force_does_not_toggle_back_to_transparent() {
@@ -65,6 +94,74 @@ fn switch_board_updates_open_board_picker_selection_and_clears_hover() {
 }
 
 #[test]
+fn switch_board_cancels_active_drawing_through_lifecycle_transition() {
+    let mut state = create_test_input_state();
+    state.state = DrawingState::Drawing {
+        tool: Tool::Pen,
+        start_x: 10,
+        start_y: 20,
+        points: vec![(10, 20), (30, 40)],
+        point_thicknesses: vec![1.0, 1.0],
+    };
+    state.begin_pointer_drag(MouseButton::Left, None);
+    state.needs_redraw = false;
+
+    state.switch_board(BOARD_ID_WHITEBOARD);
+
+    assert_eq!(state.board_id(), BOARD_ID_WHITEBOARD);
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.active_drag_button.is_none());
+    assert!(state.needs_redraw);
+}
+
+#[test]
+fn failed_switch_board_preserves_active_interaction() {
+    let mut state = create_test_input_state();
+    disable_board_auto_create(&mut state);
+    state.state = DrawingState::Drawing {
+        tool: Tool::Pen,
+        start_x: 10,
+        start_y: 20,
+        points: vec![(10, 20), (30, 40)],
+        point_thicknesses: vec![1.0, 1.0],
+    };
+    state.begin_pointer_drag(MouseButton::Left, None);
+    state.needs_redraw = false;
+
+    state.switch_board("missing-board");
+
+    assert_eq!(state.board_id(), BOARD_ID_TRANSPARENT);
+    assert!(matches!(state.state, DrawingState::Drawing { .. }));
+    assert_eq!(state.active_drag_button, Some(MouseButton::Left));
+    assert!(!state.needs_redraw);
+}
+
+#[test]
+fn switch_board_cancels_text_edit_on_source_board_before_switching() {
+    let mut state = create_test_input_state();
+    let shape_id = state.boards.active_frame_mut().add_shape(Shape::Text {
+        x: 40,
+        y: 80,
+        text: "Original".to_string(),
+        color: state.current_color,
+        size: state.current_font_size,
+        font_descriptor: state.font_descriptor.clone(),
+        background_enabled: state.text_background_enabled,
+        wrap_width: None,
+    });
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+    assert_board_text(&state, BOARD_ID_TRANSPARENT, shape_id, "");
+
+    state.switch_board(BOARD_ID_WHITEBOARD);
+
+    assert_eq!(state.board_id(), BOARD_ID_WHITEBOARD);
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.text_edit_target.is_none());
+    assert_board_text(&state, BOARD_ID_TRANSPARENT, shape_id, "Original");
+}
+
+#[test]
 fn duplicate_board_from_transparent_shows_info_toast_without_creating_board() {
     let mut state = create_test_input_state();
     let initial_count = state.boards.board_count();
@@ -77,6 +174,56 @@ fn duplicate_board_from_transparent_shows_info_toast_without_creating_board() {
         state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
         Some("Overlay board cannot be duplicated.")
     );
+}
+
+#[test]
+fn duplicate_board_cancels_text_input_through_lifecycle_transition() {
+    let mut state = create_test_input_state();
+    state.switch_board(BOARD_ID_WHITEBOARD);
+    let initial_count = state.boards.board_count();
+    state.text_wrap_width = Some(240);
+    state.state = DrawingState::TextInput {
+        x: 10,
+        y: 20,
+        buffer: "draft".to_string(),
+    };
+    state.needs_redraw = false;
+
+    state.duplicate_board();
+
+    assert_eq!(state.boards.board_count(), initial_count + 1);
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.text_wrap_width.is_none());
+    assert!(state.needs_redraw);
+}
+
+#[test]
+fn duplicate_board_cancels_text_edit_before_cloning_board() {
+    let mut state = create_test_input_state();
+    state.switch_board(BOARD_ID_WHITEBOARD);
+    let shape_id = state.boards.active_frame_mut().add_shape(Shape::Text {
+        x: 40,
+        y: 80,
+        text: "Original".to_string(),
+        color: state.current_color,
+        size: state.current_font_size,
+        font_descriptor: state.font_descriptor.clone(),
+        background_enabled: state.text_background_enabled,
+        wrap_width: None,
+    });
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+    assert_board_text(&state, BOARD_ID_WHITEBOARD, shape_id, "");
+
+    state.duplicate_board();
+
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.text_edit_target.is_none());
+    assert_board_text(&state, BOARD_ID_WHITEBOARD, shape_id, "Original");
+
+    let duplicated_id = state.board_id().to_string();
+    assert_ne!(duplicated_id, BOARD_ID_WHITEBOARD);
+    assert_board_text(&state, &duplicated_id, shape_id, "Original");
 }
 
 #[test]

--- a/src/input/state/tests/boards.rs
+++ b/src/input/state/tests/boards.rs
@@ -162,6 +162,47 @@ fn switch_board_cancels_text_edit_on_source_board_before_switching() {
 }
 
 #[test]
+fn switch_board_cancels_selection_move_on_source_board_before_switching() {
+    let mut state = create_test_input_state();
+    let shape_id = state.boards.active_frame_mut().add_shape(Shape::Rect {
+        x: 40,
+        y: 80,
+        w: 30,
+        h: 20,
+        fill: false,
+        color: state.current_color,
+        thick: state.current_thickness,
+    });
+    state.set_selection(vec![shape_id]);
+    let snapshots = state.capture_movable_selection_snapshots();
+    assert!(state.apply_translation_to_selection(25, 35));
+    state.state = DrawingState::MovingSelection {
+        last_x: 25,
+        last_y: 35,
+        snapshots,
+        moved: true,
+    };
+    state.begin_pointer_drag(MouseButton::Left, None);
+
+    state.switch_board(BOARD_ID_WHITEBOARD);
+
+    assert_eq!(state.board_id(), BOARD_ID_WHITEBOARD);
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.active_drag_button.is_none());
+
+    let source_index = board_index(&state, BOARD_ID_TRANSPARENT);
+    let source_shape = state.boards.board_states()[source_index]
+        .pages
+        .active_frame()
+        .shape(shape_id)
+        .expect("source shape");
+    match &source_shape.shape {
+        Shape::Rect { x, y, w, h, .. } => assert_eq!((*x, *y, *w, *h), (40, 80, 30, 20)),
+        _ => panic!("Expected rect shape"),
+    }
+}
+
+#[test]
 fn duplicate_board_from_transparent_shows_info_toast_without_creating_board() {
     let mut state = create_test_input_state();
     let initial_count = state.boards.board_count();

--- a/src/input/state/tests/delete_restore.rs
+++ b/src/input/state/tests/delete_restore.rs
@@ -98,6 +98,37 @@ fn delete_active_board_restore_preserves_cancelled_text_edit() {
 }
 
 #[test]
+fn restore_deleted_board_renames_reused_generated_id() {
+    let mut state = create_test_input_state();
+    let initial_count = state.boards.board_count();
+    assert!(state.create_board());
+    let deleted_id = state.board_id().to_string();
+
+    state.delete_active_board();
+    state.delete_active_board();
+    assert_eq!(state.boards.board_count(), initial_count);
+
+    assert!(state.create_board());
+    assert_eq!(state.board_id(), deleted_id);
+
+    state.restore_deleted_board();
+
+    assert_eq!(state.boards.board_count(), initial_count + 2);
+    assert_ne!(state.board_id(), deleted_id);
+    assert!(state.board_id().starts_with(&format!("{deleted_id}-")));
+
+    let mut ids: Vec<_> = state
+        .boards
+        .board_states()
+        .iter()
+        .map(|board| board.spec.id.as_str())
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), state.boards.board_count());
+}
+
+#[test]
 fn cancel_pending_board_delete_clears_confirmation_state() {
     let mut state = create_test_input_state();
     state.switch_board(BOARD_ID_BLACKBOARD);

--- a/src/input/state/tests/delete_restore.rs
+++ b/src/input/state/tests/delete_restore.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::draw::{Frame, PageDeleteOutcome};
+use crate::draw::{Frame, PageDeleteOutcome, ShapeId};
 use crate::input::{BOARD_ID_BLACKBOARD, BOARD_ID_TRANSPARENT};
 
 fn board_index(state: &InputState, id: &str) -> usize {
@@ -17,6 +17,31 @@ fn set_page_count(state: &mut InputState, board_index: usize, count: usize) {
         .pages_mut();
     pages.clear();
     pages.extend((0..count.max(1)).map(|_| Frame::new()));
+}
+
+fn add_text_shape(state: &mut InputState, text: &str) -> ShapeId {
+    state.boards.active_frame_mut().add_shape(Shape::Text {
+        x: 40,
+        y: 80,
+        text: text.to_string(),
+        color: state.current_color,
+        size: state.current_font_size,
+        font_descriptor: state.font_descriptor.clone(),
+        background_enabled: state.text_background_enabled,
+        wrap_width: None,
+    })
+}
+
+fn assert_active_text(state: &InputState, shape_id: ShapeId, expected: &str) {
+    let shape = state
+        .boards
+        .active_frame()
+        .shape(shape_id)
+        .expect("text shape");
+    match &shape.shape {
+        Shape::Text { text, .. } => assert_eq!(text, expected),
+        _ => panic!("Expected text shape"),
+    }
 }
 
 #[test]
@@ -51,6 +76,25 @@ fn delete_active_board_requires_confirmation_then_restore_recovers_board() {
         state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
         Some("Board restored: Blackboard")
     );
+}
+
+#[test]
+fn delete_active_board_restore_preserves_cancelled_text_edit() {
+    let mut state = create_test_input_state();
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    let shape_id = add_text_shape(&mut state, "Original");
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+    assert_active_text(&state, shape_id, "");
+
+    state.delete_active_board();
+    state.delete_active_board();
+    state.restore_deleted_board();
+
+    assert_eq!(state.board_id(), BOARD_ID_BLACKBOARD);
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.text_edit_target.is_none());
+    assert_active_text(&state, shape_id, "Original");
 }
 
 #[test]
@@ -96,6 +140,27 @@ fn page_delete_requires_confirmation_and_restore_recovers_deleted_page() {
         state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
         Some("Page restored (2/2)")
     );
+}
+
+#[test]
+fn page_delete_restore_preserves_cancelled_text_edit() {
+    let mut state = create_test_input_state();
+    let board = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    set_page_count(&mut state, board, 2);
+    let shape_id = add_text_shape(&mut state, "Original");
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+    assert_active_text(&state, shape_id, "");
+
+    assert_eq!(state.page_delete(), PageDeleteOutcome::Pending);
+    assert_eq!(state.page_delete(), PageDeleteOutcome::Removed);
+    state.restore_deleted_page();
+
+    assert_eq!(state.boards.active_page_index(), 1);
+    assert!(matches!(state.state, DrawingState::Idle));
+    assert!(state.text_edit_target.is_none());
+    assert_active_text(&state, shape_id, "Original");
 }
 
 #[test]

--- a/src/input/state/tests/tool_controls.rs
+++ b/src/input/state/tests/tool_controls.rs
@@ -99,6 +99,195 @@ fn toolbar_context_preserves_temporary_eraser_controls() {
 }
 
 #[test]
+fn toolbar_context_matches_tool_profiles_for_each_tool() {
+    let mut state = create_test_input_state();
+    state.show_text_controls = false;
+    state.show_marker_opacity_section = false;
+
+    let cases = [
+        (
+            Tool::Select,
+            false,
+            false,
+            ToolOptionsKind::None,
+            "",
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Pen,
+            true,
+            true,
+            ToolOptionsKind::Stroke,
+            "Thickness",
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Line,
+            true,
+            true,
+            ToolOptionsKind::Stroke,
+            "Thickness",
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Rect,
+            true,
+            true,
+            ToolOptionsKind::Shape,
+            "Thickness",
+            true,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Ellipse,
+            true,
+            true,
+            ToolOptionsKind::Shape,
+            "Thickness",
+            true,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Arrow,
+            true,
+            true,
+            ToolOptionsKind::Arrow,
+            "Thickness",
+            false,
+            true,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Blur,
+            false,
+            true,
+            ToolOptionsKind::Stroke,
+            "Blur",
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::Marker,
+            true,
+            true,
+            ToolOptionsKind::Marker,
+            "Thickness",
+            false,
+            false,
+            false,
+            false,
+            true,
+        ),
+        (
+            Tool::Highlight,
+            false,
+            false,
+            ToolOptionsKind::None,
+            "",
+            false,
+            false,
+            false,
+            false,
+            false,
+        ),
+        (
+            Tool::StepMarker,
+            true,
+            true,
+            ToolOptionsKind::StepMarker,
+            "Size",
+            false,
+            false,
+            true,
+            false,
+            false,
+        ),
+        (
+            Tool::Eraser,
+            false,
+            true,
+            ToolOptionsKind::Eraser,
+            "Eraser size",
+            false,
+            false,
+            false,
+            true,
+            false,
+        ),
+    ];
+
+    for (
+        tool,
+        needs_color,
+        needs_thickness,
+        tool_options_kind,
+        thickness_label,
+        show_fill_toggle,
+        show_arrow_labels,
+        show_step_counter,
+        show_eraser_mode,
+        show_marker_opacity,
+    ) in cases
+    {
+        assert!(state.set_tool_override(Some(tool)));
+        let snapshot = ToolbarSnapshot::from_input(&state);
+        let context = ToolContext::from_snapshot(&snapshot);
+
+        assert_eq!(context.needs_color, needs_color, "{tool:?} color");
+        assert_eq!(
+            context.needs_thickness, needs_thickness,
+            "{tool:?} thickness"
+        );
+        assert_eq!(
+            context.tool_options_kind, tool_options_kind,
+            "{tool:?} options"
+        );
+        assert_eq!(context.thickness_label, thickness_label, "{tool:?} label");
+        assert_eq!(context.show_fill_toggle, show_fill_toggle, "{tool:?} fill");
+        assert_eq!(
+            context.show_arrow_labels, show_arrow_labels,
+            "{tool:?} arrow labels"
+        );
+        assert_eq!(
+            context.show_step_counter, show_step_counter,
+            "{tool:?} step counter"
+        );
+        assert_eq!(
+            context.show_eraser_mode, show_eraser_mode,
+            "{tool:?} eraser mode"
+        );
+        assert_eq!(
+            context.show_marker_opacity, show_marker_opacity,
+            "{tool:?} marker opacity"
+        );
+        assert!(!context.show_font_controls, "{tool:?} font controls");
+    }
+}
+
+#[test]
 fn nudge_thickness_for_active_tool_clamps_pen_thickness() {
     let mut state = create_test_input_state();
     assert!(state.set_thickness(49.0));

--- a/src/input/state/tests/tool_controls.rs
+++ b/src/input/state/tests/tool_controls.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::config::{PresenterToolBehavior, PresetToolStatesConfig, ToolPresetConfig};
-use crate::input::PerToolDrawingSettings;
+use crate::input::{DragBinding, DragToolBindings, PerToolDrawingSettings};
+use crate::ui::toolbar::{ToolContext, ToolOptionsKind, ToolbarSnapshot};
 
 #[test]
 fn set_tool_override_clears_active_preset_and_resets_drawing_state() {
@@ -73,6 +74,28 @@ fn set_thickness_for_active_tool_updates_eraser_size_when_eraser_is_active() {
     assert!(state.set_thickness_for_active_tool(17.0));
     assert_eq!(state.eraser_size, 17.0);
     assert_eq!(state.current_thickness, 3.0);
+}
+
+#[test]
+fn toolbar_context_preserves_temporary_eraser_controls() {
+    let mut state = create_test_input_state();
+    let mut bindings = DragToolBindings::default();
+    bindings.left.shift_drag = DragBinding::from_tool(Tool::Eraser);
+    assert!(state.set_drag_tool_bindings(bindings));
+    assert!(state.set_tool_override(Some(Tool::Pen)));
+    state.eraser_size = 17.0;
+
+    state.on_key_press(Key::Shift);
+    let snapshot = ToolbarSnapshot::from_input(&state);
+    let context = ToolContext::from_snapshot(&snapshot);
+
+    assert_eq!(snapshot.active_tool, Tool::Eraser);
+    assert_eq!(snapshot.tool_override, Some(Tool::Pen));
+    assert!(snapshot.thickness_targets_eraser);
+    assert_eq!(snapshot.thickness, 17.0);
+    assert_eq!(context.tool_options_kind, ToolOptionsKind::Eraser);
+    assert_eq!(context.thickness_label, "Eraser size");
+    assert!(context.show_eraser_mode);
 }
 
 #[test]

--- a/src/input/tool.rs
+++ b/src/input/tool.rs
@@ -36,6 +36,191 @@ pub enum Tool {
     // Note: Text mode uses DrawingState::TextInput instead of Tool::Text
 }
 
+/// The stored color/thickness slot used by a tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolSettingsSlot {
+    Pen,
+    Line,
+    Rect,
+    Ellipse,
+    Arrow,
+    Blur,
+    Marker,
+    StepMarker,
+}
+
+impl ToolSettingsSlot {
+    pub(crate) const ALL: [Self; 8] = [
+        Self::Pen,
+        Self::Line,
+        Self::Rect,
+        Self::Ellipse,
+        Self::Arrow,
+        Self::Blur,
+        Self::Marker,
+        Self::StepMarker,
+    ];
+
+    pub(crate) fn representative_tool(self) -> Tool {
+        match self {
+            Self::Pen => Tool::Pen,
+            Self::Line => Tool::Line,
+            Self::Rect => Tool::Rect,
+            Self::Ellipse => Tool::Ellipse,
+            Self::Arrow => Tool::Arrow,
+            Self::Blur => Tool::Blur,
+            Self::Marker => Tool::Marker,
+            Self::StepMarker => Tool::StepMarker,
+        }
+    }
+}
+
+/// Where a tool's visible size value is stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolSizeSource {
+    DrawingThickness,
+    EraserSize,
+}
+
+/// Side-toolbar control family exposed by a tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolControlGroup {
+    None,
+    Stroke,
+    Marker,
+    Eraser,
+    Shape,
+    Arrow,
+    StepMarker,
+}
+
+/// Catalog entry describing the settings and controls for one drawing tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ToolProfile {
+    pub(crate) settings_slot: ToolSettingsSlot,
+    pub(crate) size_source: ToolSizeSource,
+    pub(crate) control_group: ToolControlGroup,
+    pub(crate) needs_color: bool,
+    pub(crate) thickness_label: &'static str,
+}
+
+impl ToolProfile {
+    pub(crate) fn needs_thickness_control(self) -> bool {
+        !matches!(self.control_group, ToolControlGroup::None)
+    }
+
+    pub(crate) fn show_fill_toggle(self) -> bool {
+        matches!(self.control_group, ToolControlGroup::Shape)
+    }
+
+    pub(crate) fn show_arrow_labels(self) -> bool {
+        matches!(self.control_group, ToolControlGroup::Arrow)
+    }
+
+    pub(crate) fn show_step_counter(self) -> bool {
+        matches!(self.control_group, ToolControlGroup::StepMarker)
+    }
+
+    pub(crate) fn show_eraser_mode(self) -> bool {
+        matches!(self.control_group, ToolControlGroup::Eraser)
+    }
+
+    pub(crate) fn show_marker_opacity(self) -> bool {
+        matches!(self.control_group, ToolControlGroup::Marker)
+    }
+}
+
+impl Tool {
+    pub(crate) fn profile(self) -> ToolProfile {
+        match self {
+            Self::Select | Self::Highlight => ToolProfile {
+                settings_slot: ToolSettingsSlot::Pen,
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::None,
+                needs_color: false,
+                thickness_label: "",
+            },
+            Self::Pen | Self::Line => ToolProfile {
+                settings_slot: if self == Self::Pen {
+                    ToolSettingsSlot::Pen
+                } else {
+                    ToolSettingsSlot::Line
+                },
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::Stroke,
+                needs_color: true,
+                thickness_label: "Thickness",
+            },
+            Self::Blur => ToolProfile {
+                settings_slot: ToolSettingsSlot::Blur,
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::Stroke,
+                needs_color: false,
+                thickness_label: "Blur",
+            },
+            Self::Marker => ToolProfile {
+                settings_slot: ToolSettingsSlot::Marker,
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::Marker,
+                needs_color: true,
+                thickness_label: "Thickness",
+            },
+            Self::Eraser => ToolProfile {
+                settings_slot: ToolSettingsSlot::Pen,
+                size_source: ToolSizeSource::EraserSize,
+                control_group: ToolControlGroup::Eraser,
+                needs_color: false,
+                thickness_label: "Eraser Size",
+            },
+            Self::Rect | Self::Ellipse => ToolProfile {
+                settings_slot: if self == Self::Rect {
+                    ToolSettingsSlot::Rect
+                } else {
+                    ToolSettingsSlot::Ellipse
+                },
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::Shape,
+                needs_color: true,
+                thickness_label: "Thickness",
+            },
+            Self::Arrow => ToolProfile {
+                settings_slot: ToolSettingsSlot::Arrow,
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::Arrow,
+                needs_color: true,
+                thickness_label: "Thickness",
+            },
+            Self::StepMarker => ToolProfile {
+                settings_slot: ToolSettingsSlot::StepMarker,
+                size_source: ToolSizeSource::DrawingThickness,
+                control_group: ToolControlGroup::StepMarker,
+                needs_color: true,
+                thickness_label: "Size",
+            },
+        }
+    }
+
+    pub(crate) fn settings_slot(self) -> ToolSettingsSlot {
+        self.profile().settings_slot
+    }
+
+    pub(crate) fn settings_tool(self) -> Tool {
+        self.settings_slot().representative_tool()
+    }
+
+    pub(crate) fn uses_eraser_size(self) -> bool {
+        matches!(self.profile().size_source, ToolSizeSource::EraserSize)
+    }
+
+    pub(crate) fn uses_drawing_thickness(self) -> bool {
+        matches!(self.profile().size_source, ToolSizeSource::DrawingThickness)
+    }
+
+    pub(crate) fn uses_marker_opacity(self) -> bool {
+        self.profile().show_marker_opacity()
+    }
+}
+
 /// Color and thickness stored independently for a drawing tool.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ToolDrawingSettings {
@@ -78,47 +263,48 @@ impl PerToolDrawingSettings {
     }
 
     pub fn settings_tool(tool: Tool) -> Tool {
-        match tool {
-            Tool::Select | Tool::Highlight | Tool::Eraser => Tool::Pen,
-            _ => tool,
-        }
+        tool.settings_tool()
     }
 
     pub fn get(&self, tool: Tool) -> &ToolDrawingSettings {
-        match tool {
-            Tool::Pen | Tool::Select | Tool::Highlight | Tool::Eraser => &self.pen,
-            Tool::Line => &self.line,
-            Tool::Rect => &self.rect,
-            Tool::Ellipse => &self.ellipse,
-            Tool::Arrow => &self.arrow,
-            Tool::Blur => &self.blur,
-            Tool::Marker => &self.marker,
-            Tool::StepMarker => &self.step_marker,
-        }
+        self.get_slot(tool.settings_slot())
     }
 
     pub fn get_mut(&mut self, tool: Tool) -> &mut ToolDrawingSettings {
-        match tool {
-            Tool::Pen | Tool::Select | Tool::Highlight | Tool::Eraser => &mut self.pen,
-            Tool::Line => &mut self.line,
-            Tool::Rect => &mut self.rect,
-            Tool::Ellipse => &mut self.ellipse,
-            Tool::Arrow => &mut self.arrow,
-            Tool::Blur => &mut self.blur,
-            Tool::Marker => &mut self.marker,
-            Tool::StepMarker => &mut self.step_marker,
+        self.get_slot_mut(tool.settings_slot())
+    }
+
+    pub(crate) fn get_slot(&self, slot: ToolSettingsSlot) -> &ToolDrawingSettings {
+        match slot {
+            ToolSettingsSlot::Pen => &self.pen,
+            ToolSettingsSlot::Line => &self.line,
+            ToolSettingsSlot::Rect => &self.rect,
+            ToolSettingsSlot::Ellipse => &self.ellipse,
+            ToolSettingsSlot::Arrow => &self.arrow,
+            ToolSettingsSlot::Blur => &self.blur,
+            ToolSettingsSlot::Marker => &self.marker,
+            ToolSettingsSlot::StepMarker => &self.step_marker,
+        }
+    }
+
+    pub(crate) fn get_slot_mut(&mut self, slot: ToolSettingsSlot) -> &mut ToolDrawingSettings {
+        match slot {
+            ToolSettingsSlot::Pen => &mut self.pen,
+            ToolSettingsSlot::Line => &mut self.line,
+            ToolSettingsSlot::Rect => &mut self.rect,
+            ToolSettingsSlot::Ellipse => &mut self.ellipse,
+            ToolSettingsSlot::Arrow => &mut self.arrow,
+            ToolSettingsSlot::Blur => &mut self.blur,
+            ToolSettingsSlot::Marker => &mut self.marker,
+            ToolSettingsSlot::StepMarker => &mut self.step_marker,
         }
     }
 
     pub fn clamp_thicknesses(mut self, min: f64, max: f64) -> Self {
-        self.pen.thickness = self.pen.thickness.clamp(min, max);
-        self.line.thickness = self.line.thickness.clamp(min, max);
-        self.rect.thickness = self.rect.thickness.clamp(min, max);
-        self.ellipse.thickness = self.ellipse.thickness.clamp(min, max);
-        self.arrow.thickness = self.arrow.thickness.clamp(min, max);
-        self.blur.thickness = self.blur.thickness.clamp(min, max);
-        self.marker.thickness = self.marker.thickness.clamp(min, max);
-        self.step_marker.thickness = self.step_marker.thickness.clamp(min, max);
+        for slot in ToolSettingsSlot::ALL {
+            let settings = self.get_slot_mut(slot);
+            settings.thickness = settings.thickness.clamp(min, max);
+        }
         self
     }
 }
@@ -200,4 +386,59 @@ pub enum EraserMode {
     Brush,
     /// Stroke eraser that deletes any shape it touches.
     Stroke,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn color(r: f64) -> Color {
+        Color {
+            r,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        }
+    }
+
+    #[test]
+    fn tool_profile_maps_compatibility_tools_to_pen_settings() {
+        assert_eq!(Tool::Select.settings_slot(), ToolSettingsSlot::Pen);
+        assert_eq!(Tool::Highlight.settings_slot(), ToolSettingsSlot::Pen);
+        assert_eq!(Tool::Eraser.settings_slot(), ToolSettingsSlot::Pen);
+        assert_eq!(
+            Tool::Eraser.profile().size_source,
+            ToolSizeSource::EraserSize
+        );
+
+        for slot in ToolSettingsSlot::ALL {
+            assert_eq!(slot.representative_tool().settings_slot(), slot);
+        }
+    }
+
+    #[test]
+    fn tool_profile_describes_toolbar_control_groups() {
+        assert!(!Tool::Select.profile().needs_thickness_control());
+        assert_eq!(Tool::Blur.profile().thickness_label, "Blur");
+        assert!(Tool::Marker.profile().show_marker_opacity());
+        assert!(Tool::Eraser.profile().show_eraser_mode());
+        assert!(Tool::Rect.profile().show_fill_toggle());
+        assert!(Tool::Arrow.profile().show_arrow_labels());
+        assert!(Tool::StepMarker.profile().show_step_counter());
+    }
+
+    #[test]
+    fn per_tool_settings_read_and_write_through_catalog_slot() {
+        let mut settings = PerToolDrawingSettings::new(color(1.0), 4.0);
+        settings.marker = ToolDrawingSettings::new(color(0.5), 12.0);
+
+        assert_eq!(settings.get(Tool::Eraser), &settings.pen);
+        assert_eq!(settings.get(Tool::Marker), &settings.marker);
+
+        settings.get_mut(Tool::Highlight).thickness = 8.0;
+        settings.get_mut(Tool::Marker).thickness = 16.0;
+
+        assert_eq!(settings.pen.thickness, 8.0);
+        assert_eq!(settings.marker.thickness, 16.0);
+    }
 }

--- a/src/ui/toolbar/bindings.rs
+++ b/src/ui/toolbar/bindings.rs
@@ -4,7 +4,12 @@ use crate::config::{Action, action_label, action_meta_iter, action_short_label};
 use crate::input::{InputState, Tool};
 use crate::label_format::join_binding_labels;
 
-use super::events::ToolbarEvent;
+use super::events::{
+    ToolbarEvent, action_for_apply_preset as event_action_for_apply_preset,
+    action_for_clear_preset as event_action_for_clear_preset,
+    action_for_save_preset as event_action_for_save_preset,
+    action_for_tool as event_action_for_tool,
+};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ToolbarBindingHints {
@@ -49,19 +54,7 @@ impl ToolbarBindingHints {
 }
 
 pub(crate) fn action_for_tool(tool: Tool) -> Option<Action> {
-    match tool {
-        Tool::Select => Some(Action::SelectSelectionTool),
-        Tool::Pen => Some(Action::SelectPenTool),
-        Tool::Line => Some(Action::SelectLineTool),
-        Tool::Rect => Some(Action::SelectRectTool),
-        Tool::Ellipse => Some(Action::SelectEllipseTool),
-        Tool::Arrow => Some(Action::SelectArrowTool),
-        Tool::Blur => Some(Action::SelectBlurTool),
-        Tool::Marker => Some(Action::SelectMarkerTool),
-        Tool::StepMarker => Some(Action::SelectStepMarkerTool),
-        Tool::Highlight => Some(Action::SelectHighlightTool),
-        Tool::Eraser => Some(Action::SelectEraserTool),
-    }
+    event_action_for_tool(tool)
 }
 
 #[allow(dead_code)]
@@ -77,76 +70,19 @@ pub(crate) fn tool_tooltip_label(tool: Tool) -> &'static str {
 }
 
 pub(crate) fn action_for_event(event: &ToolbarEvent) -> Option<Action> {
-    match event {
-        ToolbarEvent::SelectTool(tool) => action_for_tool(*tool),
-        ToolbarEvent::EnterTextMode => Some(Action::EnterTextMode),
-        ToolbarEvent::EnterStickyNoteMode => Some(Action::EnterStickyNoteMode),
-        ToolbarEvent::ToggleFill(_) => Some(Action::ToggleFill),
-        ToolbarEvent::Undo => Some(Action::Undo),
-        ToolbarEvent::Redo => Some(Action::Redo),
-        ToolbarEvent::UndoAll => Some(Action::UndoAll),
-        ToolbarEvent::RedoAll => Some(Action::RedoAll),
-        ToolbarEvent::UndoAllDelayed => Some(Action::UndoAllDelayed),
-        ToolbarEvent::RedoAllDelayed => Some(Action::RedoAllDelayed),
-        ToolbarEvent::ClearCanvas => Some(Action::ClearCanvas),
-        ToolbarEvent::PagePrev => Some(Action::PagePrev),
-        ToolbarEvent::PageNext => Some(Action::PageNext),
-        ToolbarEvent::PageNew => Some(Action::PageNew),
-        ToolbarEvent::PageDuplicate => Some(Action::PageDuplicate),
-        ToolbarEvent::PageDelete => Some(Action::PageDelete),
-        ToolbarEvent::BoardPrev => Some(Action::BoardPrev),
-        ToolbarEvent::BoardNext => Some(Action::BoardNext),
-        ToolbarEvent::BoardNew => Some(Action::BoardNew),
-        ToolbarEvent::BoardDelete => Some(Action::BoardDelete),
-        ToolbarEvent::BoardDuplicate => Some(Action::BoardDuplicate),
-        ToolbarEvent::BoardRename => Some(Action::BoardPicker),
-        ToolbarEvent::ToggleBoardPicker => Some(Action::BoardPicker),
-        ToolbarEvent::ToggleAllHighlight(_) => Some(Action::ToggleHighlightTool),
-        ToolbarEvent::ToggleFreeze => Some(Action::ToggleFrozenMode),
-        ToolbarEvent::ZoomIn => Some(Action::ZoomIn),
-        ToolbarEvent::ZoomOut => Some(Action::ZoomOut),
-        ToolbarEvent::ResetZoom => Some(Action::ResetZoom),
-        ToolbarEvent::ResetStepMarkerCounter => Some(Action::ResetStepMarkerCounter),
-        ToolbarEvent::ToggleZoomLock => Some(Action::ToggleZoomLock),
-        ToolbarEvent::ApplyPreset(slot) => action_for_apply_preset(*slot),
-        ToolbarEvent::SavePreset(slot) => action_for_save_preset(*slot),
-        ToolbarEvent::ClearPreset(slot) => action_for_clear_preset(*slot),
-        ToolbarEvent::OpenConfigurator => Some(Action::OpenConfigurator),
-        _ => None,
-    }
+    event.action()
 }
 
 pub(crate) fn action_for_apply_preset(slot: usize) -> Option<Action> {
-    match slot {
-        1 => Some(Action::ApplyPreset1),
-        2 => Some(Action::ApplyPreset2),
-        3 => Some(Action::ApplyPreset3),
-        4 => Some(Action::ApplyPreset4),
-        5 => Some(Action::ApplyPreset5),
-        _ => None,
-    }
+    event_action_for_apply_preset(slot)
 }
 
 pub(crate) fn action_for_save_preset(slot: usize) -> Option<Action> {
-    match slot {
-        1 => Some(Action::SavePreset1),
-        2 => Some(Action::SavePreset2),
-        3 => Some(Action::SavePreset3),
-        4 => Some(Action::SavePreset4),
-        5 => Some(Action::SavePreset5),
-        _ => None,
-    }
+    event_action_for_save_preset(slot)
 }
 
 pub(crate) fn action_for_clear_preset(slot: usize) -> Option<Action> {
-    match slot {
-        1 => Some(Action::ClearPreset1),
-        2 => Some(Action::ClearPreset2),
-        3 => Some(Action::ClearPreset3),
-        4 => Some(Action::ClearPreset4),
-        5 => Some(Action::ClearPreset5),
-        _ => None,
-    }
+    event_action_for_clear_preset(slot)
 }
 
 #[cfg(test)]

--- a/src/ui/toolbar/events.rs
+++ b/src/ui/toolbar/events.rs
@@ -1,6 +1,8 @@
-use crate::config::ToolbarLayoutMode;
+use crate::config::{Action, ToolbarLayoutMode, action_label, action_short_label};
 use crate::draw::{Color, FontDescriptor};
 use crate::input::{EraserMode, Tool, ToolbarDrawerTab};
+
+use super::ToolbarSnapshot;
 
 /// Events emitted by the floating toolbar UI.
 #[derive(Debug, Clone)]
@@ -134,4 +136,114 @@ pub enum ToolbarEvent {
         x: f64,
         y: f64,
     },
+}
+
+impl ToolbarEvent {
+    pub fn action(&self) -> Option<Action> {
+        match self {
+            Self::SelectTool(tool) => action_for_tool(*tool),
+            Self::EnterTextMode => Some(Action::EnterTextMode),
+            Self::EnterStickyNoteMode => Some(Action::EnterStickyNoteMode),
+            Self::ToggleFill(_) => Some(Action::ToggleFill),
+            Self::Undo => Some(Action::Undo),
+            Self::Redo => Some(Action::Redo),
+            Self::UndoAll => Some(Action::UndoAll),
+            Self::RedoAll => Some(Action::RedoAll),
+            Self::UndoAllDelayed => Some(Action::UndoAllDelayed),
+            Self::RedoAllDelayed => Some(Action::RedoAllDelayed),
+            Self::ClearCanvas => Some(Action::ClearCanvas),
+            Self::PagePrev => Some(Action::PagePrev),
+            Self::PageNext => Some(Action::PageNext),
+            Self::PageNew => Some(Action::PageNew),
+            Self::PageDuplicate => Some(Action::PageDuplicate),
+            Self::PageDelete => Some(Action::PageDelete),
+            Self::BoardPrev => Some(Action::BoardPrev),
+            Self::BoardNext => Some(Action::BoardNext),
+            Self::BoardNew => Some(Action::BoardNew),
+            Self::BoardDelete => Some(Action::BoardDelete),
+            Self::BoardDuplicate => Some(Action::BoardDuplicate),
+            Self::BoardRename | Self::ToggleBoardPicker => Some(Action::BoardPicker),
+            Self::ToggleAllHighlight(_) => Some(Action::ToggleHighlightTool),
+            Self::ToggleFreeze => Some(Action::ToggleFrozenMode),
+            Self::ZoomIn => Some(Action::ZoomIn),
+            Self::ZoomOut => Some(Action::ZoomOut),
+            Self::ResetZoom => Some(Action::ResetZoom),
+            Self::ResetStepMarkerCounter => Some(Action::ResetStepMarkerCounter),
+            Self::ToggleZoomLock => Some(Action::ToggleZoomLock),
+            Self::ApplyPreset(slot) => action_for_apply_preset(*slot),
+            Self::SavePreset(slot) => action_for_save_preset(*slot),
+            Self::ClearPreset(slot) => action_for_clear_preset(*slot),
+            Self::OpenConfigurator => Some(Action::OpenConfigurator),
+            _ => None,
+        }
+    }
+
+    pub fn short_label(&self, snapshot: &ToolbarSnapshot, fallback: &'static str) -> &'static str {
+        match self {
+            Self::ToggleFreeze if snapshot.frozen_active => "Unfreeze",
+            Self::ToggleZoomLock if snapshot.zoom_locked => "Unlock Zoom",
+            _ => self.action().map(action_short_label).unwrap_or(fallback),
+        }
+    }
+
+    pub fn tooltip_label(
+        &self,
+        snapshot: &ToolbarSnapshot,
+        fallback: &'static str,
+    ) -> &'static str {
+        match self {
+            Self::ToggleFreeze if snapshot.frozen_active => "Unfreeze",
+            Self::ToggleZoomLock if snapshot.zoom_locked => "Unlock Zoom",
+            _ => self.action().map(action_label).unwrap_or(fallback),
+        }
+    }
+}
+
+pub(crate) fn action_for_tool(tool: Tool) -> Option<Action> {
+    match tool {
+        Tool::Select => Some(Action::SelectSelectionTool),
+        Tool::Pen => Some(Action::SelectPenTool),
+        Tool::Line => Some(Action::SelectLineTool),
+        Tool::Rect => Some(Action::SelectRectTool),
+        Tool::Ellipse => Some(Action::SelectEllipseTool),
+        Tool::Arrow => Some(Action::SelectArrowTool),
+        Tool::Blur => Some(Action::SelectBlurTool),
+        Tool::Marker => Some(Action::SelectMarkerTool),
+        Tool::StepMarker => Some(Action::SelectStepMarkerTool),
+        Tool::Highlight => Some(Action::SelectHighlightTool),
+        Tool::Eraser => Some(Action::SelectEraserTool),
+    }
+}
+
+pub(crate) fn action_for_apply_preset(slot: usize) -> Option<Action> {
+    match slot {
+        1 => Some(Action::ApplyPreset1),
+        2 => Some(Action::ApplyPreset2),
+        3 => Some(Action::ApplyPreset3),
+        4 => Some(Action::ApplyPreset4),
+        5 => Some(Action::ApplyPreset5),
+        _ => None,
+    }
+}
+
+pub(crate) fn action_for_save_preset(slot: usize) -> Option<Action> {
+    match slot {
+        1 => Some(Action::SavePreset1),
+        2 => Some(Action::SavePreset2),
+        3 => Some(Action::SavePreset3),
+        4 => Some(Action::SavePreset4),
+        5 => Some(Action::SavePreset5),
+        _ => None,
+    }
+}
+
+pub(crate) fn action_for_clear_preset(slot: usize) -> Option<Action> {
+    match slot {
+        1 => Some(Action::ClearPreset1),
+        2 => Some(Action::ClearPreset2),
+        3 => Some(Action::ClearPreset3),
+        4 => Some(Action::ClearPreset4),
+        5 => Some(Action::ClearPreset5),
+        _ => None,
+    }
 }

--- a/src/ui/toolbar/mod.rs
+++ b/src/ui/toolbar/mod.rs
@@ -1,6 +1,8 @@
 mod apply;
 pub(crate) mod bindings;
 mod events;
+#[allow(dead_code)]
+pub(crate) mod model;
 pub mod snapshot;
 
 pub use bindings::ToolbarBindingHints;

--- a/src/ui/toolbar/model.rs
+++ b/src/ui/toolbar/model.rs
@@ -1,0 +1,245 @@
+use crate::input::ToolbarDrawerTab;
+
+use super::{ToolbarEvent, ToolbarSnapshot};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolbarCommandGroupKind {
+    BasicActions,
+    ViewActions,
+    AdvancedActions,
+    Pages,
+    Boards,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ToolbarButtonModel {
+    pub(crate) event: ToolbarEvent,
+    pub(crate) enabled: bool,
+}
+
+impl ToolbarButtonModel {
+    pub(crate) fn new(event: ToolbarEvent, enabled: bool) -> Self {
+        Self { event, enabled }
+    }
+
+    pub(crate) fn short_label(
+        &self,
+        snapshot: &ToolbarSnapshot,
+        fallback: &'static str,
+    ) -> &'static str {
+        self.event.short_label(snapshot, fallback)
+    }
+
+    pub(crate) fn tooltip_label(
+        &self,
+        snapshot: &ToolbarSnapshot,
+        fallback: &'static str,
+    ) -> &'static str {
+        self.event.tooltip_label(snapshot, fallback)
+    }
+
+    pub(crate) fn binding_hint<'a>(&self, snapshot: &'a ToolbarSnapshot) -> Option<&'a str> {
+        snapshot.binding_hints.binding_for_event(&self.event)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ToolbarCommandGroup {
+    pub(crate) kind: ToolbarCommandGroupKind,
+    pub(crate) buttons: Vec<ToolbarButtonModel>,
+}
+
+impl ToolbarCommandGroup {
+    fn new(kind: ToolbarCommandGroupKind, buttons: Vec<ToolbarButtonModel>) -> Self {
+        Self { kind, buttons }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ToolbarActionsModel {
+    groups: Vec<ToolbarCommandGroup>,
+}
+
+impl ToolbarActionsModel {
+    pub(crate) fn from_snapshot(snapshot: &ToolbarSnapshot) -> Option<Self> {
+        let show_drawer_view = drawer_view_visible(snapshot);
+        let show_advanced = snapshot.show_actions_advanced && show_drawer_view;
+        let show_view_actions = show_drawer_view
+            && snapshot.show_zoom_actions
+            && (snapshot.show_actions_section || snapshot.show_actions_advanced);
+        let show_actions = snapshot.show_actions_section || show_advanced;
+
+        if !show_actions {
+            return None;
+        }
+
+        let mut groups = Vec::with_capacity(3);
+        if snapshot.show_actions_section {
+            groups.push(ToolbarCommandGroup::new(
+                ToolbarCommandGroupKind::BasicActions,
+                vec![
+                    ToolbarButtonModel::new(ToolbarEvent::Undo, snapshot.undo_available),
+                    ToolbarButtonModel::new(ToolbarEvent::Redo, snapshot.redo_available),
+                    ToolbarButtonModel::new(ToolbarEvent::ClearCanvas, true),
+                ],
+            ));
+        }
+
+        if show_view_actions {
+            groups.push(ToolbarCommandGroup::new(
+                ToolbarCommandGroupKind::ViewActions,
+                vec![
+                    ToolbarButtonModel::new(ToolbarEvent::ZoomIn, true),
+                    ToolbarButtonModel::new(ToolbarEvent::ZoomOut, true),
+                    ToolbarButtonModel::new(ToolbarEvent::ResetZoom, snapshot.zoom_active),
+                    ToolbarButtonModel::new(ToolbarEvent::ToggleZoomLock, snapshot.zoom_active),
+                ],
+            ));
+        }
+
+        if show_advanced {
+            let mut buttons = Vec::with_capacity(5);
+            buttons.push(ToolbarButtonModel::new(
+                ToolbarEvent::UndoAll,
+                snapshot.undo_available,
+            ));
+            buttons.push(ToolbarButtonModel::new(
+                ToolbarEvent::RedoAll,
+                snapshot.redo_available,
+            ));
+            if snapshot.delay_actions_enabled {
+                buttons.push(ToolbarButtonModel::new(
+                    ToolbarEvent::UndoAllDelayed,
+                    snapshot.undo_available,
+                ));
+                buttons.push(ToolbarButtonModel::new(
+                    ToolbarEvent::RedoAllDelayed,
+                    snapshot.redo_available,
+                ));
+            }
+            buttons.push(ToolbarButtonModel::new(ToolbarEvent::ToggleFreeze, true));
+            groups.push(ToolbarCommandGroup::new(
+                ToolbarCommandGroupKind::AdvancedActions,
+                buttons,
+            ));
+        }
+
+        Some(Self { groups })
+    }
+
+    pub(crate) fn groups(&self) -> &[ToolbarCommandGroup] {
+        &self.groups
+    }
+}
+
+pub(crate) fn toolbar_pages_model(snapshot: &ToolbarSnapshot) -> Option<ToolbarCommandGroup> {
+    if !snapshot.show_pages_section || !drawer_view_visible(snapshot) {
+        return None;
+    }
+
+    Some(ToolbarCommandGroup::new(
+        ToolbarCommandGroupKind::Pages,
+        vec![
+            ToolbarButtonModel::new(ToolbarEvent::PagePrev, snapshot.page_index > 0),
+            ToolbarButtonModel::new(
+                ToolbarEvent::PageNext,
+                snapshot.page_index + 1 < snapshot.page_count,
+            ),
+            ToolbarButtonModel::new(ToolbarEvent::PageNew, true),
+            ToolbarButtonModel::new(ToolbarEvent::PageDuplicate, true),
+            ToolbarButtonModel::new(ToolbarEvent::PageDelete, true),
+        ],
+    ))
+}
+
+pub(crate) fn toolbar_boards_model(snapshot: &ToolbarSnapshot) -> Option<ToolbarCommandGroup> {
+    if !snapshot.show_boards_section || !drawer_view_visible(snapshot) {
+        return None;
+    }
+
+    let can_cycle = snapshot.board_count > 1;
+    Some(ToolbarCommandGroup::new(
+        ToolbarCommandGroupKind::Boards,
+        vec![
+            ToolbarButtonModel::new(ToolbarEvent::BoardPrev, can_cycle),
+            ToolbarButtonModel::new(ToolbarEvent::BoardNext, can_cycle),
+            ToolbarButtonModel::new(ToolbarEvent::BoardNew, true),
+            ToolbarButtonModel::new(ToolbarEvent::BoardDuplicate, !snapshot.is_transparent),
+            ToolbarButtonModel::new(ToolbarEvent::BoardDelete, true),
+        ],
+    ))
+}
+
+fn drawer_view_visible(snapshot: &ToolbarSnapshot) -> bool {
+    snapshot.drawer_open && snapshot.drawer_tab == ToolbarDrawerTab::View
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::state::test_support::make_test_input_state;
+    use crate::ui::toolbar::{ToolbarBindingHints, ToolbarSnapshot};
+
+    fn snapshot() -> ToolbarSnapshot {
+        let mut state = make_test_input_state();
+        state.toolbar_drawer_open = true;
+        state.toolbar_drawer_tab = ToolbarDrawerTab::View;
+        state.show_actions_section = true;
+        state.show_actions_advanced = false;
+        state.show_zoom_actions = true;
+        state.show_pages_section = true;
+        state.show_boards_section = true;
+        ToolbarSnapshot::from_input_with_bindings(&state, ToolbarBindingHints::default())
+    }
+
+    #[test]
+    fn actions_model_keeps_advanced_actions_in_view_drawer() {
+        let mut snapshot = snapshot();
+        snapshot.show_actions_section = false;
+        snapshot.show_actions_advanced = true;
+        snapshot.delay_actions_enabled = true;
+
+        let model = ToolbarActionsModel::from_snapshot(&snapshot).expect("actions model");
+        assert_eq!(model.groups().len(), 2);
+        assert_eq!(model.groups()[0].kind, ToolbarCommandGroupKind::ViewActions);
+        assert_eq!(
+            model.groups()[1].kind,
+            ToolbarCommandGroupKind::AdvancedActions
+        );
+        assert_eq!(model.groups()[1].buttons.len(), 5);
+
+        snapshot.drawer_open = false;
+        assert!(ToolbarActionsModel::from_snapshot(&snapshot).is_none());
+    }
+
+    #[test]
+    fn page_and_board_models_report_disabled_navigation() {
+        let mut snapshot = snapshot();
+        snapshot.page_count = 2;
+        snapshot.board_count = 1;
+        snapshot.is_transparent = true;
+
+        let pages = toolbar_pages_model(&snapshot).expect("pages model");
+        assert!(!pages.buttons[0].enabled);
+        assert!(pages.buttons[1].enabled);
+
+        let boards = toolbar_boards_model(&snapshot).expect("boards model");
+        assert!(!boards.buttons[0].enabled);
+        assert!(!boards.buttons[1].enabled);
+        assert!(!boards.buttons[3].enabled);
+    }
+
+    #[test]
+    fn dynamic_toolbar_labels_live_with_the_event_model() {
+        let mut snapshot = snapshot();
+        snapshot.frozen_active = true;
+        snapshot.zoom_locked = true;
+
+        let freeze = ToolbarButtonModel::new(ToolbarEvent::ToggleFreeze, true);
+        let zoom_lock = ToolbarButtonModel::new(ToolbarEvent::ToggleZoomLock, true);
+
+        assert_eq!(freeze.short_label(&snapshot, "Action"), "Unfreeze");
+        assert_eq!(zoom_lock.tooltip_label(&snapshot, "Action"), "Unlock Zoom");
+        assert_eq!(zoom_lock.binding_hint(&snapshot), None);
+    }
+}

--- a/src/ui/toolbar/snapshot/build.rs
+++ b/src/ui/toolbar/snapshot/build.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::input::state::PRESET_FEEDBACK_DURATION_MS;
-use crate::input::{BoardBackground, InputState, Tool};
+use crate::input::{BoardBackground, InputState};
 
 use super::super::bindings::ToolbarBindingHints;
 use super::types::{PresetFeedbackSnapshot, PresetSlotSnapshot, ToolbarSnapshot};
@@ -40,10 +40,15 @@ impl ToolbarSnapshot {
             && state.text_input_mode == crate::input::TextInputMode::Plain;
         let note_active = matches!(state.state, crate::input::DrawingState::TextInput { .. })
             && state.text_input_mode == crate::input::TextInputMode::StickyNote;
-        let thickness_targets_eraser =
-            active_tool == Tool::Eraser || matches!(state.tool_override(), Some(Tool::Eraser));
-        let thickness_targets_marker =
-            active_tool == Tool::Marker || matches!(state.tool_override(), Some(Tool::Marker));
+        let override_tool = state.tool_override();
+        let thickness_targets_eraser = active_tool.uses_eraser_size()
+            || override_tool
+                .map(|tool| tool.uses_eraser_size())
+                .unwrap_or(false);
+        let thickness_targets_marker = active_tool.uses_marker_opacity()
+            || override_tool
+                .map(|tool| tool.uses_marker_opacity())
+                .unwrap_or(false);
         let eraser_kind = state.eraser_kind;
         let eraser_mode = state.eraser_mode;
         let thickness_value = if thickness_targets_eraser {

--- a/src/ui/toolbar/snapshot/types.rs
+++ b/src/ui/toolbar/snapshot/types.rs
@@ -1,6 +1,7 @@
 use crate::config::ToolbarLayoutMode;
 use crate::draw::{Color, EraserKind, FontDescriptor};
 use crate::input::state::PresetFeedbackKind;
+use crate::input::tool::{ToolControlGroup, ToolProfile};
 use crate::input::{EraserMode, Tool, ToolbarDrawerTab};
 
 use super::super::bindings::ToolbarBindingHints;
@@ -24,6 +25,18 @@ pub enum ToolOptionsKind {
     StepMarker,
     /// Text mode: font size + font family
     Text,
+}
+
+fn tool_options_kind_from_group(group: ToolControlGroup) -> ToolOptionsKind {
+    match group {
+        ToolControlGroup::None => ToolOptionsKind::None,
+        ToolControlGroup::Stroke => ToolOptionsKind::Stroke,
+        ToolControlGroup::Marker => ToolOptionsKind::Marker,
+        ToolControlGroup::Eraser => ToolOptionsKind::Eraser,
+        ToolControlGroup::Shape => ToolOptionsKind::Shape,
+        ToolControlGroup::Arrow => ToolOptionsKind::Arrow,
+        ToolControlGroup::StepMarker => ToolOptionsKind::StepMarker,
+    }
 }
 
 /// Context that determines which UI sections to show based on the active tool.
@@ -62,7 +75,7 @@ impl ToolContext {
             return Self::all_visible(snapshot);
         }
 
-        let effective_tool = snapshot.tool_override.unwrap_or(snapshot.active_tool);
+        let effective_tool = snapshot.active_tool;
         let text_or_note_active = snapshot.text_active || snapshot.note_active;
 
         // If text/note mode is active, show text controls
@@ -82,107 +95,22 @@ impl ToolContext {
             };
         }
 
-        // Compute base context from tool, then apply snapshot settings
-        let mut ctx = match effective_tool {
-            Tool::Select | Tool::Highlight => Self {
-                needs_color: false,
-                needs_thickness: false,
-                tool_options_kind: ToolOptionsKind::None,
-                thickness_label: "",
-                show_fill_toggle: false,
-                show_arrow_labels: false,
-                show_step_counter: false,
-                show_eraser_mode: false,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-            Tool::Pen | Tool::Line => Self {
-                needs_color: true,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::Stroke,
-                thickness_label: "Thickness",
-                show_fill_toggle: false,
-                show_arrow_labels: false,
-                show_step_counter: false,
-                show_eraser_mode: false,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-            Tool::Blur => Self {
-                needs_color: false,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::Stroke,
-                thickness_label: "Blur",
-                show_fill_toggle: false,
-                show_arrow_labels: false,
-                show_step_counter: false,
-                show_eraser_mode: false,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-            Tool::Marker => Self {
-                needs_color: true,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::Marker,
-                thickness_label: "Thickness",
-                show_fill_toggle: false,
-                show_arrow_labels: false,
-                show_step_counter: false,
-                show_eraser_mode: false,
-                show_marker_opacity: true,
-                show_font_controls: false,
-            },
-            Tool::Eraser => Self {
-                needs_color: false,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::Eraser,
-                thickness_label: "Eraser Size",
-                show_fill_toggle: false,
-                show_arrow_labels: false,
-                show_step_counter: false,
-                show_eraser_mode: true,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-            Tool::Rect | Tool::Ellipse => Self {
-                needs_color: true,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::Shape,
-                thickness_label: "Thickness",
-                show_fill_toggle: true,
-                show_arrow_labels: false,
-                show_step_counter: false,
-                show_eraser_mode: false,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-            Tool::Arrow => Self {
-                needs_color: true,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::Arrow,
-                thickness_label: "Thickness",
-                show_fill_toggle: false,
-                show_arrow_labels: true,
-                show_step_counter: false,
-                show_eraser_mode: false,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-            Tool::StepMarker => Self {
-                needs_color: true,
-                needs_thickness: true,
-                tool_options_kind: ToolOptionsKind::StepMarker,
-                thickness_label: "Size",
-                show_fill_toggle: false,
-                show_arrow_labels: false,
-                show_step_counter: true,
-                show_eraser_mode: false,
-                show_marker_opacity: false,
-                show_font_controls: false,
-            },
-        };
+        // Compute base context from the tool catalog, then apply snapshot settings.
+        let mut ctx = Self::from_profile(effective_tool.profile());
 
-        // Honor snapshot settings that override tool-based visibility
+        // Honor snapshot settings that override tool-based visibility.
+        // Temporary drag bindings can make the active size target differ from
+        // the selected top-toolbar override, so keep size-specific controls
+        // aligned with the snapshot target flags.
+        if snapshot.thickness_targets_eraser {
+            ctx.needs_thickness = true;
+            ctx.tool_options_kind = ToolOptionsKind::Eraser;
+            ctx.thickness_label = "Eraser size";
+            ctx.show_eraser_mode = true;
+        }
+        if snapshot.thickness_targets_marker {
+            ctx.show_marker_opacity = true;
+        }
         // show_text_controls: keep font controls visible even when text mode is inactive
         if snapshot.show_text_controls {
             ctx.show_font_controls = true;
@@ -195,12 +123,28 @@ impl ToolContext {
         ctx
     }
 
+    fn from_profile(profile: ToolProfile) -> Self {
+        Self {
+            needs_color: profile.needs_color,
+            needs_thickness: profile.needs_thickness_control(),
+            tool_options_kind: tool_options_kind_from_group(profile.control_group),
+            thickness_label: profile.thickness_label,
+            show_fill_toggle: profile.show_fill_toggle(),
+            show_arrow_labels: profile.show_arrow_labels(),
+            show_step_counter: profile.show_step_counter(),
+            show_eraser_mode: profile.show_eraser_mode(),
+            show_marker_opacity: profile.show_marker_opacity(),
+            show_font_controls: false,
+        }
+    }
+
     /// Returns a context where all sections are visible (classic/non-contextual behavior).
     fn all_visible(snapshot: &ToolbarSnapshot) -> Self {
-        let effective_tool = snapshot.tool_override.unwrap_or(snapshot.active_tool);
+        let effective_tool = snapshot.active_tool;
+        let profile = effective_tool.profile();
         let text_or_note_active = snapshot.text_active || snapshot.note_active;
-        let show_arrow_labels = effective_tool == Tool::Arrow || snapshot.arrow_label_enabled;
-        let show_step_counter = effective_tool == Tool::StepMarker;
+        let show_arrow_labels = profile.show_arrow_labels() || snapshot.arrow_label_enabled;
+        let show_step_counter = profile.show_step_counter();
         let show_marker_opacity =
             snapshot.show_marker_opacity_section || snapshot.thickness_targets_marker;
         let show_font_controls = text_or_note_active || snapshot.show_text_controls;


### PR DESCRIPTION
## Summary
- Centralizes overlay interaction cancellation and board lifecycle transitions.
- Adds a drawing tool profile catalog used by settings, presets, and toolbar context.
- Centralizes toolbar command modeling and reduces scattered per-tool/per-command conditionals.
- Fixes board restore handling when a deleted generated board id is reused.
- Keeps toolbar CI clippy-clean by replacing manual clamp patterns.