### PR TITLE
Fix session saves when persisted history exceeds size limit

### DIFF
--- a/src/session/snapshot/save.rs
+++ b/src/session/snapshot/save.rs
@@ -1,5 +1,7 @@
 use super::compression::{compress_bytes, temp_path};
-use super::types::{BoardFile, CURRENT_VERSION, SessionFile, SessionSnapshot};
+use super::types::{
+    BoardFile, BoardPagesSnapshot, BoardSnapshot, CURRENT_VERSION, SessionFile, SessionSnapshot,
+};
 use crate::session::lock::{lock_exclusive, unlock};
 use crate::session::options::{CompressionMode, SessionOptions};
 use crate::time_utils::now_rfc3339;
@@ -7,6 +9,7 @@ use anyhow::{Context, Result, anyhow};
 use log::{debug, info, warn};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::path::Path;
 
 /// Persist the provided snapshot to disk according to the configured options.
 pub fn save_snapshot(snapshot: &SessionSnapshot, options: &SessionOptions) -> Result<()> {
@@ -49,59 +52,12 @@ pub fn save_snapshot(snapshot: &SessionSnapshot, options: &SessionOptions) -> Re
 fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> Result<()> {
     let session_path = options.session_file_path();
     let backup_path = options.backup_file_path();
+    let last_modified = now_rfc3339();
 
-    if snapshot.is_empty() && snapshot.tool_state.is_none() {
-        if session_path.exists() {
-            debug!(
-                "Removing session file {} because snapshot is empty",
-                session_path.display()
-            );
-            fs::remove_file(&session_path).with_context(|| {
-                format!(
-                    "failed to remove empty session file {}",
-                    session_path.display()
-                )
-            })?;
-        }
+    let Some(mut json_bytes) = payload_within_limit(snapshot, options, &last_modified)? else {
+        remove_session_file(&session_path)?;
         return Ok(());
-    }
-
-    let file_payload = SessionFile {
-        version: CURRENT_VERSION,
-        last_modified: now_rfc3339(),
-        active_board_id: Some(snapshot.active_board_id.clone()),
-        active_mode: None,
-        boards: snapshot
-            .boards
-            .iter()
-            .map(|board| BoardFile {
-                id: board.id.clone(),
-                pages: board.pages.pages.clone(),
-                active_page: board.pages.active,
-            })
-            .collect(),
-        transparent: None,
-        whiteboard: None,
-        blackboard: None,
-        transparent_pages: None,
-        whiteboard_pages: None,
-        blackboard_pages: None,
-        transparent_active_page: None,
-        whiteboard_active_page: None,
-        blackboard_active_page: None,
-        tool_state: snapshot.tool_state.clone(),
     };
-
-    let mut json_bytes =
-        serde_json::to_vec_pretty(&file_payload).context("failed to serialise session payload")?;
-
-    if json_bytes.len() as u64 > options.max_file_size_bytes {
-        return Err(anyhow!(
-            "Session data size {} bytes exceeds the configured limit of {} bytes; skipping save",
-            json_bytes.len(),
-            options.max_file_size_bytes
-        ));
-    }
 
     let should_compress = match options.compression {
         CompressionMode::Off => false,
@@ -165,5 +121,183 @@ fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> 
         should_compress
     );
 
+    Ok(())
+}
+
+fn payload_within_limit(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    last_modified: &str,
+) -> Result<Option<Vec<u8>>> {
+    if snapshot.is_empty() && snapshot.tool_state.is_none() {
+        return Ok(None);
+    }
+
+    let full_payload = serialize_payload(snapshot, last_modified)?;
+    if full_payload.len() as u64 <= options.max_file_size_bytes {
+        return Ok(Some(full_payload));
+    }
+
+    let full_size = full_payload.len();
+    let history_depth = max_history_depth(snapshot);
+    if history_depth > 0
+        && let Some((depth, payload)) =
+            largest_fitting_history_payload(snapshot, history_depth, options, last_modified)?
+    {
+        warn!(
+            "Session data size {} bytes exceeds the configured limit of {} bytes; saving recent {} undo/redo history entries per stack ({} bytes)",
+            full_size,
+            options.max_file_size_bytes,
+            depth,
+            payload.len()
+        );
+        return Ok(Some(payload));
+    }
+
+    let visible_only = snapshot_without_history(snapshot);
+    if visible_only.is_empty() && visible_only.tool_state.is_none() {
+        warn!(
+            "Session data size {} bytes exceeds the configured limit of {} bytes; dropping undo/redo history leaves no visible session data, clearing saved session",
+            full_size, options.max_file_size_bytes
+        );
+        return Ok(None);
+    }
+
+    let visible_payload = serialize_payload(&visible_only, last_modified)?;
+    if visible_payload.len() as u64 <= options.max_file_size_bytes {
+        warn!(
+            "Session data size {} bytes exceeds the configured limit of {} bytes; saving visible data without undo/redo history ({} bytes)",
+            full_size,
+            options.max_file_size_bytes,
+            visible_payload.len()
+        );
+        return Ok(Some(visible_payload));
+    }
+
+    Err(anyhow!(
+        "Session data size {} bytes exceeds the configured limit of {} bytes; skipping save",
+        visible_payload.len(),
+        options.max_file_size_bytes
+    ))
+}
+
+fn largest_fitting_history_payload(
+    snapshot: &SessionSnapshot,
+    max_depth: usize,
+    options: &SessionOptions,
+    last_modified: &str,
+) -> Result<Option<(usize, Vec<u8>)>> {
+    let mut low = 1;
+    let mut high = max_depth;
+    let mut best = None;
+
+    while low <= high {
+        let depth = low + (high - low) / 2;
+        let candidate = snapshot_with_history_depth(snapshot, depth);
+        let payload = serialize_payload(&candidate, last_modified)?;
+
+        if payload.len() as u64 <= options.max_file_size_bytes {
+            best = Some((depth, payload));
+            low = depth.saturating_add(1);
+        } else if depth == 1 {
+            break;
+        } else {
+            high = depth - 1;
+        }
+    }
+
+    Ok(best)
+}
+
+fn serialize_payload(snapshot: &SessionSnapshot, last_modified: &str) -> Result<Vec<u8>> {
+    let file_payload = SessionFile {
+        version: CURRENT_VERSION,
+        last_modified: last_modified.to_string(),
+        active_board_id: Some(snapshot.active_board_id.clone()),
+        active_mode: None,
+        boards: snapshot
+            .boards
+            .iter()
+            .map(|board| BoardFile {
+                id: board.id.clone(),
+                pages: board.pages.pages.clone(),
+                active_page: board.pages.active,
+            })
+            .collect(),
+        transparent: None,
+        whiteboard: None,
+        blackboard: None,
+        transparent_pages: None,
+        whiteboard_pages: None,
+        blackboard_pages: None,
+        transparent_active_page: None,
+        whiteboard_active_page: None,
+        blackboard_active_page: None,
+        tool_state: snapshot.tool_state.clone(),
+    };
+
+    serde_json::to_vec_pretty(&file_payload).context("failed to serialise session payload")
+}
+
+fn max_history_depth(snapshot: &SessionSnapshot) -> usize {
+    snapshot
+        .boards
+        .iter()
+        .flat_map(|board| board.pages.pages.iter())
+        .map(|page| page.undo_stack_len().max(page.redo_stack_len()))
+        .max()
+        .unwrap_or(0)
+}
+
+fn snapshot_with_history_depth(snapshot: &SessionSnapshot, depth: usize) -> SessionSnapshot {
+    let mut candidate = snapshot.clone();
+    for board in &mut candidate.boards {
+        for page in &mut board.pages.pages {
+            page.clamp_history_depth(depth);
+        }
+    }
+    candidate
+}
+
+fn snapshot_without_history(snapshot: &SessionSnapshot) -> SessionSnapshot {
+    let mut boards = Vec::with_capacity(snapshot.boards.len());
+    for board in &snapshot.boards {
+        let pages = BoardPagesSnapshot {
+            pages: board
+                .pages
+                .pages
+                .iter()
+                .map(|page| page.clone_without_history())
+                .collect(),
+            active: board.pages.active,
+        };
+        if pages.has_persistable_data() {
+            boards.push(BoardSnapshot {
+                id: board.id.clone(),
+                pages,
+            });
+        }
+    }
+
+    SessionSnapshot {
+        active_board_id: snapshot.active_board_id.clone(),
+        boards,
+        tool_state: snapshot.tool_state.clone(),
+    }
+}
+
+fn remove_session_file(session_path: &Path) -> Result<()> {
+    if session_path.exists() {
+        debug!(
+            "Removing session file {} because snapshot is empty",
+            session_path.display()
+        );
+        fs::remove_file(session_path).with_context(|| {
+            format!(
+                "failed to remove empty session file {}",
+                session_path.display()
+            )
+        })?;
+    }
     Ok(())
 }

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -1,8 +1,10 @@
 use super::super::*;
 use super::helpers::dummy_input_state;
+use crate::draw::frame::{ShapeSnapshot, UndoAction};
 use crate::draw::{Color, FontDescriptor, Shape};
 use crate::input::EraserMode;
 use std::fs;
+use std::path::Path;
 
 #[test]
 fn save_snapshot_errors_when_payload_exceeds_max_file_size() {
@@ -130,4 +132,211 @@ fn load_snapshot_truncates_shapes_when_exceeding_max_shapes_per_frame() {
         2,
         "frame should be truncated to max_shapes_per_frame"
     );
+}
+
+#[test]
+fn save_snapshot_drops_history_when_modified_stroke_exceeds_limit() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut input = dummy_input_state();
+    let point_count = 1_500;
+
+    {
+        let frame = input.boards.active_frame_mut();
+        let id = frame.add_shape(large_freehand(point_count, 0));
+        let current = frame.shape(id).expect("shape should exist");
+        let before = ShapeSnapshot {
+            shape: current.shape.clone(),
+            locked: current.locked,
+        };
+        let after_shape = large_freehand(point_count, 1);
+        frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+        frame.push_undo_action(
+            UndoAction::Modify {
+                shape_id: id,
+                before,
+                after: ShapeSnapshot {
+                    shape: after_shape,
+                    locked: false,
+                },
+            },
+            input.undo_stack_limit,
+        );
+    }
+
+    let mut full_options = limit_test_options(temp.path(), "display-full", true);
+    full_options.max_file_size_bytes = u64::MAX;
+    let full_snapshot = snapshot_from_input(&input, &full_options).expect("snapshot present");
+    save_snapshot(&full_snapshot, &full_options).expect("full save should fit measuring cap");
+    let full_size = fs::metadata(full_options.session_file_path())
+        .expect("full session metadata")
+        .len();
+
+    let mut visible_options = limit_test_options(temp.path(), "display-visible", false);
+    visible_options.max_file_size_bytes = u64::MAX;
+    let visible_snapshot =
+        snapshot_from_input(&input, &visible_options).expect("visible snapshot present");
+    save_snapshot(&visible_snapshot, &visible_options)
+        .expect("visible-only save should fit measuring cap");
+    let visible_size = fs::metadata(visible_options.session_file_path())
+        .expect("visible session metadata")
+        .len();
+    assert!(
+        full_size > visible_size,
+        "history should make the session larger than visible-only data"
+    );
+
+    let mut options = limit_test_options(temp.path(), "display-fallback", true);
+    options.max_file_size_bytes = visible_size + (full_size - visible_size) / 2;
+    let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
+
+    save_snapshot(&snapshot, &options).expect("save should drop oversized history");
+
+    let saved_size = fs::metadata(options.session_file_path())
+        .expect("fallback session metadata")
+        .len();
+    assert!(
+        saved_size <= options.max_file_size_bytes,
+        "saved visible-only session should fit the configured limit"
+    );
+
+    let loaded = load_snapshot(&options)
+        .expect("load_snapshot should succeed")
+        .expect("snapshot should be present");
+    let transparent = loaded
+        .boards
+        .iter()
+        .find(|board| board.id == "transparent")
+        .expect("transparent board should be present");
+    let frame = &transparent.pages.pages[0];
+
+    assert_eq!(frame.shapes.len(), 1, "visible stroke should be saved");
+    assert_eq!(
+        frame.undo_stack_len(),
+        0,
+        "oversized undo history is dropped"
+    );
+    assert_eq!(
+        frame.redo_stack_len(),
+        0,
+        "oversized redo history is dropped"
+    );
+
+    match &frame.shapes[0].shape {
+        Shape::Freehand { points, .. } => {
+            assert_eq!(points.len(), point_count);
+            assert_eq!(points[0], (1, 1));
+        }
+        other => panic!("expected freehand stroke, got {other:?}"),
+    }
+}
+
+#[test]
+fn save_snapshot_keeps_largest_recent_history_depth_that_fits() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut input = dummy_input_state();
+    let point_count = 600;
+
+    {
+        let frame = input.boards.active_frame_mut();
+        let id = frame.add_shape(large_freehand(point_count, 0));
+        for offset in 1..=3 {
+            let current = frame.shape(id).expect("shape should exist");
+            let before = ShapeSnapshot {
+                shape: current.shape.clone(),
+                locked: current.locked,
+            };
+            let after_shape = large_freehand(point_count, offset);
+            frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+            frame.push_undo_action(
+                UndoAction::Modify {
+                    shape_id: id,
+                    before,
+                    after: ShapeSnapshot {
+                        shape: after_shape,
+                        locked: false,
+                    },
+                },
+                input.undo_stack_limit,
+            );
+        }
+    }
+
+    let mut depth_two_options = limit_test_options(temp.path(), "display-depth-two", true);
+    depth_two_options.max_file_size_bytes = u64::MAX;
+    depth_two_options.max_persisted_undo_depth = Some(2);
+    let depth_two_snapshot =
+        snapshot_from_input(&input, &depth_two_options).expect("depth two snapshot present");
+    save_snapshot(&depth_two_snapshot, &depth_two_options).expect("depth two save should fit");
+    let depth_two_size = fs::metadata(depth_two_options.session_file_path())
+        .expect("depth two metadata")
+        .len();
+
+    let mut depth_three_options = limit_test_options(temp.path(), "display-depth-three", true);
+    depth_three_options.max_file_size_bytes = u64::MAX;
+    depth_three_options.max_persisted_undo_depth = Some(3);
+    let depth_three_snapshot =
+        snapshot_from_input(&input, &depth_three_options).expect("depth three snapshot present");
+    save_snapshot(&depth_three_snapshot, &depth_three_options)
+        .expect("depth three save should fit");
+    let depth_three_size = fs::metadata(depth_three_options.session_file_path())
+        .expect("depth three metadata")
+        .len();
+    assert!(
+        depth_three_size > depth_two_size,
+        "extra history depth should make the session larger"
+    );
+
+    let mut options = limit_test_options(temp.path(), "display-trimmed", true);
+    options.max_file_size_bytes = depth_two_size + (depth_three_size - depth_two_size) / 2;
+    let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
+
+    save_snapshot(&snapshot, &options).expect("save should trim history to the fitting depth");
+
+    let loaded = load_snapshot(&options)
+        .expect("load_snapshot should succeed")
+        .expect("snapshot should be present");
+    let transparent = loaded
+        .boards
+        .iter()
+        .find(|board| board.id == "transparent")
+        .expect("transparent board should be present");
+    let frame = &transparent.pages.pages[0];
+
+    assert_eq!(frame.shapes.len(), 1, "visible stroke should be saved");
+    assert_eq!(
+        frame.undo_stack_len(),
+        2,
+        "save should keep the largest recent undo depth that fits"
+    );
+    assert_eq!(frame.redo_stack_len(), 0);
+}
+
+fn limit_test_options(base_dir: &Path, display_id: &str, persist_history: bool) -> SessionOptions {
+    let mut options = SessionOptions::new(base_dir.to_path_buf(), display_id);
+    options.persist_transparent = true;
+    options.persist_history = persist_history;
+    options.restore_tool_state = false;
+    options.compression = CompressionMode::Off;
+    options.backup_retention = 0;
+    options
+}
+
+fn large_freehand(point_count: usize, offset: i32) -> Shape {
+    let points = (0..point_count)
+        .map(|index| {
+            let x = i32::try_from(index).expect("test point count fits i32");
+            (x + offset, (x % 173) + offset)
+        })
+        .collect();
+
+    Shape::Freehand {
+        points,
+        color: Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 3.0,
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #204.

- Add a save-side fallback when undo/redo history makes the session JSON exceed `session.max_file_size_mb`
- Keep the largest recent undo/redo history depth that still fits the raw JSON cap
- Fall back to visible drawings/tool state without history when no history depth fits
- Preserve the existing hard error when visible-only session data is still too large