### PR TITLE
Fix local version check path handling

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -63,6 +63,9 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Check version metadata
+        run: bash tools/check-version-consistency.sh --release-version "${{ steps.meta.outputs.version }}"
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           workspaces: |
             .
 
+      - name: Check version metadata
+        run: bash tools/check-version-consistency.sh
+
       - name: cargo fmt
         run: cargo fmt --all -- --check
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ nix profile install github:devmobasa/wayscriber
 nix profile install github:devmobasa/wayscriber#wayscriber-configurator
 ```
 
+Unpinned GitHub flake URLs follow the default branch. To run or install a specific release, pin the tag, for example:
+```bash
+nix run 'github:devmobasa/wayscriber?ref=v0.9.19'
+nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19'
+nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19#wayscriber-configurator'
+```
+
 For browser downloads, see [No terminal install](#no-terminal-install-github-releases). For source builds, see [From Source](#from-source).
 
 ### First launch
@@ -392,6 +399,13 @@ nix profile install github:devmobasa/wayscriber#wayscriber-configurator
 **Development shell:**
 ```bash
 nix develop github:devmobasa/wayscriber
+```
+
+Unpinned GitHub flake URLs follow the default branch. Pin a release tag when you want reproducible release installs:
+```bash
+nix run 'github:devmobasa/wayscriber?ref=v0.9.19'
+nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19'
+nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19#wayscriber-configurator'
 ```
 
 ### From Source

--- a/README.md
+++ b/README.md
@@ -120,16 +120,17 @@ Use your preferred AUR helper if you do not use `yay`.
 #### Nix and NixOS
 
 ```bash
-nix run github:devmobasa/wayscriber
+nix run github:devmobasa/wayscriber -- --active
 # or install to your profile:
 nix profile install github:devmobasa/wayscriber
+wayscriber --active
 # Optional GUI configurator:
 nix profile install github:devmobasa/wayscriber#wayscriber-configurator
 ```
 
 Unpinned GitHub flake URLs follow the default branch. To run or install a specific release, pin the tag, for example:
 ```bash
-nix run 'github:devmobasa/wayscriber?ref=v0.9.19'
+nix run 'github:devmobasa/wayscriber?ref=v0.9.19' -- --active
 nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19'
 nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19#wayscriber-configurator'
 ```
@@ -145,7 +146,7 @@ wayscriber --version
 wayscriber --active
 ```
 
-If you used `nix run`, that command already launches the app without installing it to `PATH`.
+If you used the `nix run` command above, it already launches the app without installing it to `PATH`.
 
 Press <kbd>F1</kbd> or <kbd>F10</kbd> for help, <kbd>Shift+F1</kbd> for quick reference, <kbd>Ctrl+K</kbd> for the command palette, and <kbd>Escape</kbd> to hide or exit.
 
@@ -364,7 +365,7 @@ yay -S wayscriber-configurator
 
 **Run without installing:**
 ```bash
-nix run github:devmobasa/wayscriber
+nix run github:devmobasa/wayscriber -- --active
 ```
 
 **Install to profile:**
@@ -403,7 +404,7 @@ nix develop github:devmobasa/wayscriber
 
 Unpinned GitHub flake URLs follow the default branch. Pin a release tag when you want reproducible release installs:
 ```bash
-nix run 'github:devmobasa/wayscriber?ref=v0.9.19'
+nix run 'github:devmobasa/wayscriber?ref=v0.9.19' -- --active
 nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19'
 nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19#wayscriber-configurator'
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -45,14 +45,26 @@ Helper scripts for development, installation, packaging, and release workflows.
   - Supports MAJOR.MINOR.PATCH.HOTFIX for packaging-only hotfix releases
   - Usage: `./tools/bump-version.sh [--dry-run] [new_version]`
 
+- **check-version-consistency.sh** - Check release metadata alignment
+  - Verifies Cargo manifests, lockfiles, packaging metadata, and flake version sourcing
+  - With `--release-version X.Y.Z[.N]`, rejects tags that do not match Cargo or an explicit packaging hotfix of Cargo
+  - Usage: `bash tools/check-version-consistency.sh [--release-version X.Y.Z[.N]]`
+
+Packaging-only hotfix policy:
+- Normal releases use one version everywhere: Cargo, package metadata, Git tags, and artifacts all use `X.Y.Z`.
+- Hotfix releases may use `X.Y.Z.N` only when the Cargo version is still `X.Y.Z`. In that case, `packaging/PKGBUILD`, `packaging/.SRCINFO`, release artifacts, and AUR metadata use `X.Y.Z.N`; Cargo manifests and `flake.nix` stay on `X.Y.Z`.
+- Release builds set `WAYSCRIBER_RELEASE_VERSION`, so packaged binaries report the release artifact version. Nix builds follow Cargo and report `X.Y.Z` unless the Cargo version itself is bumped.
+
 - **create-release-tag.sh** - Create git tag (local only)
   - Creates annotated tag `v<version>` without pushing
   - Requires clean working tree
+  - Runs version consistency checks before tagging
   - Usage: `./tools/create-release-tag.sh <version>` (X.Y.Z or X.Y.Z.N)
 
 - **publish-release-tag.sh** - Create and push git tag
   - Creates annotated tag and pushes to origin
   - Auto-detects version from Cargo.toml if not specified
+  - Runs version consistency checks before tagging
   - Usage: `./tools/publish-release-tag.sh [--version X.Y.Z[.N]] [--dry-run]`
 
 - **release.sh** - Full release workflow

--- a/tools/README.md
+++ b/tools/README.md
@@ -67,11 +67,6 @@ Packaging-only hotfix policy:
   - Runs version consistency checks before tagging
   - Usage: `./tools/publish-release-tag.sh [--version X.Y.Z[.N]] [--dry-run]`
 
-- **release.sh** - Full release workflow
-  - Bumps version, commits changes, creates tag, and pushes
-  - All-in-one release script for maintainers
-  - Usage: `./tools/release.sh <version> [--force-tag]`
-
 ## Packaging
 
 - **package.sh** - Build distribution packages
@@ -107,6 +102,5 @@ All scripts work from any location in the project.
 
 The release/tag scripts have overlapping functionality:
 - `create-release-tag.sh` + push = `publish-release-tag.sh`
-- `bump-version.sh` + commit + `create-release-tag.sh` + push = `release.sh`
 
-Consider using `release.sh` for full releases, or the individual scripts for more control.
+Use the individual scripts in sequence for full releases when you need explicit control over each step.

--- a/tools/bump-version.sh
+++ b/tools/bump-version.sh
@@ -7,6 +7,8 @@ Usage: tools/bump-version.sh [--dry-run] [new_version]
 
 - If new_version is omitted, bumps the patch version (e.g., 0.9.2 -> 0.9.3).
 - new_version can be MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH.HOTFIX.
+- HOTFIX versions are packaging-only: Cargo and flake.nix stay on MAJOR.MINOR.PATCH;
+  packaging/PKGBUILD, packaging/.SRCINFO, and release artifacts use the HOTFIX version.
 - Updates:
   * Cargo.toml (wayscriber)
   * configurator/Cargo.toml
@@ -16,7 +18,7 @@ Usage: tools/bump-version.sh [--dry-run] [new_version]
   * packaging/PKGBUILD pkgver
   * packaging/.SRCINFO (via makepkg --printsrcinfo)
 
-Requires: cargo, jq, makepkg, sed, perl.
+Requires: cargo, jq, makepkg, sed, perl, python3 or python pointing to Python 3.
 EOF
 }
 
@@ -37,6 +39,11 @@ require_bin jq
 require_bin makepkg
 require_bin sed
 require_bin perl
+if ! { command -v python3 >/dev/null 2>&1 && python3 -c 'import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; } \
+    && ! { command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; }; then
+    echo "error: python3 or python pointing to Python 3 is required" >&2
+    exit 1
+fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
@@ -168,5 +175,6 @@ fi
 if $DRY_RUN; then
     echo "Dry run complete (no changes made)"
 else
+    bash tools/check-version-consistency.sh --release-version "$package_version"
     echo "Updated versions to $next_version"
 fi

--- a/tools/check-version-consistency.sh
+++ b/tools/check-version-consistency.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: tools/check-version-consistency.sh [--release-version X.Y.Z[.N]]
+
+Checks that release/version metadata agrees across:
+  * Cargo.toml
+  * configurator/Cargo.toml
+  * Cargo.lock
+  * configurator/Cargo.lock
+  * packaging/PKGBUILD
+  * packaging/.SRCINFO
+  * flake.nix
+
+When --release-version is provided, it must either match Cargo.toml exactly
+or be a packaging hotfix version of the Cargo version (for example, Cargo
+0.9.19 with release 0.9.19.1). Hotfix releases require packaging/PKGBUILD
+and packaging/.SRCINFO to use the hotfix version.
+EOF
+}
+
+release_version=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --release-version)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --release-version requires a value" >&2
+                usage
+                exit 1
+            fi
+            release_version="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown arg: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PYTHON=""
+for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 \
+        && "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1; then
+        PYTHON="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$PYTHON" ]]; then
+    echo "error: python3 or python pointing to Python 3 is required" >&2
+    exit 1
+fi
+
+"$PYTHON" - "$REPO_ROOT" "$release_version" <<'PY'
+import pathlib
+import re
+import sys
+
+try:
+    import tomllib
+except ImportError:
+    tomllib = None
+
+root = pathlib.Path(sys.argv[1])
+release_version = sys.argv[2] or None
+errors = []
+
+version_re = re.compile(r"^\d+\.\d+\.\d+(?:\.\d+)?$")
+
+def read_text(path):
+    return (root / path).read_text(encoding="utf-8")
+
+def cargo_version(path):
+    text = read_text(path)
+    if tomllib is not None:
+        return tomllib.loads(text)["package"]["version"]
+
+    package_match = re.search(r"(?ms)^\[package\]\s*(.*?)(?:^\[|\Z)", text)
+    if not package_match:
+        errors.append(f"{path}: missing [package] section")
+        return ""
+    version_match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', package_match.group(1))
+    if not version_match:
+        errors.append(f"{path}: missing package version")
+        return ""
+    return version_match.group(1)
+
+def lock_package_version(path, package):
+    pattern = re.compile(
+        r'\[\[package\]\]\s+name\s*=\s*"' + re.escape(package) + r'"\s+version\s*=\s*"([^"]+)"',
+        re.MULTILINE,
+    )
+    match = pattern.search(read_text(path))
+    return match.group(1) if match else None
+
+def pkgbuild_version(path):
+    match = re.search(r"^pkgver=(.+)$", read_text(path), re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+def srcinfo_version(path):
+    match = re.search(r"^\s*pkgver = (.+)$", read_text(path), re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+def is_hotfix_of(version, base):
+    return re.fullmatch(re.escape(base) + r"\.\d+", version) is not None
+
+def require_equal(label, actual, expected):
+    if actual != expected:
+        errors.append(f"{label}: expected {expected}, got {actual or 'missing'}")
+
+root_version = cargo_version("Cargo.toml")
+config_version = cargo_version("configurator/Cargo.toml")
+require_equal("configurator/Cargo.toml", config_version, root_version)
+
+for lockfile in ("Cargo.lock", "configurator/Cargo.lock"):
+    require_equal(f"{lockfile} wayscriber", lock_package_version(lockfile, "wayscriber"), root_version)
+    require_equal(
+        f"{lockfile} wayscriber-configurator",
+        lock_package_version(lockfile, "wayscriber-configurator"),
+        root_version,
+    )
+
+if not version_re.fullmatch(root_version):
+    errors.append(f"Cargo.toml version has unsupported format: {root_version}")
+
+packaging_version = pkgbuild_version("packaging/PKGBUILD")
+srcinfo_pkgver = srcinfo_version("packaging/.SRCINFO")
+
+if release_version:
+    if not version_re.fullmatch(release_version):
+        errors.append(f"release version has unsupported format: {release_version}")
+    elif release_version != root_version and not is_hotfix_of(release_version, root_version):
+        errors.append(
+            f"release version {release_version} must equal Cargo version {root_version} "
+            f"or be a hotfix of it, such as {root_version}.1"
+        )
+    expected_packaging_version = release_version
+else:
+    expected_packaging_version = root_version
+    if packaging_version and is_hotfix_of(packaging_version, root_version):
+        expected_packaging_version = packaging_version
+
+require_equal("packaging/PKGBUILD pkgver", packaging_version, expected_packaging_version)
+require_equal("packaging/.SRCINFO pkgver", srcinfo_pkgver, expected_packaging_version)
+
+flake_text = read_text("flake.nix")
+if "builtins.fromTOML (builtins.readFile ./Cargo.toml)" not in flake_text:
+    errors.append("flake.nix package version should be derived from Cargo.toml")
+
+if errors:
+    print("Version consistency check failed:", file=sys.stderr)
+    for error in errors:
+        print(f"- {error}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"Version consistency OK: Cargo={root_version}, packaging={expected_packaging_version}")
+PY

--- a/tools/create-release-tag.sh
+++ b/tools/create-release-tag.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 usage() {
     cat <<'EOF'
 Usage: tools/create-release-tag.sh <version>
@@ -38,6 +41,9 @@ if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
     echo "error: invalid version format: $version (expected MAJOR.MINOR.PATCH[.HOTFIX])" >&2
     exit 1
 fi
+
+cd "$REPO_ROOT"
+bash tools/check-version-consistency.sh --release-version "$version"
 
 if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
     echo "error: working tree is not clean; commit/stash changes before tagging" >&2

--- a/tools/lint-and-test.sh
+++ b/tools/lint-and-test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+bash tools/check-version-consistency.sh
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features

--- a/tools/publish-release-tag.sh
+++ b/tools/publish-release-tag.sh
@@ -46,6 +46,8 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
+bash tools/check-version-consistency.sh --release-version "$VERSION"
+
 if git rev-parse "$TAG" >/dev/null 2>&1; then
     echo "Tag $TAG already exists locally; aborting." >&2
     exit 1


### PR DESCRIPTION
## Summary

- Make `tools/lint-and-test.sh` resolve the repo root before running checks, so it works from subdirectories
- Add the version consistency check to the local lint/test wrapper to match CI
- Fix README Nix `nix run` examples to launch the overlay with `-- --active`
- Remove stale `release.sh` references from `tools/README.md`