### PR TITLE
docs: improve quick install docs and add Nix checks

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           workspaces: |
             .
-            configurator
 
       - name: Read release version
         id: meta
@@ -63,6 +62,25 @@ jobs:
             VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="wayscriber") | .version')
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check Nix flake package versions
+        run: |
+          cargo_version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+          wayscriber_version="$(nix eval .#packages.x86_64-linux.wayscriber.version --raw)"
+          configurator_version="$(nix eval .#packages.x86_64-linux.wayscriber-configurator.version --raw)"
+
+          test "$wayscriber_version" = "$cargo_version"
+          test "$configurator_version" = "$cargo_version"
+
+      - name: Check Nix flake package instantiation
+        run: nix build .#wayscriber .#wayscriber-configurator --no-link --dry-run
 
       - name: Pre-fetch Cargo dependencies (locked)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           workspaces: |
             .
-            configurator
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -64,3 +63,29 @@ jobs:
 
       - name: cargo test (no default features)
         run: cargo test --workspace --no-default-features
+
+  nix-flake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake package versions
+        run: |
+          cargo_version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+          wayscriber_version="$(nix eval .#packages.x86_64-linux.wayscriber.version --raw)"
+          configurator_version="$(nix eval .#packages.x86_64-linux.wayscriber-configurator.version --raw)"
+
+          test "$wayscriber_version" = "$cargo_version"
+          test "$configurator_version" = "$cargo_version"
+
+      - name: Check flake package instantiation
+        run: nix build .#wayscriber .#wayscriber-configurator --no-link --dry-run

--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ Use your preferred AUR helper if you do not use `yay`.
 #### Nix and NixOS
 
 ```bash
-nix run github:devmobasa/wayscriber
+nix run github:devmobasa/wayscriber -- --active
 # or install to your profile:
 nix profile install github:devmobasa/wayscriber
+wayscriber --active
 # Optional GUI configurator:
 nix profile install github:devmobasa/wayscriber#wayscriber-configurator
 ```
@@ -138,7 +139,7 @@ wayscriber --version
 wayscriber --active
 ```
 
-If you used `nix run`, that command already launches the app without installing it to `PATH`.
+If you used the `nix run` command above, it already launches the app without installing it to `PATH`.
 
 Press <kbd>F1</kbd> or <kbd>F10</kbd> for help, <kbd>Shift+F1</kbd> for quick reference, <kbd>Ctrl+K</kbd> for the command palette, and <kbd>Escape</kbd> to hide or exit.
 
@@ -357,7 +358,7 @@ yay -S wayscriber-configurator
 
 **Run without installing:**
 ```bash
-nix run github:devmobasa/wayscriber
+nix run github:devmobasa/wayscriber -- --active
 ```
 
 **Install to profile:**

--- a/README.md
+++ b/README.md
@@ -30,10 +30,25 @@ https://github.com/user-attachments/assets/4b5ed159-8d1c-44cb-8fe4-e0f2ea41d818
 
 ## Table of Contents
 
+- [Quick Start](#quick-start)
+  - [CLI quick install](#cli-quick-install)
+    - [Debian and Ubuntu](#debian-and-ubuntu)
+    - [Fedora and RHEL](#fedora-and-rhel)
+    - [Arch Linux](#arch-linux)
+    - [Nix and NixOS](#nix-and-nixos)
+  - [First launch](#first-launch)
+  - [Daily daemon setup](#daily-daemon-setup)
 - [Why wayscriber?](#why-wayscriber)
 - [Features](#features)
-- [Quick Start](#quick-start)
 - [Installation](#installation)
+  - [Pick an install path](#pick-an-install-path)
+  - [No terminal install (GitHub Releases)](#no-terminal-install-github-releases)
+  - [Debian / Ubuntu (repo - recommended)](#debian--ubuntu-repo--recommended)
+  - [Fedora / RHEL (repo - recommended)](#fedora--rhel-repo--recommended)
+  - [Arch Linux (AUR)](#arch-linux-aur)
+  - [NixOS / Nix](#nixos--nix)
+  - [From Source](#from-source)
+  - [Screenshot Tools](#screenshot-tools)
 - [Usage](#usage)
 - [Getting Help](#getting-help)
 - [Controls Reference](#controls-reference)
@@ -43,6 +58,102 @@ https://github.com/user-attachments/assets/4b5ed159-8d1c-44cb-8fe4-e0f2ea41d818
 - [Roadmap](#roadmap)
 - [Additional Information](#additional-information)
 - [License & Credits](#license--credits)
+
+---
+
+## Quick Start
+
+### CLI quick install
+
+Pick the block for your distro. Repo, AUR, and Nix installs are the best default for CLI users because they use the normal system update flow. GitHub `.deb`/`.rpm` downloads are one-off installs; use them only when you do not want to add a repo.
+
+#### Debian and Ubuntu
+
+Also use this path for Linux Mint, Pop!_OS, and other Debian-based distros.
+
+```bash
+sudo apt update
+sudo apt install curl gpg
+sudo install -d -m 0755 /usr/share/keyrings
+curl -fsSL https://wayscriber.com/apt/WAYSCRIBER-GPG-KEY.asc | gpg --dearmor | sudo tee /usr/share/keyrings/wayscriber.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/wayscriber.gpg] https://wayscriber.com/apt stable main" | sudo tee /etc/apt/sources.list.d/wayscriber.list
+sudo apt update
+sudo apt install wayscriber
+# Optional GUI configurator:
+sudo apt install wayscriber-configurator
+```
+
+#### Fedora and RHEL
+
+Also use this path for Rocky Linux, AlmaLinux, Nobara, and other RPM-based distros.
+
+```bash
+cat <<'EOF' | sudo tee /etc/yum.repos.d/wayscriber.repo
+[wayscriber]
+name=Wayscriber Repo
+baseurl=https://wayscriber.com/rpm
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://wayscriber.com/rpm/RPM-GPG-KEY-wayscriber.asc
+EOF
+sudo dnf clean all
+sudo dnf install wayscriber
+# Optional GUI configurator:
+sudo dnf install wayscriber-configurator
+```
+
+#### Arch Linux
+
+Also use this path for Manjaro, CachyOS, and other Arch-based distros.
+
+```bash
+yay -S wayscriber-bin    # prebuilt binary
+# or:
+yay -S wayscriber        # build from source
+# Optional GUI configurator:
+yay -S wayscriber-configurator
+```
+
+Use your preferred AUR helper if you do not use `yay`.
+
+#### Nix and NixOS
+
+```bash
+nix run github:devmobasa/wayscriber
+# or install to your profile:
+nix profile install github:devmobasa/wayscriber
+# Optional GUI configurator:
+nix profile install github:devmobasa/wayscriber#wayscriber-configurator
+```
+
+For browser downloads, see [No terminal install](#no-terminal-install-github-releases). For source builds, see [From Source](#from-source).
+
+### First launch
+
+After a package-manager install:
+
+```bash
+wayscriber --version
+wayscriber --active
+```
+
+If you used `nix run`, that command already launches the app without installing it to `PATH`.
+
+Press <kbd>F1</kbd> or <kbd>F10</kbd> for help, <kbd>Shift+F1</kbd> for quick reference, <kbd>Ctrl+K</kbd> for the command palette, and <kbd>Escape</kbd> to hide or exit.
+
+### Daily daemon setup
+
+Daemon mode is preferred for daily use because toggles are faster and session state survives between activations.
+
+```bash
+systemctl --user enable --now wayscriber.service
+wayscriber --daemon-toggle
+```
+
+Bind `wayscriber --daemon-toggle` to a global shortcut in your compositor or desktop environment. Ubuntu GNOME users: <kbd>Super+G</kbd> is a good default because <kbd>Super+D</kbd> is often reserved.
+
+For distro-specific package details, see [Installation](#installation). For keybinding examples and daemon behavior, see [Usage](#daemon-mode-preferred).
 
 ---
 
@@ -148,51 +259,20 @@ https://github.com/user-attachments/assets/4b5ed159-8d1c-44cb-8fe4-e0f2ea41d818
 
 ---
 
-## Quick Start
-
-**1. Install wayscriber (choose one path)**
-
-**Option A: No CLI (click and install)**
-- Main app (`wayscriber`) `.deb` (Ubuntu, Debian, Linux Mint, Pop!_OS, and other Debian-based distros): [wayscriber-amd64.deb](https://github.com/devmobasa/wayscriber/releases/latest/download/wayscriber-amd64.deb)
-- Main app (`wayscriber`) `.rpm` (Fedora, RHEL, Rocky Linux, AlmaLinux, Nobara, and other RPM-based distros): [wayscriber-x86_64.rpm](https://github.com/devmobasa/wayscriber/releases/latest/download/wayscriber-x86_64.rpm)
-- Optional GUI app (`wayscriber-configurator`) `.deb`: [wayscriber-configurator-amd64.deb](https://github.com/devmobasa/wayscriber/releases/latest/download/wayscriber-configurator-amd64.deb)
-- Optional GUI app (`wayscriber-configurator`) `.rpm`: [wayscriber-configurator-x86_64.rpm](https://github.com/devmobasa/wayscriber/releases/latest/download/wayscriber-configurator-x86_64.rpm)
-- [Latest release page (all assets)](https://github.com/devmobasa/wayscriber/releases/latest)
-
-Install the main app package first. `wayscriber-configurator` is optional and does not include the `wayscriber` binary.
-Open the downloaded package in your software installer (Software Center / Discover), then install.
-Important: direct GitHub `.deb`/`.rpm` installs are one-off installs and do not auto-update. Use repo install commands if you want automatic updates.
-
-**Option B: CLI (Debian/Ubuntu repo, auto-updates recommended)**
-```bash
-sudo install -d /usr/share/keyrings
-curl -fsSL https://wayscriber.com/apt/WAYSCRIBER-GPG-KEY.asc | sudo gpg --dearmor -o /usr/share/keyrings/wayscriber.gpg
-echo "deb [signed-by=/usr/share/keyrings/wayscriber.gpg] https://wayscriber.com/apt stable main" | sudo tee /etc/apt/sources.list.d/wayscriber.list
-sudo apt update
-sudo apt install wayscriber
-# Optional GUI configurator (separate app)
-sudo apt install wayscriber-configurator
-```
-Fedora/RHEL CLI users: use the [Fedora / RHEL (repo – recommended)](#fedora--rhel-repo--recommended) section below instead of this `apt` block.
-
-**2. First launch (GUI-first, no terminal needed)**
-Open your app menu/launcher and start **Wayscriber**.
-Press <kbd>F1</kbd> or <kbd>F10</kbd> for help; <kbd>Shift+F1</kbd> for quick reference; <kbd>Ctrl+K</kbd> for the command palette; <kbd>Escape</kbd> hides/exits.
-
-**3. Daemon mode (preferred for daily use, optional)**
-Daemon mode is faster and keeps session state between toggles.
-For setup steps, see [Usage](#daemon-mode-preferred). Ubuntu GNOME users: <kbd>Super+G</kbd> is a good default because <kbd>Super+D</kbd> is often reserved.
-
-Alternative (one-shot mode):
-```bash
-wayscriber --active
-```
-
-For distro-specific package steps, see [Installation](#installation). For daemon vs one-shot behavior, see [Usage](#usage).
-
----
-
 ## Installation
+
+### Pick an install path
+
+| You want | Use |
+|----------|-----|
+| Fast CLI install with auto-updates on Debian/Ubuntu/Mint/Pop!_OS | [Debian / Ubuntu repo](#debian--ubuntu-repo--recommended) |
+| Fast CLI install with auto-updates on Fedora/RHEL/Rocky/Alma/Nobara | [Fedora / RHEL repo](#fedora--rhel-repo--recommended) |
+| Arch, Manjaro, CachyOS, or another Arch-based distro | [AUR](#arch-linux-aur), preferably `wayscriber-bin` for the prebuilt package |
+| Nix profile, `nix run`, or NixOS flake setup | [NixOS / Nix](#nixos--nix) |
+| Browser-based install without adding a repo | [GitHub Releases](#no-terminal-install-github-releases) |
+| Hacking on wayscriber or building a local binary | [From Source](#from-source) |
+
+Install the main `wayscriber` package first. `wayscriber-configurator` is optional and does not include the `wayscriber` binary.
 
 ### No terminal install (GitHub Releases)
 
@@ -213,12 +293,14 @@ Release packages are one-off installs (no auto-updates). Use repo installs below
 
 ### Debian / Ubuntu (repo – recommended)
 ```bash
-sudo install -d /usr/share/keyrings
-curl -fsSL https://wayscriber.com/apt/WAYSCRIBER-GPG-KEY.asc | sudo gpg --dearmor -o /usr/share/keyrings/wayscriber.gpg
+sudo apt update
+sudo apt install curl gpg
+sudo install -d -m 0755 /usr/share/keyrings
+curl -fsSL https://wayscriber.com/apt/WAYSCRIBER-GPG-KEY.asc | gpg --dearmor | sudo tee /usr/share/keyrings/wayscriber.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/wayscriber.gpg] https://wayscriber.com/apt stable main" | sudo tee /etc/apt/sources.list.d/wayscriber.list
 sudo apt update
 sudo apt install wayscriber
-# Optional GUI configurator
+# Optional GUI configurator:
 sudo apt install wayscriber-configurator
 ```
 
@@ -246,26 +328,27 @@ gpgkey=https://wayscriber.com/rpm/RPM-GPG-KEY-wayscriber.asc
 EOF
 sudo dnf clean all
 sudo dnf install wayscriber
-# Optional GUI configurator
+# Optional GUI configurator:
 sudo dnf install wayscriber-configurator
 ```
 
 One-off .rpm (no auto-updates):
 ```bash
 wget -O wayscriber-x86_64.rpm https://github.com/devmobasa/wayscriber/releases/latest/download/wayscriber-x86_64.rpm
-sudo rpm -Uvh wayscriber-x86_64.rpm
+sudo dnf install ./wayscriber-x86_64.rpm
 ```
 Configurator .rpm (optional):
 ```bash
 wget -O wayscriber-configurator-x86_64.rpm https://github.com/devmobasa/wayscriber/releases/latest/download/wayscriber-configurator-x86_64.rpm
-sudo rpm -Uvh wayscriber-configurator-x86_64.rpm
+sudo dnf install ./wayscriber-configurator-x86_64.rpm
 ```
 
 ### Arch Linux (AUR)
 
 ```bash
-yay -S wayscriber        # from source
 yay -S wayscriber-bin    # prebuilt binary
+# or:
+yay -S wayscriber        # build from source
 # Optional GUI configurator:
 yay -S wayscriber-configurator
 ```

--- a/configurator/Cargo.lock
+++ b/configurator/Cargo.lock
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "wayscriber"
-version = "0.9.0"
+version = "0.9.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "wayscriber-configurator"
-version = "0.9.0"
+version = "0.9.19"
 dependencies = [
  "iced",
  "wayscriber",

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        version = "0.9.8";
+        version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
       in {
         packages = {
           wayscriber = pkgs.rustPlatform.buildRustPackage {

--- a/tools/README.md
+++ b/tools/README.md
@@ -39,7 +39,8 @@ Helper scripts for development, installation, packaging, and release workflows.
 ## Version & Release
 
 - **bump-version.sh** - Bump version numbers
-  - Updates Cargo.toml, configurator/Cargo.toml, Cargo.lock, PKGBUILD, .SRCINFO
+  - Updates Cargo.toml, configurator/Cargo.toml, Cargo.lock, configurator/Cargo.lock, PKGBUILD, .SRCINFO
+  - flake.nix package version follows Cargo.toml automatically
   - Auto-increments patch version if no version specified
   - Supports MAJOR.MINOR.PATCH.HOTFIX for packaging-only hotfix releases
   - Usage: `./tools/bump-version.sh [--dry-run] [new_version]`

--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -11,6 +11,8 @@ Usage: tools/bump-version.sh [--dry-run] [new_version]
   * Cargo.toml (wayscriber)
   * configurator/Cargo.toml
   * Cargo.lock (via cargo generate-lockfile)
+  * configurator/Cargo.lock local package versions
+  * flake.nix package version follows Cargo.toml automatically
   * packaging/PKGBUILD pkgver
   * packaging/.SRCINFO (via makepkg --printsrcinfo)
 
@@ -121,6 +123,26 @@ update_version_field() {
 
 update_version_field "Cargo.toml"
 update_version_field "configurator/Cargo.toml"
+
+update_lock_package_version() {
+    local file="$1"
+    local package="$2"
+    if ! [[ -f "$file" ]]; then
+        echo "warn: $file not found, skipping $package lockfile entry" >&2
+        return
+    fi
+    if $DRY_RUN; then
+        echo "dry-run: would update $package entry in $file"
+    else
+        PACKAGE_NAME="$package" NEXT_VERSION="$cargo_version" perl -0777 -pi -e '
+            my $name = quotemeta($ENV{PACKAGE_NAME});
+            s/(\[\[package\]\]\nname\s*=\s*"$name"\nversion\s*=\s*")\K[^"]+/$ENV{NEXT_VERSION}/s
+        ' "$file"
+    fi
+}
+
+update_lock_package_version "configurator/Cargo.lock" "wayscriber"
+update_lock_package_version "configurator/Cargo.lock" "wayscriber-configurator"
 
 if [[ -f Cargo.lock ]]; then
     if $DRY_RUN; then


### PR DESCRIPTION
## Summary

- Add distro-focused quick install instructions near the top of the README
- Document repo/AUR/Nix install paths and clarify one-off GitHub package installs
- Fix Nix launch examples to pass `--active`
- Make `flake.nix` derive package version from `Cargo.toml`
- Add CI/release checks for Nix package version drift and flake instantiation
- Keep `configurator/Cargo.lock` local package versions aligned in `bump-version.sh`