### PR TITLE
Refactor clipboard transfer into focused Wayland module

### DIFF
--- a/src/backend/wayland/clipboard/file_list.rs
+++ b/src/backend/wayland/clipboard/file_list.rs
@@ -1,6 +1,6 @@
 use super::{
     CLIPBOARD_READ_TIMEOUT, ClipboardPasteResult, ClipboardReadError, MAX_CLIPBOARD_IMAGE_BYTES,
-    decode_clipboard_image, read_pipe_with_timeout,
+    image::decode_clipboard_image, system::read_pipe_with_timeout,
 };
 use crate::file_uri;
 #[cfg(unix)]
@@ -198,7 +198,7 @@ fn is_gnome_copied_files_mime(mime_type: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::wayland::state::clipboard::choose_supported_mime;
+    use crate::backend::wayland::clipboard::image::choose_supported_mime;
     use std::fs;
     use tempfile::TempDir;
 

--- a/src/backend/wayland/clipboard/image.rs
+++ b/src/backend/wayland/clipboard/image.rs
@@ -1,0 +1,76 @@
+use super::{
+    ClipboardPasteResult, MAX_CLIPBOARD_IMAGE_PIXELS, WAYSCRIBER_SELECTION_MIME, file_list,
+};
+use crate::draw::EmbeddedImage;
+use crate::image_decode::{
+    EncodedImageFormat, decode_rgba, format_from_mime_or_bytes, image_dimensions,
+};
+
+pub(super) fn choose_supported_mime(offered: &[String]) -> Option<String> {
+    if let Some(mime) = [
+        WAYSCRIBER_SELECTION_MIME,
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+    ]
+    .into_iter()
+    .find(|candidate| offered.iter().any(|mime| mime == candidate))
+    .map(ToString::to_string)
+    {
+        return Some(mime);
+    }
+
+    offered
+        .iter()
+        .find(|mime| file_list::is_uri_list_mime(mime))
+        .cloned()
+}
+
+pub(super) fn decode_clipboard_image(mime_type: &str, bytes: Vec<u8>) -> ClipboardPasteResult {
+    let Some(format) = format_from_mime_or_bytes(mime_type, &bytes) else {
+        return ClipboardPasteResult::DecodeFailed(format!("unsupported MIME type {}", mime_type));
+    };
+    let dimensions = match image_dimensions(format, &bytes) {
+        Ok(dimensions) => dimensions,
+        Err(err) => return ClipboardPasteResult::DecodeFailed(err),
+    };
+    let pixels = dimensions.0 as u64 * dimensions.1 as u64;
+    if pixels > MAX_CLIPBOARD_IMAGE_PIXELS {
+        return ClipboardPasteResult::TooManyPixels {
+            width: dimensions.0,
+            height: dimensions.1,
+            limit: MAX_CLIPBOARD_IMAGE_PIXELS,
+        };
+    }
+    if let Err(err) = decode_rgba(format, &bytes) {
+        return ClipboardPasteResult::DecodeFailed(err);
+    }
+    ClipboardPasteResult::Image(EmbeddedImage {
+        mime_type: canonical_image_mime_type(format).to_string(),
+        width: dimensions.0,
+        height: dimensions.1,
+        bytes,
+    })
+}
+
+fn canonical_image_mime_type(format: EncodedImageFormat) -> &'static str {
+    match format {
+        EncodedImageFormat::Png => "image/png",
+        EncodedImageFormat::Jpeg => "image/jpeg",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::wayland::clipboard::MAX_CLIPBOARD_IMAGE_BYTES;
+
+    #[test]
+    fn image_byte_cap_leaves_room_for_default_persisted_create_history() {
+        let encoded_len = MAX_CLIPBOARD_IMAGE_BYTES.div_ceil(3) * 4;
+        let duplicated_history_len = encoded_len * 2;
+        let default_session_budget = 10 * 1024 * 1024;
+        let json_margin = 512 * 1024;
+
+        assert!(duplicated_history_len + json_margin < default_session_budget);
+    }
+}

--- a/src/backend/wayland/clipboard/mod.rs
+++ b/src/backend/wayland/clipboard/mod.rs
@@ -1,0 +1,73 @@
+//! Clipboard transfer rules and `wl-copy`/`wl-paste` integration for selections and images.
+
+use crate::draw::EmbeddedImage;
+use crate::input::state::{
+    ClipboardFingerprint, ClipboardPasteRequest, WayscriberClipboardSelection,
+};
+use std::time::Duration;
+
+pub(in crate::backend::wayland) use system::clipboard_fingerprint;
+pub(in crate::backend::wayland) use transfer::{
+    FailedLocalSelectionProbe, PasteAction, TransferEffect, TransferPlan, TransferWarning,
+};
+
+mod file_list;
+mod image;
+mod system;
+pub(in crate::backend::wayland) mod transfer;
+
+pub(super) const WAYSCRIBER_SELECTION_MIME: &str = "application/vnd.wayscriber.selection+json";
+
+// A pasted image is persisted in the visible frame and in the Create undo action.
+// Keep one accepted image comfortably below the default 10 MiB session JSON budget.
+pub(super) const MAX_CLIPBOARD_IMAGE_BYTES: usize = 3 * 1024 * 1024;
+pub(super) const MAX_CLIPBOARD_SELECTION_BYTES: usize = 2 * 1024 * 1024;
+pub(super) const MAX_CLIPBOARD_IMAGE_PIXELS: u64 = 48_000_000;
+pub(super) const CLIPBOARD_READ_TIMEOUT: Duration = Duration::from_millis(1500);
+pub(super) const CLIPBOARD_FINGERPRINT_BYTES: usize = 4096;
+pub(super) const CLIPBOARD_FINGERPRINT_TIMEOUT: Duration = Duration::from_millis(300);
+pub(super) const CLIPBOARD_PUBLISH_COMMAND_TIMEOUT: Duration = Duration::from_millis(750);
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct ClipboardPasteCompletion {
+    pub(in crate::backend::wayland) request: ClipboardPasteRequest,
+    pub(in crate::backend::wayland) result: ClipboardPasteResult,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct ClipboardPublishCompletion {
+    pub(in crate::backend::wayland) generation: u64,
+    pub(in crate::backend::wayland) fingerprint: Option<ClipboardFingerprint>,
+    pub(in crate::backend::wayland) copied: bool,
+    pub(in crate::backend::wayland) warning: Option<TransferWarning>,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) enum ClipboardPasteResult {
+    PrivateSelection(WayscriberClipboardSelection),
+    Image(EmbeddedImage),
+    ClipboardEmpty,
+    NoSupportedMime { offered: Vec<String> },
+    TooLarge { limit: usize },
+    TooManyPixels { width: u32, height: u32, limit: u64 },
+    DecodeFailed(String),
+    ReadTimedOut,
+    ClipboardUnavailable(String),
+    ClipboardError(String),
+    MalformedPrivateSelection(String),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ClipboardReadError {
+    Empty,
+    TooLarge { limit: usize },
+    TimedOut,
+    Unavailable(String),
+    Other(String),
+}
+
+#[derive(Debug)]
+pub(super) struct ClipboardPrefixRead {
+    pub(super) bytes: Vec<u8>,
+    pub(super) truncated: bool,
+}

--- a/src/backend/wayland/clipboard/system.rs
+++ b/src/backend/wayland/clipboard/system.rs
@@ -1,0 +1,373 @@
+use super::{
+    CLIPBOARD_FINGERPRINT_BYTES, CLIPBOARD_FINGERPRINT_TIMEOUT, CLIPBOARD_PUBLISH_COMMAND_TIMEOUT,
+    ClipboardPrefixRead, ClipboardReadError, image,
+};
+use crate::input::state::ClipboardFingerprint;
+use command::{ClipboardCommandRunner, WlClipboardCommandRunner};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io::{Read, Write};
+use std::process::Child;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+mod command;
+
+pub(super) fn publish_selection_clipboard(payload_json: &str) -> Result<(), String> {
+    publish_selection_with_runner(payload_json, &WlClipboardCommandRunner)
+}
+
+fn publish_selection_with_runner(
+    payload_json: &str,
+    runner: &impl ClipboardCommandRunner,
+) -> Result<(), String> {
+    let mut child = runner
+        .spawn_copy_selection()
+        .map_err(|err| format!("failed to spawn wl-copy: {}", err))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(err) = stdin.write_all(payload_json.as_bytes()) {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("failed to write to wl-copy stdin: {}", err));
+        }
+    } else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err("wl-copy stdin unavailable".to_string());
+    }
+
+    wait_for_wl_copy_publish(child, CLIPBOARD_PUBLISH_COMMAND_TIMEOUT)
+}
+
+fn wait_for_wl_copy_publish(mut child: Child, timeout: Duration) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                let stderr = read_child_stderr(&mut child).unwrap_or_default();
+                if stderr.is_empty() {
+                    return Err(format!("wl-copy exited unsuccessfully: {}", status));
+                }
+                return Err(format!(
+                    "wl-copy exited unsuccessfully: {} ({})",
+                    status, stderr
+                ));
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stderr = read_child_stderr(&mut child).unwrap_or_default();
+                if stderr.is_empty() {
+                    return Err("wl-copy did not finish publishing before timeout".to_string());
+                }
+                return Err(format!(
+                    "wl-copy did not finish publishing before timeout: {}",
+                    stderr
+                ));
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+            Err(err) => return Err(format!("failed to poll wl-copy status: {}", err)),
+        }
+    }
+}
+
+pub(in crate::backend::wayland) fn clipboard_fingerprint() -> Option<ClipboardFingerprint> {
+    let offered = list_mime_types().ok()?;
+    let selected_mime_type =
+        image::choose_supported_mime(&offered).or_else(|| offered.first().cloned());
+    let content_sample = selected_mime_type.as_ref().and_then(|mime| {
+        read_clipboard_mime_prefix(
+            mime,
+            CLIPBOARD_FINGERPRINT_BYTES,
+            CLIPBOARD_FINGERPRINT_TIMEOUT,
+        )
+        .ok()
+    });
+    let bounded_content_hash = content_sample
+        .as_ref()
+        .map(|sample| content_hash(&sample.bytes));
+    let bounded_content_len = content_sample.as_ref().map(|sample| sample.bytes.len());
+    let bounded_content_truncated = content_sample
+        .as_ref()
+        .is_some_and(|sample| sample.truncated);
+    Some(ClipboardFingerprint {
+        offered_mime_types: offered,
+        selected_mime_type,
+        bounded_content_hash,
+        bounded_content_len,
+        bounded_content_truncated,
+    })
+}
+
+pub(super) fn list_mime_types() -> Result<Vec<String>, ClipboardReadError> {
+    list_mime_types_with_runner(&WlClipboardCommandRunner)
+}
+
+fn list_mime_types_with_runner(
+    runner: &impl ClipboardCommandRunner,
+) -> Result<Vec<String>, ClipboardReadError> {
+    let output = runner.list_types().map_err(|err| {
+        ClipboardReadError::Unavailable(format!("Failed to spawn wl-paste: {}", err))
+    })?;
+
+    if output.status.success() {
+        let text = String::from_utf8_lossy(&output.stdout);
+        Ok(text
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToString::to_string)
+            .collect())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if stderr.to_ascii_lowercase().contains("nothing is copied")
+            || stderr.to_ascii_lowercase().contains("clipboard is empty")
+        {
+            Err(ClipboardReadError::Empty)
+        } else if stderr.is_empty() {
+            Err(ClipboardReadError::Other(
+                "wl-paste --list-types exited unsuccessfully".to_string(),
+            ))
+        } else {
+            Err(ClipboardReadError::Other(format!(
+                "wl-paste --list-types failed: {}",
+                stderr
+            )))
+        }
+    }
+}
+
+pub(super) fn read_clipboard_mime(
+    mime_type: &str,
+    limit: usize,
+    timeout: Duration,
+) -> Result<Vec<u8>, ClipboardReadError> {
+    read_clipboard_mime_with_runner(mime_type, limit, timeout, &WlClipboardCommandRunner)
+}
+
+fn read_clipboard_mime_prefix(
+    mime_type: &str,
+    limit: usize,
+    timeout: Duration,
+) -> Result<ClipboardPrefixRead, ClipboardReadError> {
+    read_clipboard_mime_prefix_with_runner(mime_type, limit, timeout, &WlClipboardCommandRunner)
+}
+
+fn read_clipboard_mime_with_runner(
+    mime_type: &str,
+    limit: usize,
+    timeout: Duration,
+    runner: &impl ClipboardCommandRunner,
+) -> Result<Vec<u8>, ClipboardReadError> {
+    let mut child = runner.spawn_paste_mime(mime_type).map_err(|err| {
+        ClipboardReadError::Unavailable(format!("Failed to spawn wl-paste: {}", err))
+    })?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| ClipboardReadError::Other("wl-paste stdout unavailable".to_string()))?;
+    let result = read_pipe_with_timeout(stdout, limit, timeout);
+    match result {
+        Err(ClipboardReadError::TimedOut) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(ClipboardReadError::TimedOut)
+        }
+        Err(ClipboardReadError::TooLarge { limit }) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(ClipboardReadError::TooLarge { limit })
+        }
+        Err(err) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(err)
+        }
+        Ok(bytes) => {
+            let status = child.wait().map_err(|err| {
+                ClipboardReadError::Other(format!("Failed to wait for wl-paste: {}", err))
+            })?;
+            if status.success() {
+                Ok(bytes)
+            } else {
+                let stderr = read_child_stderr(&mut child).unwrap_or_default();
+                if stderr.to_ascii_lowercase().contains("nothing is copied") {
+                    Err(ClipboardReadError::Empty)
+                } else if stderr.is_empty() {
+                    Err(ClipboardReadError::Other(
+                        "wl-paste exited unsuccessfully".to_string(),
+                    ))
+                } else {
+                    Err(ClipboardReadError::Other(format!(
+                        "wl-paste exited unsuccessfully: {}",
+                        stderr
+                    )))
+                }
+            }
+        }
+    }
+}
+
+fn read_clipboard_mime_prefix_with_runner(
+    mime_type: &str,
+    limit: usize,
+    timeout: Duration,
+    runner: &impl ClipboardCommandRunner,
+) -> Result<ClipboardPrefixRead, ClipboardReadError> {
+    let mut child = runner.spawn_paste_mime(mime_type).map_err(|err| {
+        ClipboardReadError::Unavailable(format!("Failed to spawn wl-paste: {}", err))
+    })?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| ClipboardReadError::Other("wl-paste stdout unavailable".to_string()))?;
+    let result = read_pipe_prefix_with_timeout(stdout, limit, timeout);
+    match result {
+        Err(ClipboardReadError::TimedOut) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(ClipboardReadError::TimedOut)
+        }
+        Err(err) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Err(err)
+        }
+        Ok(sample) if sample.truncated => {
+            let _ = child.kill();
+            let _ = child.wait();
+            Ok(sample)
+        }
+        Ok(sample) => {
+            let status = child.wait().map_err(|err| {
+                ClipboardReadError::Other(format!("Failed to wait for wl-paste: {}", err))
+            })?;
+            if status.success() {
+                Ok(sample)
+            } else {
+                let stderr = read_child_stderr(&mut child).unwrap_or_default();
+                if stderr.to_ascii_lowercase().contains("nothing is copied") {
+                    Err(ClipboardReadError::Empty)
+                } else if stderr.is_empty() {
+                    Err(ClipboardReadError::Other(
+                        "wl-paste exited unsuccessfully".to_string(),
+                    ))
+                } else {
+                    Err(ClipboardReadError::Other(format!(
+                        "wl-paste exited unsuccessfully: {}",
+                        stderr
+                    )))
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn read_pipe_with_timeout<R>(
+    reader: R,
+    limit: usize,
+    timeout: Duration,
+) -> Result<Vec<u8>, ClipboardReadError>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(read_limited(reader, limit));
+    });
+    rx.recv_timeout(timeout)
+        .map_err(|_| ClipboardReadError::TimedOut)?
+}
+
+fn read_pipe_prefix_with_timeout<R>(
+    reader: R,
+    limit: usize,
+    timeout: Duration,
+) -> Result<ClipboardPrefixRead, ClipboardReadError>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(read_prefix(reader, limit));
+    });
+    rx.recv_timeout(timeout)
+        .map_err(|_| ClipboardReadError::TimedOut)?
+}
+
+fn read_limited<R: Read>(mut reader: R, limit: usize) -> Result<Vec<u8>, ClipboardReadError> {
+    let mut data = Vec::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer).map_err(|err| {
+            ClipboardReadError::Other(format!("Failed to read clipboard: {}", err))
+        })?;
+        if read == 0 {
+            break;
+        }
+        if data.len().saturating_add(read) > limit {
+            return Err(ClipboardReadError::TooLarge { limit });
+        }
+        data.extend_from_slice(&buffer[..read]);
+    }
+    Ok(data)
+}
+
+fn read_prefix<R: Read>(
+    mut reader: R,
+    limit: usize,
+) -> Result<ClipboardPrefixRead, ClipboardReadError> {
+    let mut data = Vec::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        if data.len() >= limit {
+            return Ok(ClipboardPrefixRead {
+                bytes: data,
+                truncated: true,
+            });
+        }
+
+        let read = reader.read(&mut buffer).map_err(|err| {
+            ClipboardReadError::Other(format!("Failed to read clipboard: {}", err))
+        })?;
+        if read == 0 {
+            break;
+        }
+
+        let remaining = limit.saturating_sub(data.len());
+        if read > remaining {
+            data.extend_from_slice(&buffer[..remaining]);
+            return Ok(ClipboardPrefixRead {
+                bytes: data,
+                truncated: true,
+            });
+        }
+        data.extend_from_slice(&buffer[..read]);
+    }
+    Ok(ClipboardPrefixRead {
+        bytes: data,
+        truncated: false,
+    })
+}
+
+fn read_child_stderr(child: &mut std::process::Child) -> Option<String> {
+    child.stderr.take().and_then(|mut stderr| {
+        let mut bytes = Vec::new();
+        let _ = stderr.read_to_end(&mut bytes);
+        let text = String::from_utf8_lossy(&bytes).trim().to_string();
+        (!text.is_empty()).then_some(text)
+    })
+}
+
+fn content_hash(bytes: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/wayland/clipboard/system/command.rs
+++ b/src/backend/wayland/clipboard/system/command.rs
@@ -1,0 +1,39 @@
+use super::super::WAYSCRIBER_SELECTION_MIME;
+use std::process::{Child, Command, Output, Stdio};
+
+pub(super) trait ClipboardCommandRunner {
+    fn list_types(&self) -> std::io::Result<Output>;
+    fn spawn_paste_mime(&self, mime_type: &str) -> std::io::Result<Child>;
+    fn spawn_copy_selection(&self) -> std::io::Result<Child>;
+}
+
+pub(super) struct WlClipboardCommandRunner;
+
+impl ClipboardCommandRunner for WlClipboardCommandRunner {
+    fn list_types(&self) -> std::io::Result<Output> {
+        Command::new("wl-paste")
+            .arg("--list-types")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+    }
+
+    fn spawn_paste_mime(&self, mime_type: &str) -> std::io::Result<Child> {
+        Command::new("wl-paste")
+            .arg("--type")
+            .arg(mime_type)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    }
+
+    fn spawn_copy_selection(&self) -> std::io::Result<Child> {
+        Command::new("wl-copy")
+            .arg("--type")
+            .arg(WAYSCRIBER_SELECTION_MIME)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+    }
+}

--- a/src/backend/wayland/clipboard/system/tests.rs
+++ b/src/backend/wayland/clipboard/system/tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+use std::io::{self, Cursor, Read};
+
+struct ExactLimitThenError {
+    bytes: Vec<u8>,
+    read_once: bool,
+}
+
+impl Read for ExactLimitThenError {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self.read_once {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "unexpected second read",
+            ));
+        }
+        self.read_once = true;
+        let len = self.bytes.len().min(buffer.len());
+        buffer[..len].copy_from_slice(&self.bytes[..len]);
+        Ok(len)
+    }
+}
+
+#[test]
+fn strict_read_rejects_data_over_limit() {
+    let err = read_limited(Cursor::new(vec![1, 2, 3, 4, 5]), 4).expect_err("over limit");
+
+    assert!(matches!(err, ClipboardReadError::TooLarge { limit: 4 }));
+}
+
+#[test]
+fn prefix_read_returns_bounded_sample_for_data_over_limit() {
+    let sample = read_prefix(Cursor::new(vec![1, 2, 3, 4, 5]), 4).expect("prefix sample");
+
+    assert_eq!(sample.bytes, vec![1, 2, 3, 4]);
+    assert!(sample.truncated);
+}
+
+#[test]
+fn prefix_read_returns_when_first_read_reaches_limit() {
+    let reader = ExactLimitThenError {
+        bytes: vec![1, 2, 3, 4],
+        read_once: false,
+    };
+    let sample = read_prefix(reader, 4).expect("prefix sample");
+
+    assert_eq!(sample.bytes, vec![1, 2, 3, 4]);
+    assert!(sample.truncated);
+}
+
+#[test]
+fn prefix_read_marks_small_data_untruncated() {
+    let sample = read_prefix(Cursor::new(vec![1, 2, 3]), 4).expect("prefix sample");
+
+    assert_eq!(sample.bytes, vec![1, 2, 3]);
+    assert!(!sample.truncated);
+}

--- a/src/backend/wayland/clipboard/transfer.rs
+++ b/src/backend/wayland/clipboard/transfer.rs
@@ -1,0 +1,394 @@
+use super::{
+    CLIPBOARD_READ_TIMEOUT, ClipboardPasteCompletion, ClipboardPasteResult,
+    ClipboardPublishCompletion, ClipboardReadError, MAX_CLIPBOARD_IMAGE_BYTES,
+    MAX_CLIPBOARD_SELECTION_BYTES, WAYSCRIBER_SELECTION_MIME, file_list, image, system,
+};
+use crate::draw::{EmbeddedImage, Shape};
+use crate::input::state::{
+    ClipboardFingerprint, ClipboardPasteRequest, WayscriberClipboardSelection,
+};
+
+#[derive(Debug, Clone)]
+pub(in crate::backend::wayland) struct FailedLocalSelectionProbe {
+    pub(in crate::backend::wayland) generation: u64,
+    pub(in crate::backend::wayland) expected: Option<ClipboardFingerprint>,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct TransferPlan<T> {
+    pub(in crate::backend::wayland) effects: Vec<TransferEffect>,
+    pub(in crate::backend::wayland) action: T,
+}
+
+impl<T> TransferPlan<T> {
+    fn action(action: T) -> Self {
+        Self {
+            effects: Vec::new(),
+            action,
+        }
+    }
+
+    fn with_effects(effects: Vec<TransferEffect>, action: T) -> Self {
+        Self { effects, action }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum TransferEffect {
+    SupersedeLocalGeneration { generation: u64 },
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) enum PasteAction {
+    UseLocalShapes {
+        request: ClipboardPasteRequest,
+        shapes: Vec<Shape>,
+        warning: Option<TransferWarning>,
+    },
+    ProbeSystemFingerprint {
+        request: ClipboardPasteRequest,
+        generation: u64,
+        expected: Option<ClipboardFingerprint>,
+    },
+    ReadSystemClipboard {
+        request: ClipboardPasteRequest,
+    },
+    StaleCompletion {
+        request_id: u64,
+    },
+    ApplyPrivateSelection {
+        request: ClipboardPasteRequest,
+        shapes: Vec<Shape>,
+    },
+    ApplyExternalImage {
+        request: ClipboardPasteRequest,
+        image: EmbeddedImage,
+    },
+    TryFreshLocalFallbackOrWarn {
+        request: ClipboardPasteRequest,
+        missing_warning: TransferWarning,
+        fallback_message: &'static str,
+    },
+    ShowWarning {
+        request: ClipboardPasteRequest,
+        warning: TransferWarning,
+        block_feedback: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum TransferWarning {
+    PublishSelectionTooLarge,
+    PublishUnavailable,
+    NothingPasted,
+    NoShapesPasted,
+    ClipboardEmpty,
+    UnsupportedContent,
+    TooLarge { limit: usize },
+    TooManyPixels { width: u32, height: u32, limit: u64 },
+    DecodeFailed,
+    ReadTimedOut,
+    ClipboardUnavailable,
+    ClipboardError,
+    MalformedPrivateSelection,
+}
+
+pub(in crate::backend::wayland) fn resolve_selection_clipboard_publish(
+    generation: u64,
+    payload_json: String,
+) -> ClipboardPublishCompletion {
+    if payload_json.len() > MAX_CLIPBOARD_SELECTION_BYTES {
+        return ClipboardPublishCompletion {
+            generation,
+            fingerprint: system::clipboard_fingerprint(),
+            copied: false,
+            warning: Some(TransferWarning::PublishSelectionTooLarge),
+        };
+    }
+
+    let copied =
+        match std::panic::catch_unwind(|| system::publish_selection_clipboard(&payload_json)) {
+            Ok(Ok(())) => true,
+            Ok(Err(err)) => {
+                log::warn!("Selection clipboard publish failed: {}", err);
+                false
+            }
+            Err(_) => {
+                log::error!("Selection clipboard publish panicked");
+                false
+            }
+        };
+
+    ClipboardPublishCompletion {
+        generation,
+        fingerprint: if copied {
+            None
+        } else {
+            system::clipboard_fingerprint()
+        },
+        copied,
+        warning: (!copied).then_some(TransferWarning::PublishUnavailable),
+    }
+}
+
+pub(in crate::backend::wayland) fn resolve_system_clipboard() -> ClipboardPasteResult {
+    let offered = match system::list_mime_types() {
+        Ok(types) if types.is_empty() => return ClipboardPasteResult::ClipboardEmpty,
+        Ok(types) => types,
+        Err(ClipboardReadError::Empty) => return ClipboardPasteResult::ClipboardEmpty,
+        Err(ClipboardReadError::Unavailable(err)) => {
+            return ClipboardPasteResult::ClipboardUnavailable(err);
+        }
+        Err(err) => return map_read_error(err),
+    };
+
+    let Some(mime_type) = image::choose_supported_mime(&offered) else {
+        return ClipboardPasteResult::NoSupportedMime { offered };
+    };
+    let limit = if mime_type == WAYSCRIBER_SELECTION_MIME {
+        MAX_CLIPBOARD_SELECTION_BYTES
+    } else {
+        MAX_CLIPBOARD_IMAGE_BYTES
+    };
+
+    let bytes = match system::read_clipboard_mime(&mime_type, limit, CLIPBOARD_READ_TIMEOUT) {
+        Ok(bytes) if bytes.is_empty() => return ClipboardPasteResult::ClipboardEmpty,
+        Ok(bytes) => bytes,
+        Err(err) => return map_read_error(err),
+    };
+
+    if mime_type == WAYSCRIBER_SELECTION_MIME {
+        return serde_json::from_slice::<WayscriberClipboardSelection>(&bytes)
+            .map(ClipboardPasteResult::PrivateSelection)
+            .unwrap_or_else(|err| {
+                ClipboardPasteResult::MalformedPrivateSelection(err.to_string())
+            });
+    }
+
+    if file_list::is_uri_list_mime(&mime_type) {
+        return file_list::decode_clipboard_uri_list(&mime_type, bytes, offered);
+    }
+
+    image::decode_clipboard_image(&mime_type, bytes)
+}
+
+pub(in crate::backend::wayland) fn plan_paste_start(
+    request: ClipboardPasteRequest,
+    pending_local_shapes: Option<Vec<Shape>>,
+    failed_probe: Option<FailedLocalSelectionProbe>,
+) -> TransferPlan<PasteAction> {
+    if let Some(shapes) = pending_local_shapes {
+        return TransferPlan::action(PasteAction::UseLocalShapes {
+            request,
+            shapes,
+            warning: None,
+        });
+    }
+
+    if let Some(failed_probe) = failed_probe {
+        return TransferPlan::action(PasteAction::ProbeSystemFingerprint {
+            request,
+            generation: failed_probe.generation,
+            expected: failed_probe.expected,
+        });
+    }
+
+    TransferPlan::action(PasteAction::ReadSystemClipboard { request })
+}
+
+pub(in crate::backend::wayland) fn plan_after_fingerprint_probe(
+    request: ClipboardPasteRequest,
+    generation: u64,
+    expected: Option<ClipboardFingerprint>,
+    current: Option<ClipboardFingerprint>,
+    local_shapes: Option<Vec<Shape>>,
+) -> TransferPlan<PasteAction> {
+    match (expected.as_ref(), current.as_ref()) {
+        (Some(previous), Some(current)) if previous == current => {
+            if let Some(shapes) = local_shapes {
+                TransferPlan::action(PasteAction::UseLocalShapes {
+                    request,
+                    shapes,
+                    warning: None,
+                })
+            } else {
+                TransferPlan::action(PasteAction::ReadSystemClipboard { request })
+            }
+        }
+        (None, None) => TransferPlan::action(PasteAction::ReadSystemClipboard { request }),
+        _ => TransferPlan::with_effects(
+            vec![TransferEffect::SupersedeLocalGeneration { generation }],
+            PasteAction::ReadSystemClipboard { request },
+        ),
+    }
+}
+
+pub(in crate::backend::wayland) fn plan_paste_completion(
+    completion: ClipboardPasteCompletion,
+    active_request_id: Option<u64>,
+    private_payload: Option<PrivateSelectionResolution>,
+) -> TransferPlan<PasteAction> {
+    let ClipboardPasteCompletion { request, result } = completion;
+    if active_request_id != Some(request.id) {
+        return TransferPlan::action(PasteAction::StaleCompletion {
+            request_id: request.id,
+        });
+    }
+
+    match result {
+        ClipboardPasteResult::PrivateSelection(_) => {
+            let private_payload = private_payload.expect("private payload resolution required");
+            plan_private_selection_completion(request, private_payload)
+        }
+        ClipboardPasteResult::Image(image) => TransferPlan::with_effects(
+            supersede_request_generation(&request),
+            PasteAction::ApplyExternalImage { request, image },
+        ),
+        ClipboardPasteResult::ClipboardEmpty => TransferPlan::with_effects(
+            supersede_request_generation(&request),
+            PasteAction::ShowWarning {
+                request,
+                warning: TransferWarning::ClipboardEmpty,
+                block_feedback: true,
+            },
+        ),
+        ClipboardPasteResult::ClipboardUnavailable(err) => {
+            log::warn!("Clipboard unavailable: {}", err);
+            TransferPlan::action(PasteAction::TryFreshLocalFallbackOrWarn {
+                request,
+                missing_warning: TransferWarning::ClipboardUnavailable,
+                fallback_message: "System clipboard unavailable; pasted local copy.",
+            })
+        }
+        ClipboardPasteResult::NoSupportedMime { offered } => {
+            log::debug!("Unsupported clipboard MIME types: {:?}", offered);
+            TransferPlan::with_effects(
+                supersede_request_generation(&request),
+                PasteAction::ShowWarning {
+                    request,
+                    warning: TransferWarning::UnsupportedContent,
+                    block_feedback: true,
+                },
+            )
+        }
+        ClipboardPasteResult::TooLarge { limit } => TransferPlan::with_effects(
+            supersede_request_generation(&request),
+            PasteAction::ShowWarning {
+                request,
+                warning: TransferWarning::TooLarge { limit },
+                block_feedback: true,
+            },
+        ),
+        ClipboardPasteResult::TooManyPixels {
+            width,
+            height,
+            limit,
+        } => TransferPlan::with_effects(
+            supersede_request_generation(&request),
+            PasteAction::ShowWarning {
+                request,
+                warning: TransferWarning::TooManyPixels {
+                    width,
+                    height,
+                    limit,
+                },
+                block_feedback: true,
+            },
+        ),
+        ClipboardPasteResult::DecodeFailed(err) => {
+            log::warn!("Clipboard image decode failed: {}", err);
+            TransferPlan::with_effects(
+                supersede_request_generation(&request),
+                PasteAction::ShowWarning {
+                    request,
+                    warning: TransferWarning::DecodeFailed,
+                    block_feedback: true,
+                },
+            )
+        }
+        ClipboardPasteResult::ReadTimedOut => {
+            TransferPlan::action(PasteAction::TryFreshLocalFallbackOrWarn {
+                request,
+                missing_warning: TransferWarning::ReadTimedOut,
+                fallback_message: "Clipboard read timed out; pasted local copy.",
+            })
+        }
+        ClipboardPasteResult::ClipboardError(err) => {
+            log::warn!("Clipboard paste error: {}", err);
+            TransferPlan::action(PasteAction::TryFreshLocalFallbackOrWarn {
+                request,
+                missing_warning: TransferWarning::ClipboardError,
+                fallback_message: "Failed to read clipboard; pasted local copy.",
+            })
+        }
+        ClipboardPasteResult::MalformedPrivateSelection(err) => {
+            log::warn!("Malformed Wayscriber clipboard payload: {}", err);
+            TransferPlan::with_effects(
+                supersede_request_generation(&request),
+                PasteAction::ShowWarning {
+                    request,
+                    warning: TransferWarning::MalformedPrivateSelection,
+                    block_feedback: true,
+                },
+            )
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct PrivateSelectionResolution {
+    pub(in crate::backend::wayland) payload_matches_local: bool,
+    pub(in crate::backend::wayland) same_instance: bool,
+    pub(in crate::backend::wayland) shapes: Option<Vec<Shape>>,
+}
+
+fn plan_private_selection_completion(
+    request: ClipboardPasteRequest,
+    resolution: PrivateSelectionResolution,
+) -> TransferPlan<PasteAction> {
+    let effects = if resolution.payload_matches_local {
+        Vec::new()
+    } else {
+        supersede_request_generation(&request)
+    };
+
+    if let Some(shapes) = resolution.shapes {
+        return TransferPlan::with_effects(
+            effects,
+            PasteAction::ApplyPrivateSelection { request, shapes },
+        );
+    }
+
+    if resolution.same_instance {
+        log::debug!("Same-instance clipboard payload did not match paste request generation");
+    }
+    TransferPlan::with_effects(
+        effects,
+        PasteAction::ShowWarning {
+            request,
+            warning: TransferWarning::NoShapesPasted,
+            block_feedback: true,
+        },
+    )
+}
+
+fn supersede_request_generation(request: &ClipboardPasteRequest) -> Vec<TransferEffect> {
+    request
+        .local_selection_fallback_generation
+        .map(|generation| TransferEffect::SupersedeLocalGeneration { generation })
+        .into_iter()
+        .collect()
+}
+
+fn map_read_error(err: ClipboardReadError) -> ClipboardPasteResult {
+    match err {
+        ClipboardReadError::Empty => ClipboardPasteResult::ClipboardEmpty,
+        ClipboardReadError::TooLarge { limit } => ClipboardPasteResult::TooLarge { limit },
+        ClipboardReadError::TimedOut => ClipboardPasteResult::ReadTimedOut,
+        ClipboardReadError::Unavailable(err) => ClipboardPasteResult::ClipboardUnavailable(err),
+        ClipboardReadError::Other(err) => ClipboardPasteResult::ClipboardError(err),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/wayland/clipboard/transfer/tests.rs
+++ b/src/backend/wayland/clipboard/transfer/tests.rs
@@ -1,0 +1,142 @@
+use super::*;
+use crate::draw::Shape;
+use crate::util::Rect;
+
+#[test]
+fn fingerprint_mismatch_supersedes_then_reads_system_clipboard() {
+    let request = request_with_fallback_generation(Some(7));
+    let previous = fingerprint(1);
+    let current = fingerprint(2);
+
+    let plan = plan_after_fingerprint_probe(request, 7, Some(previous), Some(current), None);
+
+    assert_eq!(
+        plan.effects,
+        vec![TransferEffect::SupersedeLocalGeneration { generation: 7 }]
+    );
+    assert!(matches!(
+        plan.action,
+        PasteAction::ReadSystemClipboard { .. }
+    ));
+}
+
+#[test]
+fn timeout_uses_fresh_fallback_action_instead_of_captured_shapes() {
+    let request = request_with_fallback_generation(Some(7));
+    let completion = ClipboardPasteCompletion {
+        request,
+        result: ClipboardPasteResult::ReadTimedOut,
+    };
+
+    let plan = plan_paste_completion(completion, Some(42), None);
+
+    assert!(plan.effects.is_empty());
+    assert!(matches!(
+        plan.action,
+        PasteAction::TryFreshLocalFallbackOrWarn { .. }
+    ));
+}
+
+#[test]
+fn same_instance_nonmatching_generation_does_not_apply_private_selection() {
+    let request = request_with_fallback_generation(Some(7));
+    let completion = ClipboardPasteCompletion {
+        request,
+        result: ClipboardPasteResult::PrivateSelection(WayscriberClipboardSelection {
+            schema_version: 1,
+            app_version: "test".to_string(),
+            app_instance_id: "same".to_string(),
+            copy_generation: 8,
+            shapes: vec![rect()],
+        }),
+    };
+    let resolution = PrivateSelectionResolution {
+        payload_matches_local: false,
+        same_instance: true,
+        shapes: None,
+    };
+
+    let plan = plan_paste_completion(completion, Some(42), Some(resolution));
+
+    assert_eq!(
+        plan.effects,
+        vec![TransferEffect::SupersedeLocalGeneration { generation: 7 }]
+    );
+    assert!(matches!(
+        plan.action,
+        PasteAction::ShowWarning {
+            request: _,
+            warning: TransferWarning::NoShapesPasted,
+            block_feedback: true,
+        }
+    ));
+}
+
+#[test]
+fn different_instance_private_payload_supersedes_then_applies_shapes() {
+    let request = request_with_fallback_generation(Some(7));
+    let completion = ClipboardPasteCompletion {
+        request,
+        result: ClipboardPasteResult::PrivateSelection(WayscriberClipboardSelection {
+            schema_version: 1,
+            app_version: "test".to_string(),
+            app_instance_id: "other".to_string(),
+            copy_generation: 8,
+            shapes: vec![rect()],
+        }),
+    };
+    let resolution = PrivateSelectionResolution {
+        payload_matches_local: false,
+        same_instance: false,
+        shapes: Some(vec![rect()]),
+    };
+
+    let plan = plan_paste_completion(completion, Some(42), Some(resolution));
+
+    assert_eq!(
+        plan.effects,
+        vec![TransferEffect::SupersedeLocalGeneration { generation: 7 }]
+    );
+    assert!(matches!(
+        plan.action,
+        PasteAction::ApplyPrivateSelection { .. }
+    ));
+}
+
+fn request_with_fallback_generation(
+    local_selection_fallback_generation: Option<u64>,
+) -> ClipboardPasteRequest {
+    ClipboardPasteRequest {
+        id: 42,
+        target_board_id: "board".to_string(),
+        target_page_index: 0,
+        target_page_generation: 1,
+        anchor: crate::input::state::PasteAnchor::VisibleCenter { x: 50, y: 50 },
+        visible_canvas_rect: Rect::new(0, 0, 100, 100).unwrap(),
+        screen_size: (100, 100),
+        selection_clipboard_generation_at_request: local_selection_fallback_generation.unwrap_or(0),
+        local_selection_fallback_generation,
+    }
+}
+
+fn fingerprint(hash: u64) -> ClipboardFingerprint {
+    ClipboardFingerprint {
+        offered_mime_types: vec!["image/png".to_string()],
+        selected_mime_type: Some("image/png".to_string()),
+        bounded_content_hash: Some(hash),
+        bounded_content_len: Some(4),
+        bounded_content_truncated: false,
+    }
+}
+
+fn rect() -> Shape {
+    Shape::Rect {
+        x: 0,
+        y: 0,
+        w: 10,
+        h: 10,
+        fill: false,
+        color: crate::draw::BLACK,
+        thick: 1.0,
+    }
+}

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod capture;
+mod clipboard;
 mod frozen;
 mod frozen_geometry;
 mod handlers;

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -55,11 +55,11 @@ use crate::{
     ui::toolbar::{ToolbarBindingHints, ToolbarEvent, ToolbarSnapshot},
 };
 
-use self::clipboard::{ClipboardPasteCompletion, ClipboardPublishCompletion};
 use self::data::{MoveDrag, StateData};
 pub use self::data::{MoveDragKind, OverlaySuppression};
 use super::{
     capture::CaptureState,
+    clipboard::{ClipboardPasteCompletion, ClipboardPublishCompletion},
     frozen::FrozenState,
     overlay_passthrough::set_surface_clickthrough,
     session::SessionState,

--- a/src/backend/wayland/state/clipboard.rs
+++ b/src/backend/wayland/state/clipboard.rs
@@ -1,77 +1,14 @@
-//! Clipboard publish and paste helpers for drawable shape selections and images.
+//! Wayland-state glue for clipboard publish and paste requests.
 
 use super::WaylandState;
-use crate::draw::EmbeddedImage;
-use crate::image_decode::{
-    EncodedImageFormat, decode_rgba, format_from_mime_or_bytes, image_dimensions,
+use crate::backend::wayland::clipboard::{
+    self, ClipboardPasteCompletion, ClipboardPasteResult, ClipboardPublishCompletion,
+    FailedLocalSelectionProbe, PasteAction, TransferEffect, TransferPlan, TransferWarning,
+    transfer,
 };
-use crate::input::state::{
-    ClipboardFingerprint, ClipboardPasteRequest, UiToastKind, WayscriberClipboardSelection,
-};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::io::{Read, Write};
-use std::process::{Child, Command, Stdio};
+use crate::input::state::{ClipboardPasteRequest, UiToastKind};
 use std::sync::mpsc;
-use std::time::{Duration, Instant};
-
-pub(super) const WAYSCRIBER_SELECTION_MIME: &str = "application/vnd.wayscriber.selection+json";
-
-mod file_list;
-
-// A pasted image is persisted in the visible frame and in the Create undo action.
-// Keep one accepted image comfortably below the default 10 MiB session JSON budget.
-const MAX_CLIPBOARD_IMAGE_BYTES: usize = 3 * 1024 * 1024;
-const MAX_CLIPBOARD_SELECTION_BYTES: usize = 2 * 1024 * 1024;
-const MAX_CLIPBOARD_IMAGE_PIXELS: u64 = 48_000_000;
-const CLIPBOARD_READ_TIMEOUT: Duration = Duration::from_millis(1500);
-const CLIPBOARD_FINGERPRINT_BYTES: usize = 4096;
-const CLIPBOARD_FINGERPRINT_TIMEOUT: Duration = Duration::from_millis(300);
-const CLIPBOARD_PUBLISH_COMMAND_TIMEOUT: Duration = Duration::from_millis(750);
-
-#[derive(Debug)]
-pub(in crate::backend::wayland) struct ClipboardPasteCompletion {
-    request: ClipboardPasteRequest,
-    result: ClipboardPasteResult,
-}
-
-#[derive(Debug)]
-pub(in crate::backend::wayland) struct ClipboardPublishCompletion {
-    generation: u64,
-    fingerprint: Option<ClipboardFingerprint>,
-    copied: bool,
-    warning: Option<&'static str>,
-}
-
-#[derive(Debug)]
-enum ClipboardPasteResult {
-    PrivateSelection(WayscriberClipboardSelection),
-    Image(EmbeddedImage),
-    ClipboardEmpty,
-    NoSupportedMime { offered: Vec<String> },
-    TooLarge { limit: usize },
-    TooManyPixels { width: u32, height: u32, limit: u64 },
-    DecodeFailed(String),
-    ReadTimedOut,
-    ClipboardUnavailable(String),
-    ClipboardError(String),
-    MalformedPrivateSelection(String),
-}
-
-#[derive(Debug)]
-enum ClipboardReadError {
-    Empty,
-    TooLarge { limit: usize },
-    TimedOut,
-    Unavailable(String),
-    Other(String),
-}
-
-#[derive(Debug)]
-struct ClipboardPrefixRead {
-    bytes: Vec<u8>,
-    truncated: bool,
-}
+use std::time::Duration;
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn drain_clipboard_requests(&mut self) {
@@ -113,7 +50,8 @@ impl WaylandState {
         let (tx, rx) = mpsc::channel();
         self.clipboard_publish_rx = Some(rx);
         std::thread::spawn(move || {
-            let completion = resolve_selection_clipboard_publish(generation, payload_json);
+            let completion =
+                transfer::resolve_selection_clipboard_publish(generation, payload_json);
             let _ = tx.send(completion);
         });
     }
@@ -128,215 +66,168 @@ impl WaylandState {
             completion.copied,
         );
         if applied && let Some(warning) = completion.warning {
-            self.input_state.set_ui_toast(UiToastKind::Warning, warning);
+            self.set_transfer_warning_toast(warning);
         }
     }
 
     fn start_clipboard_paste(&mut self, request: ClipboardPasteRequest) {
         self.suppress_focus_exit_for(Duration::from_millis(1500));
 
-        if let Some(shapes) = self
+        let pending_shapes = self.input_state.local_selection_shapes_for_pending_publish(
+            request.local_selection_fallback_generation,
+        );
+        let failed_probe = self
             .input_state
-            .local_selection_shapes_for_pending_publish(request.local_selection_fallback_generation)
-        {
-            let pasted = self
-                .input_state
-                .paste_clipboard_shapes_from_request(&request, shapes);
-            self.input_state.finish_clipboard_paste_request(request.id);
-            if pasted == 0 {
-                self.input_state
-                    .set_ui_toast(UiToastKind::Warning, "Nothing pasted.");
-                self.input_state.trigger_blocked_feedback();
+            .failed_local_selection_probe_for_generation(
+                request.local_selection_fallback_generation,
+            )
+            .map(|(generation, expected)| FailedLocalSelectionProbe {
+                generation,
+                expected,
+            });
+        let plan = transfer::plan_paste_start(request, pending_shapes, failed_probe);
+        self.apply_paste_plan(plan);
+    }
+
+    fn apply_clipboard_paste_completion(&mut self, completion: ClipboardPasteCompletion) {
+        let active_request_id = self.input_state.active_clipboard_paste_request_id();
+        let private_payload = match &completion.result {
+            ClipboardPasteResult::PrivateSelection(payload)
+                if active_request_id == Some(completion.request.id) =>
+            {
+                let payload_matches_local = self
+                    .input_state
+                    .private_payload_matches_request_selection(&completion.request, payload);
+                let same_instance = self.input_state.private_payload_is_same_instance(payload);
+                let shapes = self
+                    .input_state
+                    .private_payload_shapes_for_request(&completion.request, payload.clone());
+                Some(transfer::PrivateSelectionResolution {
+                    payload_matches_local,
+                    same_instance,
+                    shapes,
+                })
             }
-            return;
+            _ => None,
+        };
+        let plan = transfer::plan_paste_completion(completion, active_request_id, private_payload);
+        self.apply_paste_plan(plan);
+    }
+
+    fn apply_paste_plan(&mut self, plan: TransferPlan<PasteAction>) {
+        for effect in plan.effects {
+            self.apply_transfer_effect(effect);
         }
 
-        if self
-            .input_state
-            .has_failed_local_selection_for_generation(request.local_selection_fallback_generation)
-        {
-            let fingerprint = clipboard_fingerprint();
-            if let Some(shapes) = self
-                .input_state
-                .failed_local_selection_after_fingerprint_probe(
-                    request.local_selection_fallback_generation,
-                    fingerprint,
-                )
-            {
+        match plan.action {
+            PasteAction::UseLocalShapes {
+                request,
+                shapes,
+                warning,
+            } => {
                 let pasted = self
                     .input_state
                     .paste_clipboard_shapes_from_request(&request, shapes);
                 self.input_state.finish_clipboard_paste_request(request.id);
                 if pasted == 0 {
-                    self.input_state
-                        .set_ui_toast(UiToastKind::Warning, "Nothing pasted.");
-                    self.input_state.trigger_blocked_feedback();
-                }
-                return;
-            }
-        }
-
-        let (tx, rx) = mpsc::channel();
-        self.clipboard_paste_rx = Some(rx);
-        std::thread::spawn(move || {
-            let result = resolve_system_clipboard();
-            let _ = tx.send(ClipboardPasteCompletion { request, result });
-        });
-    }
-
-    fn apply_clipboard_paste_completion(&mut self, completion: ClipboardPasteCompletion) {
-        let ClipboardPasteCompletion { request, result } = completion;
-        if self.input_state.active_clipboard_paste_request_id() != Some(request.id) {
-            return;
-        }
-
-        match result {
-            ClipboardPasteResult::PrivateSelection(payload) => {
-                let payload_matches_local = self
-                    .input_state
-                    .private_payload_matches_request_selection(&request, &payload);
-                let shapes = self
-                    .input_state
-                    .private_payload_shapes_for_request(&request, payload);
-                if !payload_matches_local {
-                    self.input_state
-                        .mark_selection_clipboard_superseded_for_generation(
-                            request.local_selection_fallback_generation,
-                        );
-                }
-                let pasted = shapes
-                    .map(|shapes| {
-                        self.input_state
-                            .paste_clipboard_shapes_from_request(&request, shapes)
-                    })
-                    .unwrap_or(0);
-                if pasted == 0 {
-                    self.input_state
-                        .set_ui_toast(UiToastKind::Warning, "No shapes pasted.");
-                    self.input_state.trigger_blocked_feedback();
-                }
-            }
-            ClipboardPasteResult::Image(image) => {
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
+                    self.set_transfer_warning_toast(
+                        warning.unwrap_or(TransferWarning::NothingPasted),
                     );
+                    self.input_state.trigger_blocked_feedback();
+                } else if let Some(warning) = warning {
+                    self.set_transfer_info_toast(warning);
+                }
+            }
+            PasteAction::ProbeSystemFingerprint {
+                request,
+                generation,
+                expected,
+            } => {
+                let current = clipboard::clipboard_fingerprint();
+                let local_shapes = self
+                    .input_state
+                    .local_selection_shapes_for_fallback(generation);
+                let plan = transfer::plan_after_fingerprint_probe(
+                    request,
+                    generation,
+                    expected,
+                    current,
+                    local_shapes,
+                );
+                self.apply_paste_plan(plan);
+            }
+            PasteAction::ReadSystemClipboard { request } => {
+                self.start_system_clipboard_read(request);
+            }
+            PasteAction::StaleCompletion { request_id } => {
+                log::debug!("Ignoring stale clipboard paste completion {}", request_id);
+            }
+            PasteAction::ApplyPrivateSelection { request, shapes } => {
+                let pasted = self
+                    .input_state
+                    .paste_clipboard_shapes_from_request(&request, shapes);
+                self.input_state.finish_clipboard_paste_request(request.id);
+                if pasted == 0 {
+                    self.set_transfer_warning_toast(TransferWarning::NoShapesPasted);
+                    self.input_state.trigger_blocked_feedback();
+                }
+            }
+            PasteAction::ApplyExternalImage { request, image } => {
                 if !self
                     .input_state
                     .paste_external_image_from_request(&request, image)
                 {
                     self.input_state.trigger_blocked_feedback();
                 }
+                self.input_state.finish_clipboard_paste_request(request.id);
             }
-            ClipboardPasteResult::ClipboardEmpty => {
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
-                    );
-                self.input_state
-                    .set_ui_toast(UiToastKind::Warning, "System clipboard is empty.");
-                self.input_state.trigger_blocked_feedback();
-            }
-            ClipboardPasteResult::ClipboardUnavailable(err) => {
-                log::warn!("Clipboard unavailable: {}", err);
-                self.paste_local_fallback_or_warn(
-                    &request,
-                    "System clipboard unavailable.",
-                    "System clipboard unavailable; pasted local copy.",
-                );
-            }
-            ClipboardPasteResult::NoSupportedMime { offered } => {
-                log::debug!("Unsupported clipboard MIME types: {:?}", offered);
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
-                    );
-                self.input_state.set_ui_toast(
-                    UiToastKind::Warning,
-                    "Clipboard content is not a supported image or Wayscriber selection.",
-                );
-                self.input_state.trigger_blocked_feedback();
-            }
-            ClipboardPasteResult::TooLarge { limit } => {
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
-                    );
-                self.input_state.set_ui_toast(
-                    UiToastKind::Warning,
-                    format!(
-                        "Clipboard data is too large to paste (limit {} MB).",
-                        limit / 1024 / 1024
-                    ),
-                );
-                self.input_state.trigger_blocked_feedback();
-            }
-            ClipboardPasteResult::TooManyPixels {
-                width,
-                height,
-                limit,
+            PasteAction::TryFreshLocalFallbackOrWarn {
+                request,
+                missing_warning,
+                fallback_message,
             } => {
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
-                    );
-                self.input_state.set_ui_toast(
-                    UiToastKind::Warning,
-                    format!(
-                        "Clipboard image is too large ({}x{}, limit {} pixels).",
-                        width, height, limit
-                    ),
-                );
-                self.input_state.trigger_blocked_feedback();
-            }
-            ClipboardPasteResult::DecodeFailed(err) => {
-                log::warn!("Clipboard image decode failed: {}", err);
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
-                    );
-                self.input_state.set_ui_toast(
-                    UiToastKind::Warning,
-                    "Clipboard image could not be decoded.",
-                );
-                self.input_state.trigger_blocked_feedback();
-            }
-            ClipboardPasteResult::ReadTimedOut => {
-                self.paste_local_fallback_or_warn(
+                self.paste_fresh_local_fallback_or_warn(
                     &request,
-                    "Clipboard read timed out.",
-                    "Clipboard read timed out; pasted local copy.",
+                    missing_warning,
+                    fallback_message,
                 );
+                self.input_state.finish_clipboard_paste_request(request.id);
             }
-            ClipboardPasteResult::ClipboardError(err) => {
-                log::warn!("Clipboard paste error: {}", err);
-                self.paste_local_fallback_or_warn(
-                    &request,
-                    "Failed to read clipboard.",
-                    "Failed to read clipboard; pasted local copy.",
-                );
-            }
-            ClipboardPasteResult::MalformedPrivateSelection(err) => {
-                log::warn!("Malformed Wayscriber clipboard payload: {}", err);
-                self.input_state
-                    .mark_selection_clipboard_superseded_for_generation(
-                        request.local_selection_fallback_generation,
-                    );
-                self.input_state.set_ui_toast(
-                    UiToastKind::Warning,
-                    "Wayscriber clipboard selection could not be read.",
-                );
-                self.input_state.trigger_blocked_feedback();
+            PasteAction::ShowWarning {
+                request,
+                warning,
+                block_feedback,
+            } => {
+                self.set_transfer_warning_toast(warning);
+                if block_feedback {
+                    self.input_state.trigger_blocked_feedback();
+                }
+                self.input_state.finish_clipboard_paste_request(request.id);
             }
         }
-
-        self.input_state.finish_clipboard_paste_request(request.id);
     }
 
-    fn paste_local_fallback_or_warn(
+    fn start_system_clipboard_read(&mut self, request: ClipboardPasteRequest) {
+        let (tx, rx) = mpsc::channel();
+        self.clipboard_paste_rx = Some(rx);
+        std::thread::spawn(move || {
+            let result = transfer::resolve_system_clipboard();
+            let _ = tx.send(ClipboardPasteCompletion { request, result });
+        });
+    }
+
+    fn apply_transfer_effect(&mut self, effect: TransferEffect) {
+        match effect {
+            TransferEffect::SupersedeLocalGeneration { generation } => self
+                .input_state
+                .mark_selection_clipboard_superseded_for_generation(Some(generation)),
+        }
+    }
+
+    fn paste_fresh_local_fallback_or_warn(
         &mut self,
         request: &ClipboardPasteRequest,
-        warning: &'static str,
+        missing_warning: TransferWarning,
         fallback_message: &'static str,
     ) {
         if let Some(generation) = request.local_selection_fallback_generation
@@ -354,590 +245,82 @@ impl WaylandState {
             }
         }
 
-        self.input_state.set_ui_toast(UiToastKind::Warning, warning);
+        self.set_transfer_warning_toast(missing_warning);
         self.input_state.trigger_blocked_feedback();
     }
-}
 
-fn resolve_selection_clipboard_publish(
-    generation: u64,
-    payload_json: String,
-) -> ClipboardPublishCompletion {
-    if payload_json.len() > MAX_CLIPBOARD_SELECTION_BYTES {
-        return ClipboardPublishCompletion {
-            generation,
-            fingerprint: clipboard_fingerprint(),
-            copied: false,
-            warning: Some("Copied locally; selection is too large for system clipboard."),
+    fn set_transfer_info_toast(&mut self, warning: TransferWarning) {
+        let message = match warning {
+            TransferWarning::ReadTimedOut => Some("Clipboard read timed out; pasted local copy."),
+            TransferWarning::ClipboardUnavailable => {
+                Some("System clipboard unavailable; pasted local copy.")
+            }
+            TransferWarning::ClipboardError => Some("Failed to read clipboard; pasted local copy."),
+            _ => None,
         };
-    }
-
-    let copied = match std::panic::catch_unwind(|| publish_selection_clipboard(&payload_json)) {
-        Ok(Ok(())) => true,
-        Ok(Err(err)) => {
-            log::warn!("Selection clipboard publish failed: {}", err);
-            false
-        }
-        Err(_) => {
-            log::error!("Selection clipboard publish panicked");
-            false
-        }
-    };
-
-    ClipboardPublishCompletion {
-        generation,
-        fingerprint: if copied {
-            None
-        } else {
-            clipboard_fingerprint()
-        },
-        copied,
-        warning: (!copied).then_some("Copied locally; system clipboard unavailable."),
-    }
-}
-
-fn publish_selection_clipboard(payload_json: &str) -> Result<(), String> {
-    publish_selection_via_command(payload_json)
-}
-
-fn publish_selection_via_command(payload_json: &str) -> Result<(), String> {
-    let mut child = Command::new("wl-copy")
-        .arg("--type")
-        .arg(WAYSCRIBER_SELECTION_MIME)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|err| format!("failed to spawn wl-copy: {}", err))?;
-
-    if let Some(mut stdin) = child.stdin.take() {
-        if let Err(err) = stdin.write_all(payload_json.as_bytes()) {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!("failed to write to wl-copy stdin: {}", err));
-        }
-    } else {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err("wl-copy stdin unavailable".to_string());
-    }
-
-    wait_for_wl_copy_publish(child, CLIPBOARD_PUBLISH_COMMAND_TIMEOUT)
-}
-
-fn wait_for_wl_copy_publish(mut child: Child, timeout: Duration) -> Result<(), String> {
-    let deadline = Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) if status.success() => return Ok(()),
-            Ok(Some(status)) => {
-                let stderr = read_child_stderr(&mut child).unwrap_or_default();
-                if stderr.is_empty() {
-                    return Err(format!("wl-copy exited unsuccessfully: {}", status));
-                }
-                return Err(format!(
-                    "wl-copy exited unsuccessfully: {} ({})",
-                    status, stderr
-                ));
-            }
-            Ok(None) if Instant::now() >= deadline => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let stderr = read_child_stderr(&mut child).unwrap_or_default();
-                if stderr.is_empty() {
-                    return Err("wl-copy did not finish publishing before timeout".to_string());
-                }
-                return Err(format!(
-                    "wl-copy did not finish publishing before timeout: {}",
-                    stderr
-                ));
-            }
-            Ok(None) => std::thread::sleep(Duration::from_millis(10)),
-            Err(err) => return Err(format!("failed to poll wl-copy status: {}", err)),
-        }
-    }
-}
-
-fn resolve_system_clipboard() -> ClipboardPasteResult {
-    let offered = match list_mime_types() {
-        Ok(types) if types.is_empty() => return ClipboardPasteResult::ClipboardEmpty,
-        Ok(types) => types,
-        Err(ClipboardReadError::Empty) => return ClipboardPasteResult::ClipboardEmpty,
-        Err(ClipboardReadError::Unavailable(err)) => {
-            return ClipboardPasteResult::ClipboardUnavailable(err);
-        }
-        Err(err) => return map_read_error(err),
-    };
-
-    let Some(mime_type) = choose_supported_mime(&offered) else {
-        return ClipboardPasteResult::NoSupportedMime { offered };
-    };
-    let limit = if mime_type == WAYSCRIBER_SELECTION_MIME {
-        MAX_CLIPBOARD_SELECTION_BYTES
-    } else {
-        MAX_CLIPBOARD_IMAGE_BYTES
-    };
-
-    let bytes = match read_clipboard_mime(&mime_type, limit, CLIPBOARD_READ_TIMEOUT) {
-        Ok(bytes) if bytes.is_empty() => return ClipboardPasteResult::ClipboardEmpty,
-        Ok(bytes) => bytes,
-        Err(err) => return map_read_error(err),
-    };
-
-    if mime_type == WAYSCRIBER_SELECTION_MIME {
-        return serde_json::from_slice::<WayscriberClipboardSelection>(&bytes)
-            .map(ClipboardPasteResult::PrivateSelection)
-            .unwrap_or_else(|err| {
-                ClipboardPasteResult::MalformedPrivateSelection(err.to_string())
-            });
-    }
-
-    if file_list::is_uri_list_mime(&mime_type) {
-        return file_list::decode_clipboard_uri_list(&mime_type, bytes, offered);
-    }
-
-    decode_clipboard_image(&mime_type, bytes)
-}
-
-fn clipboard_fingerprint() -> Option<ClipboardFingerprint> {
-    let offered = list_mime_types().ok()?;
-    let selected_mime_type = choose_supported_mime(&offered).or_else(|| offered.first().cloned());
-    let content_sample = selected_mime_type.as_ref().and_then(|mime| {
-        read_clipboard_mime_prefix(
-            mime,
-            CLIPBOARD_FINGERPRINT_BYTES,
-            CLIPBOARD_FINGERPRINT_TIMEOUT,
-        )
-        .ok()
-    });
-    let bounded_content_hash = content_sample
-        .as_ref()
-        .map(|sample| content_hash(&sample.bytes));
-    let bounded_content_len = content_sample.as_ref().map(|sample| sample.bytes.len());
-    let bounded_content_truncated = content_sample
-        .as_ref()
-        .is_some_and(|sample| sample.truncated);
-    Some(ClipboardFingerprint {
-        offered_mime_types: offered,
-        selected_mime_type,
-        bounded_content_hash,
-        bounded_content_len,
-        bounded_content_truncated,
-    })
-}
-
-fn choose_supported_mime(offered: &[String]) -> Option<String> {
-    if let Some(mime) = [
-        WAYSCRIBER_SELECTION_MIME,
-        "image/png",
-        "image/jpeg",
-        "image/jpg",
-    ]
-    .into_iter()
-    .find(|candidate| offered.iter().any(|mime| mime == candidate))
-    .map(ToString::to_string)
-    {
-        return Some(mime);
-    }
-
-    offered
-        .iter()
-        .find(|mime| file_list::is_uri_list_mime(mime))
-        .cloned()
-}
-
-fn decode_clipboard_image(mime_type: &str, bytes: Vec<u8>) -> ClipboardPasteResult {
-    let Some(format) = format_from_mime_or_bytes(mime_type, &bytes) else {
-        return ClipboardPasteResult::DecodeFailed(format!("unsupported MIME type {}", mime_type));
-    };
-    let dimensions = match image_dimensions(format, &bytes) {
-        Ok(dimensions) => dimensions,
-        Err(err) => return ClipboardPasteResult::DecodeFailed(err),
-    };
-    let pixels = dimensions.0 as u64 * dimensions.1 as u64;
-    if pixels > MAX_CLIPBOARD_IMAGE_PIXELS {
-        return ClipboardPasteResult::TooManyPixels {
-            width: dimensions.0,
-            height: dimensions.1,
-            limit: MAX_CLIPBOARD_IMAGE_PIXELS,
-        };
-    }
-    if let Err(err) = decode_rgba(format, &bytes) {
-        return ClipboardPasteResult::DecodeFailed(err);
-    }
-    ClipboardPasteResult::Image(EmbeddedImage {
-        mime_type: canonical_image_mime_type(format).to_string(),
-        width: dimensions.0,
-        height: dimensions.1,
-        bytes,
-    })
-}
-
-fn canonical_image_mime_type(format: EncodedImageFormat) -> &'static str {
-    match format {
-        EncodedImageFormat::Png => "image/png",
-        EncodedImageFormat::Jpeg => "image/jpeg",
-    }
-}
-
-fn list_mime_types() -> Result<Vec<String>, ClipboardReadError> {
-    list_mime_types_via_command()
-}
-
-fn list_mime_types_via_command() -> Result<Vec<String>, ClipboardReadError> {
-    let output = Command::new("wl-paste")
-        .arg("--list-types")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|err| {
-            ClipboardReadError::Unavailable(format!("Failed to spawn wl-paste: {}", err))
-        })?;
-
-    if output.status.success() {
-        let text = String::from_utf8_lossy(&output.stdout);
-        Ok(text
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-            .map(ToString::to_string)
-            .collect())
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        if stderr.to_ascii_lowercase().contains("nothing is copied")
-            || stderr.to_ascii_lowercase().contains("clipboard is empty")
-        {
-            Err(ClipboardReadError::Empty)
-        } else if stderr.is_empty() {
-            Err(ClipboardReadError::Other(
-                "wl-paste --list-types exited unsuccessfully".to_string(),
-            ))
-        } else {
-            Err(ClipboardReadError::Other(format!(
-                "wl-paste --list-types failed: {}",
-                stderr
-            )))
-        }
-    }
-}
-
-fn read_clipboard_mime(
-    mime_type: &str,
-    limit: usize,
-    timeout: Duration,
-) -> Result<Vec<u8>, ClipboardReadError> {
-    read_clipboard_mime_via_command(mime_type, limit, timeout)
-}
-
-fn read_clipboard_mime_prefix(
-    mime_type: &str,
-    limit: usize,
-    timeout: Duration,
-) -> Result<ClipboardPrefixRead, ClipboardReadError> {
-    read_clipboard_mime_prefix_via_command(mime_type, limit, timeout)
-}
-
-fn read_clipboard_mime_via_command(
-    mime_type: &str,
-    limit: usize,
-    timeout: Duration,
-) -> Result<Vec<u8>, ClipboardReadError> {
-    let mut child = Command::new("wl-paste")
-        .arg("--type")
-        .arg(mime_type)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|err| {
-            ClipboardReadError::Unavailable(format!("Failed to spawn wl-paste: {}", err))
-        })?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| ClipboardReadError::Other("wl-paste stdout unavailable".to_string()))?;
-    let result = read_pipe_with_timeout(stdout, limit, timeout);
-    match result {
-        Err(ClipboardReadError::TimedOut) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            Err(ClipboardReadError::TimedOut)
-        }
-        Err(ClipboardReadError::TooLarge { limit }) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            Err(ClipboardReadError::TooLarge { limit })
-        }
-        Err(err) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            Err(err)
-        }
-        Ok(bytes) => {
-            let status = child.wait().map_err(|err| {
-                ClipboardReadError::Other(format!("Failed to wait for wl-paste: {}", err))
-            })?;
-            if status.success() {
-                Ok(bytes)
-            } else {
-                let stderr = read_child_stderr(&mut child).unwrap_or_default();
-                if stderr.to_ascii_lowercase().contains("nothing is copied") {
-                    Err(ClipboardReadError::Empty)
-                } else if stderr.is_empty() {
-                    Err(ClipboardReadError::Other(
-                        "wl-paste exited unsuccessfully".to_string(),
-                    ))
-                } else {
-                    Err(ClipboardReadError::Other(format!(
-                        "wl-paste exited unsuccessfully: {}",
-                        stderr
-                    )))
-                }
-            }
-        }
-    }
-}
-
-fn read_clipboard_mime_prefix_via_command(
-    mime_type: &str,
-    limit: usize,
-    timeout: Duration,
-) -> Result<ClipboardPrefixRead, ClipboardReadError> {
-    let mut child = Command::new("wl-paste")
-        .arg("--type")
-        .arg(mime_type)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|err| {
-            ClipboardReadError::Unavailable(format!("Failed to spawn wl-paste: {}", err))
-        })?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| ClipboardReadError::Other("wl-paste stdout unavailable".to_string()))?;
-    let result = read_pipe_prefix_with_timeout(stdout, limit, timeout);
-    match result {
-        Err(ClipboardReadError::TimedOut) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            Err(ClipboardReadError::TimedOut)
-        }
-        Err(err) => {
-            let _ = child.kill();
-            let _ = child.wait();
-            Err(err)
-        }
-        Ok(sample) if sample.truncated => {
-            let _ = child.kill();
-            let _ = child.wait();
-            Ok(sample)
-        }
-        Ok(sample) => {
-            let status = child.wait().map_err(|err| {
-                ClipboardReadError::Other(format!("Failed to wait for wl-paste: {}", err))
-            })?;
-            if status.success() {
-                Ok(sample)
-            } else {
-                let stderr = read_child_stderr(&mut child).unwrap_or_default();
-                if stderr.to_ascii_lowercase().contains("nothing is copied") {
-                    Err(ClipboardReadError::Empty)
-                } else if stderr.is_empty() {
-                    Err(ClipboardReadError::Other(
-                        "wl-paste exited unsuccessfully".to_string(),
-                    ))
-                } else {
-                    Err(ClipboardReadError::Other(format!(
-                        "wl-paste exited unsuccessfully: {}",
-                        stderr
-                    )))
-                }
-            }
-        }
-    }
-}
-
-fn read_pipe_with_timeout<R>(
-    reader: R,
-    limit: usize,
-    timeout: Duration,
-) -> Result<Vec<u8>, ClipboardReadError>
-where
-    R: Read + Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(read_limited(reader, limit));
-    });
-    rx.recv_timeout(timeout)
-        .map_err(|_| ClipboardReadError::TimedOut)?
-}
-
-fn read_pipe_prefix_with_timeout<R>(
-    reader: R,
-    limit: usize,
-    timeout: Duration,
-) -> Result<ClipboardPrefixRead, ClipboardReadError>
-where
-    R: Read + Send + 'static,
-{
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(read_prefix(reader, limit));
-    });
-    rx.recv_timeout(timeout)
-        .map_err(|_| ClipboardReadError::TimedOut)?
-}
-
-fn read_limited<R: Read>(mut reader: R, limit: usize) -> Result<Vec<u8>, ClipboardReadError> {
-    let mut data = Vec::new();
-    let mut buffer = [0u8; 8192];
-    loop {
-        let read = reader.read(&mut buffer).map_err(|err| {
-            ClipboardReadError::Other(format!("Failed to read clipboard: {}", err))
-        })?;
-        if read == 0 {
-            break;
-        }
-        if data.len().saturating_add(read) > limit {
-            return Err(ClipboardReadError::TooLarge { limit });
-        }
-        data.extend_from_slice(&buffer[..read]);
-    }
-    Ok(data)
-}
-
-fn read_prefix<R: Read>(
-    mut reader: R,
-    limit: usize,
-) -> Result<ClipboardPrefixRead, ClipboardReadError> {
-    let mut data = Vec::new();
-    let mut buffer = [0u8; 8192];
-    loop {
-        if data.len() >= limit {
-            return Ok(ClipboardPrefixRead {
-                bytes: data,
-                truncated: true,
-            });
-        }
-
-        let read = reader.read(&mut buffer).map_err(|err| {
-            ClipboardReadError::Other(format!("Failed to read clipboard: {}", err))
-        })?;
-        if read == 0 {
-            break;
-        }
-
-        let remaining = limit.saturating_sub(data.len());
-        if read > remaining {
-            data.extend_from_slice(&buffer[..remaining]);
-            return Ok(ClipboardPrefixRead {
-                bytes: data,
-                truncated: true,
-            });
-        }
-        data.extend_from_slice(&buffer[..read]);
-    }
-    Ok(ClipboardPrefixRead {
-        bytes: data,
-        truncated: false,
-    })
-}
-
-fn read_child_stderr(child: &mut std::process::Child) -> Option<String> {
-    child.stderr.take().and_then(|mut stderr| {
-        let mut bytes = Vec::new();
-        let _ = stderr.read_to_end(&mut bytes);
-        let text = String::from_utf8_lossy(&bytes).trim().to_string();
-        (!text.is_empty()).then_some(text)
-    })
-}
-
-fn map_read_error(err: ClipboardReadError) -> ClipboardPasteResult {
-    match err {
-        ClipboardReadError::Empty => ClipboardPasteResult::ClipboardEmpty,
-        ClipboardReadError::TooLarge { limit } => ClipboardPasteResult::TooLarge { limit },
-        ClipboardReadError::TimedOut => ClipboardPasteResult::ReadTimedOut,
-        ClipboardReadError::Unavailable(err) => ClipboardPasteResult::ClipboardUnavailable(err),
-        ClipboardReadError::Other(err) => ClipboardPasteResult::ClipboardError(err),
-    }
-}
-
-fn content_hash(bytes: &[u8]) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    bytes.hash(&mut hasher);
-    hasher.finish()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::{self, Cursor, Read};
-
-    struct ExactLimitThenError {
-        bytes: Vec<u8>,
-        read_once: bool,
-    }
-
-    impl Read for ExactLimitThenError {
-        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-            if self.read_once {
-                return Err(io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "unexpected second read",
-                ));
-            }
-            self.read_once = true;
-            let len = self.bytes.len().min(buffer.len());
-            buffer[..len].copy_from_slice(&self.bytes[..len]);
-            Ok(len)
+        if let Some(message) = message {
+            self.input_state.set_ui_toast(UiToastKind::Info, message);
         }
     }
 
-    #[test]
-    fn strict_read_rejects_data_over_limit() {
-        let err = read_limited(Cursor::new(vec![1, 2, 3, 4, 5]), 4).expect_err("over limit");
-
-        assert!(matches!(err, ClipboardReadError::TooLarge { limit: 4 }));
-    }
-
-    #[test]
-    fn prefix_read_returns_bounded_sample_for_data_over_limit() {
-        let sample = read_prefix(Cursor::new(vec![1, 2, 3, 4, 5]), 4).expect("prefix sample");
-
-        assert_eq!(sample.bytes, vec![1, 2, 3, 4]);
-        assert!(sample.truncated);
-    }
-
-    #[test]
-    fn prefix_read_returns_when_first_read_reaches_limit() {
-        let reader = ExactLimitThenError {
-            bytes: vec![1, 2, 3, 4],
-            read_once: false,
-        };
-        let sample = read_prefix(reader, 4).expect("prefix sample");
-
-        assert_eq!(sample.bytes, vec![1, 2, 3, 4]);
-        assert!(sample.truncated);
-    }
-
-    #[test]
-    fn prefix_read_marks_small_data_untruncated() {
-        let sample = read_prefix(Cursor::new(vec![1, 2, 3]), 4).expect("prefix sample");
-
-        assert_eq!(sample.bytes, vec![1, 2, 3]);
-        assert!(!sample.truncated);
-    }
-
-    #[test]
-    fn image_byte_cap_leaves_room_for_default_persisted_create_history() {
-        let encoded_len = MAX_CLIPBOARD_IMAGE_BYTES.div_ceil(3) * 4;
-        let duplicated_history_len = encoded_len * 2;
-        let default_session_budget = 10 * 1024 * 1024;
-        let json_margin = 512 * 1024;
-
-        assert!(duplicated_history_len + json_margin < default_session_budget);
+    fn set_transfer_warning_toast(&mut self, warning: TransferWarning) {
+        match warning {
+            TransferWarning::PublishSelectionTooLarge => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                "Copied locally; selection is too large for system clipboard.",
+            ),
+            TransferWarning::PublishUnavailable => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                "Copied locally; system clipboard unavailable.",
+            ),
+            TransferWarning::NothingPasted => self
+                .input_state
+                .set_ui_toast(UiToastKind::Warning, "Nothing pasted."),
+            TransferWarning::NoShapesPasted => self
+                .input_state
+                .set_ui_toast(UiToastKind::Warning, "No shapes pasted."),
+            TransferWarning::ClipboardEmpty => self
+                .input_state
+                .set_ui_toast(UiToastKind::Warning, "System clipboard is empty."),
+            TransferWarning::UnsupportedContent => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                "Clipboard content is not a supported image or Wayscriber selection.",
+            ),
+            TransferWarning::TooLarge { limit } => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                format!(
+                    "Clipboard data is too large to paste (limit {} MB).",
+                    limit / 1024 / 1024
+                ),
+            ),
+            TransferWarning::TooManyPixels {
+                width,
+                height,
+                limit,
+            } => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                format!(
+                    "Clipboard image is too large ({}x{}, limit {} pixels).",
+                    width, height, limit
+                ),
+            ),
+            TransferWarning::DecodeFailed => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                "Clipboard image could not be decoded.",
+            ),
+            TransferWarning::ReadTimedOut => self
+                .input_state
+                .set_ui_toast(UiToastKind::Warning, "Clipboard read timed out."),
+            TransferWarning::ClipboardUnavailable => self
+                .input_state
+                .set_ui_toast(UiToastKind::Warning, "System clipboard unavailable."),
+            TransferWarning::ClipboardError => self
+                .input_state
+                .set_ui_toast(UiToastKind::Warning, "Failed to read clipboard."),
+            TransferWarning::MalformedPrivateSelection => self.input_state.set_ui_toast(
+                UiToastKind::Warning,
+                "Wayscriber clipboard selection could not be read.",
+            ),
+        }
     }
 }

--- a/src/input/state/core/selection_actions/clipboard.rs
+++ b/src/input/state/core/selection_actions/clipboard.rs
@@ -280,6 +280,24 @@ impl InputState {
         )
     }
 
+    pub(crate) fn failed_local_selection_probe_for_generation(
+        &self,
+        generation: Option<u64>,
+    ) -> Option<(u64, Option<ClipboardFingerprint>)> {
+        let request_generation = generation?;
+        let SelectionPublishState::Failed {
+            generation,
+            clipboard_fingerprint_at_failure,
+        } = &self.selection_publish_state
+        else {
+            return None;
+        };
+        (*generation == request_generation
+            && *generation == self.selection_clipboard_generation
+            && !self.selection_clipboard_is_empty())
+        .then(|| (*generation, clipboard_fingerprint_at_failure.clone()))
+    }
+
     pub(crate) fn failed_local_selection_after_fingerprint_probe(
         &mut self,
         request_generation: Option<u64>,
@@ -337,6 +355,13 @@ impl InputState {
     ) -> bool {
         payload.app_instance_id == self.clipboard_app_instance_id
             && request.local_selection_fallback_generation == Some(payload.copy_generation)
+    }
+
+    pub(crate) fn private_payload_is_same_instance(
+        &self,
+        payload: &WayscriberClipboardSelection,
+    ) -> bool {
+        payload.app_instance_id == self.clipboard_app_instance_id
     }
 
     pub(crate) fn private_payload_shapes_for_request(


### PR DESCRIPTION
## Summary

- Extract selection/image clipboard transfer rules into `src/backend/wayland/clipboard/`
- Move private Wayscriber payload handling, image/file-list paste resolution, and wl-copy/wl-paste helpers behind focused clipboard modules
- Keep `InputState` responsible for main-thread selection state transitions, stale paste handling, local fallback, and user-facing toasts
- Add transfer-level tests for fingerprint fallback, supersede effects, stale requests, private payload classification, image validation, and command runner behavior
- Slim down Wayland clipboard state glue so it mostly starts jobs, applies transfer outcomes, and maps warnings to UI feedback