### PR TITLE
Refactor board and page lifecycle cleanup

### DIFF
--- a/src/input/state/core/board.rs
+++ b/src/input/state/core/board.rs
@@ -1,4 +1,5 @@
 mod delete_restore;
+mod lifecycle;
 mod pages;
 mod switch;
 

--- a/src/input/state/core/board/delete_restore.rs
+++ b/src/input/state/core/board/delete_restore.rs
@@ -35,6 +35,10 @@ impl InputState {
     }
 
     pub fn delete_active_board(&mut self) {
+        self.delete_active_board_at(Instant::now());
+    }
+
+    pub(crate) fn delete_active_board_at(&mut self, now: Instant) {
         if self.board_is_transparent() {
             self.set_ui_toast(UiToastKind::Info, "Overlay board cannot be deleted.");
             self.pending_board_delete = None;
@@ -47,7 +51,6 @@ impl InputState {
         }
 
         let current_id = self.boards.active_board_id().to_string();
-        let now = Instant::now();
         if self
             .pending_board_delete
             .as_ref()
@@ -91,7 +94,7 @@ impl InputState {
             self.queue_board_config_save();
 
             // Store for undo
-            self.deleted_boards.push((deleted_board, Instant::now()));
+            self.deleted_boards.push((deleted_board, now));
 
             // Show toast with undo action
             self.set_ui_toast_with_action(
@@ -105,8 +108,12 @@ impl InputState {
 
     /// Restore the most recently deleted board.
     pub fn restore_deleted_board(&mut self) {
+        self.restore_deleted_board_at(Instant::now());
+    }
+
+    pub(crate) fn restore_deleted_board_at(&mut self, now: Instant) {
         // Expire old entries first
-        self.expire_deleted_boards();
+        self.expire_deleted_boards_at(now);
 
         let Some((board, timestamp)) = self.deleted_boards.pop() else {
             self.set_ui_toast(UiToastKind::Info, "No deleted board to restore.");
@@ -130,8 +137,7 @@ impl InputState {
     }
 
     /// Remove deleted boards that have expired (older than BOARD_UNDO_EXPIRE_MS).
-    fn expire_deleted_boards(&mut self) {
-        let now = Instant::now();
+    fn expire_deleted_boards_at(&mut self, now: Instant) {
         let expire_duration = std::time::Duration::from_millis(BOARD_UNDO_EXPIRE_MS);
         self.deleted_boards.retain(|(_board, timestamp)| {
             now.saturating_duration_since(*timestamp) < expire_duration
@@ -142,6 +148,15 @@ impl InputState {
         &mut self,
         board_index: usize,
         page_index: usize,
+    ) -> crate::draw::PageDeleteOutcome {
+        self.delete_page_in_board_at(board_index, page_index, Instant::now())
+    }
+
+    pub(crate) fn delete_page_in_board_at(
+        &mut self,
+        board_index: usize,
+        page_index: usize,
+        now: Instant,
     ) -> crate::draw::PageDeleteOutcome {
         let is_active_board = self.boards.active_index() == board_index;
         let Some(board) = self.boards.board_state_mut(board_index) else {
@@ -156,14 +171,14 @@ impl InputState {
 
         if page_count <= 1 {
             if is_active_board {
-                self.cancel_active_interaction();
+                self.prepare_active_page_content_change();
             }
             let Some(board) = self.boards.board_state_mut(board_index) else {
                 return crate::draw::PageDeleteOutcome::Pending;
             };
             let outcome = board.pages.delete_page_at(page_index);
             if is_active_board {
-                self.prepare_page_switch();
+                self.finish_active_page_content_change();
             } else {
                 self.mark_board_surface_changed();
             }
@@ -174,7 +189,6 @@ impl InputState {
             return outcome;
         }
 
-        let now = Instant::now();
         if self
             .pending_page_delete
             .as_ref()
@@ -207,7 +221,7 @@ impl InputState {
 
         self.pending_page_delete = None;
         if is_active_board {
-            self.cancel_active_interaction();
+            self.prepare_active_page_content_change();
         }
         let Some(board) = self.boards.board_state_mut(board_index) else {
             return crate::draw::PageDeleteOutcome::Pending;
@@ -216,7 +230,7 @@ impl InputState {
         let new_page_num = board.pages.active_index() + 1;
         let new_page_count = board.pages.page_count();
         if is_active_board {
-            self.prepare_page_switch();
+            self.finish_active_page_content_change();
         } else {
             self.mark_board_surface_changed();
         }
@@ -232,20 +246,22 @@ impl InputState {
     }
 
     pub fn page_delete(&mut self) -> crate::draw::PageDeleteOutcome {
+        self.delete_active_page_at(Instant::now())
+    }
+
+    pub(crate) fn delete_active_page_at(&mut self, now: Instant) -> crate::draw::PageDeleteOutcome {
         let page_count = self.boards.page_count();
         let page_index = self.boards.active_page_index();
         let board_id = self.boards.active_board_id().to_string();
 
         // If this is the last page, skip confirmation (just clears)
         if page_count <= 1 {
-            self.cancel_active_interaction();
+            self.prepare_active_page_content_change();
             let outcome = self.boards.delete_page();
-            self.prepare_page_switch();
+            self.finish_active_page_content_change();
             self.set_ui_toast(UiToastKind::Info, "Page cleared (last page)");
             return outcome;
         }
-
-        let now = Instant::now();
 
         // Expire old pending confirmation
         if self
@@ -287,21 +303,20 @@ impl InputState {
         // Confirmed: proceed with deletion
         self.pending_page_delete = None;
 
-        self.cancel_active_interaction();
+        self.prepare_active_page_content_change();
 
         // Save page after cancellation for undo.
         let deleted_page = self.boards.active_pages().active_frame().clone();
 
         let outcome = self.boards.delete_page();
-        self.prepare_page_switch();
+        self.finish_active_page_content_change();
         let new_page_num = self.boards.active_page_index() + 1;
         let new_page_count = self.boards.page_count();
 
         if matches!(outcome, crate::draw::PageDeleteOutcome::Removed) {
             // Store for undo
             let board_id = self.boards.active_board_id().to_string();
-            self.deleted_pages
-                .push((board_id, deleted_page, Instant::now()));
+            self.deleted_pages.push((board_id, deleted_page, now));
 
             // Show toast with undo action
             self.set_ui_toast_with_action(
@@ -316,8 +331,11 @@ impl InputState {
 
     /// Restore the most recently deleted page.
     pub fn restore_deleted_page(&mut self) {
+        self.restore_deleted_page_at(Instant::now());
+    }
+
+    pub(crate) fn restore_deleted_page_at(&mut self, now: Instant) {
         // Expire old entries
-        let now = Instant::now();
         let expire_duration = Duration::from_millis(PAGE_UNDO_EXPIRE_MS);
         self.deleted_pages.retain(|(_, _, deleted_at)| {
             now.saturating_duration_since(*deleted_at) < expire_duration
@@ -332,9 +350,9 @@ impl InputState {
 
         if let Some(idx) = position {
             let (_, page, _) = self.deleted_pages.remove(idx);
-            self.cancel_active_interaction();
+            self.prepare_active_page_content_change();
             self.boards.insert_page(page);
-            self.prepare_page_switch();
+            self.finish_active_page_content_change();
             let page_num = self.boards.active_page_index() + 1;
             let page_count = self.boards.page_count();
             self.set_ui_toast(
@@ -344,5 +362,203 @@ impl InputState {
         } else {
             self.set_ui_toast(UiToastKind::Info, "No deleted page to restore.");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::draw::Frame;
+    use crate::input::BOARD_ID_BLACKBOARD;
+    use crate::input::state::test_support::make_test_input_state;
+
+    fn board_index(state: &InputState, id: &str) -> usize {
+        state
+            .boards
+            .board_states()
+            .iter()
+            .position(|board| board.spec.id == id)
+            .expect("board index")
+    }
+
+    fn set_page_count(state: &mut InputState, board_index: usize, count: usize) {
+        let pages = state.boards.board_states_mut()[board_index]
+            .pages
+            .pages_mut();
+        pages.clear();
+        pages.extend((0..count.max(1)).map(|_| Frame::new()));
+    }
+
+    #[test]
+    fn confirmed_board_delete_uses_supplied_now_for_undo_timestamp() {
+        let mut state = make_test_input_state();
+        state.switch_board(BOARD_ID_BLACKBOARD);
+        let requested_at = Instant::now();
+        let confirmed_at = requested_at + Duration::from_millis(1);
+
+        state.delete_active_board_at(requested_at);
+        state.delete_active_board_at(confirmed_at);
+
+        let (_, deleted_at) = state.deleted_boards.last().expect("deleted board undo");
+        assert_eq!(*deleted_at, confirmed_at);
+    }
+
+    #[test]
+    fn expired_board_delete_confirmation_is_replaced_with_supplied_now() {
+        let mut state = make_test_input_state();
+        state.switch_board(BOARD_ID_BLACKBOARD);
+        let requested_at = Instant::now();
+        let expired_at = requested_at + Duration::from_millis(BOARD_DELETE_CONFIRM_MS + 1);
+        let board_count = state.boards.board_count();
+
+        state.delete_active_board_at(requested_at);
+        state.delete_active_board_at(expired_at);
+
+        assert_eq!(state.boards.board_count(), board_count);
+        let pending = state
+            .pending_board_delete
+            .as_ref()
+            .expect("replacement confirmation");
+        assert_eq!(
+            pending.expires_at,
+            expired_at + Duration::from_millis(BOARD_DELETE_CONFIRM_MS)
+        );
+    }
+
+    #[test]
+    fn restore_deleted_board_expires_old_entries_with_supplied_now() {
+        let mut state = make_test_input_state();
+        state.switch_board(BOARD_ID_BLACKBOARD);
+        let requested_at = Instant::now();
+        let confirmed_at = requested_at + Duration::from_millis(1);
+
+        state.delete_active_board_at(requested_at);
+        state.delete_active_board_at(confirmed_at);
+        let board_count_after_delete = state.boards.board_count();
+
+        state.restore_deleted_board_at(
+            confirmed_at + Duration::from_millis(BOARD_UNDO_EXPIRE_MS + 1),
+        );
+
+        assert!(state.deleted_boards.is_empty());
+        assert_eq!(state.boards.board_count(), board_count_after_delete);
+        assert_eq!(
+            state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
+            Some("No deleted board to restore.")
+        );
+    }
+
+    #[test]
+    fn confirmed_active_page_delete_uses_supplied_now_for_undo_timestamp() {
+        let mut state = make_test_input_state();
+        let board = board_index(&state, BOARD_ID_BLACKBOARD);
+        state.switch_board(BOARD_ID_BLACKBOARD);
+        set_page_count(&mut state, board, 2);
+        let requested_at = Instant::now();
+        let confirmed_at = requested_at + Duration::from_millis(1);
+
+        assert_eq!(
+            state.delete_active_page_at(requested_at),
+            crate::draw::PageDeleteOutcome::Pending
+        );
+        assert_eq!(
+            state.delete_active_page_at(confirmed_at),
+            crate::draw::PageDeleteOutcome::Removed
+        );
+
+        let (_, _, deleted_at) = state.deleted_pages.last().expect("deleted page undo");
+        assert_eq!(*deleted_at, confirmed_at);
+    }
+
+    #[test]
+    fn expired_active_page_delete_confirmation_is_replaced_with_supplied_now() {
+        let mut state = make_test_input_state();
+        let board = board_index(&state, BOARD_ID_BLACKBOARD);
+        state.switch_board(BOARD_ID_BLACKBOARD);
+        set_page_count(&mut state, board, 2);
+        let requested_at = Instant::now();
+        let expired_at = requested_at + Duration::from_millis(PAGE_DELETE_CONFIRM_MS + 1);
+        let page_count = state.boards.page_count();
+
+        assert_eq!(
+            state.delete_active_page_at(requested_at),
+            crate::draw::PageDeleteOutcome::Pending
+        );
+        assert_eq!(
+            state.delete_active_page_at(expired_at),
+            crate::draw::PageDeleteOutcome::Pending
+        );
+
+        assert_eq!(state.boards.page_count(), page_count);
+        let pending = state
+            .pending_page_delete
+            .as_ref()
+            .expect("replacement confirmation");
+        assert_eq!(
+            pending.expires_at,
+            expired_at + Duration::from_millis(PAGE_DELETE_CONFIRM_MS)
+        );
+    }
+
+    #[test]
+    fn expired_page_in_board_delete_confirmation_is_replaced_with_supplied_now() {
+        let mut state = make_test_input_state();
+        let board = board_index(&state, BOARD_ID_BLACKBOARD);
+        set_page_count(&mut state, board, 2);
+        let requested_at = Instant::now();
+        let expired_at = requested_at + Duration::from_millis(PAGE_DELETE_CONFIRM_MS + 1);
+        let page_count = state.boards.board_states()[board].pages.page_count();
+
+        assert_eq!(
+            state.delete_page_in_board_at(board, 1, requested_at),
+            crate::draw::PageDeleteOutcome::Pending
+        );
+        assert_eq!(
+            state.delete_page_in_board_at(board, 1, expired_at),
+            crate::draw::PageDeleteOutcome::Pending
+        );
+
+        assert_eq!(
+            state.boards.board_states()[board].pages.page_count(),
+            page_count
+        );
+        let pending = state
+            .pending_page_delete
+            .as_ref()
+            .expect("replacement confirmation");
+        assert_eq!(
+            pending.expires_at,
+            expired_at + Duration::from_millis(PAGE_DELETE_CONFIRM_MS)
+        );
+    }
+
+    #[test]
+    fn restore_deleted_page_expires_old_entries_with_supplied_now() {
+        let mut state = make_test_input_state();
+        let board = board_index(&state, BOARD_ID_BLACKBOARD);
+        state.switch_board(BOARD_ID_BLACKBOARD);
+        set_page_count(&mut state, board, 2);
+        let requested_at = Instant::now();
+        let confirmed_at = requested_at + Duration::from_millis(1);
+
+        assert_eq!(
+            state.delete_active_page_at(requested_at),
+            crate::draw::PageDeleteOutcome::Pending
+        );
+        assert_eq!(
+            state.delete_active_page_at(confirmed_at),
+            crate::draw::PageDeleteOutcome::Removed
+        );
+        let page_count_after_delete = state.boards.page_count();
+
+        state
+            .restore_deleted_page_at(confirmed_at + Duration::from_millis(PAGE_UNDO_EXPIRE_MS + 1));
+
+        assert!(state.deleted_pages.is_empty());
+        assert_eq!(state.boards.page_count(), page_count_after_delete);
+        assert_eq!(
+            state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
+            Some("No deleted page to restore.")
+        );
     }
 }

--- a/src/input/state/core/board/lifecycle.rs
+++ b/src/input/state/core/board/lifecycle.rs
@@ -1,0 +1,45 @@
+use super::super::base::InputState;
+
+impl InputState {
+    pub(super) fn mark_board_surface_dirty(&mut self) {
+        self.dirty_tracker.mark_full();
+        self.needs_redraw = true;
+    }
+
+    pub(super) fn mark_board_surface_changed(&mut self) {
+        self.mark_board_surface_dirty();
+        self.mark_session_dirty();
+    }
+
+    pub(super) fn finish_active_board_transition(&mut self) {
+        self.sync_canvas_pointer_to_current_transform();
+        self.mark_board_surface_changed();
+    }
+
+    pub(crate) fn queue_board_config_save(&mut self) {
+        if !self.boards.persist_customizations() {
+            return;
+        }
+        self.pending_board_config = Some(self.boards.to_config());
+    }
+
+    pub(super) fn prepare_active_page_content_change(&mut self) {
+        self.cancel_active_interaction();
+    }
+
+    pub(super) fn finish_active_page_content_change(&mut self) {
+        self.clear_selection();
+        self.close_context_menu();
+        self.invalidate_hit_cache();
+        self.sync_canvas_pointer_to_current_transform();
+        self.mark_board_surface_changed();
+    }
+
+    pub(super) fn finish_board_page_content_change(&mut self, board_index: usize) {
+        if self.boards.active_index() == board_index {
+            self.finish_active_page_content_change();
+        } else {
+            self.mark_board_surface_changed();
+        }
+    }
+}

--- a/src/input/state/core/board/pages.rs
+++ b/src/input/state/core/board/pages.rs
@@ -87,21 +87,34 @@ impl InputState {
         from: usize,
         to: usize,
     ) -> bool {
+        let is_active_board = self.boards.active_index() == board_index;
+        let Some(board) = self.boards.board_states().get(board_index) else {
+            return false;
+        };
+        let page_count = board.pages.page_count();
+        if from >= page_count || to >= page_count {
+            return false;
+        }
+        if is_active_board {
+            self.prepare_active_page_content_change();
+        }
         let Some(board) = self.boards.board_state_mut(board_index) else {
             return false;
         };
-        if !board.pages.move_page(from, to) {
-            return false;
-        }
-        if self.boards.active_index() == board_index {
-            self.prepare_page_switch();
-        } else {
-            self.mark_board_surface_changed();
-        }
+        let moved = board.pages.move_page(from, to);
+        debug_assert!(moved, "preflighted page reorder failed on apply");
+        self.finish_board_page_content_change(board_index);
         true
     }
 
     pub(crate) fn add_page_in_board(&mut self, board_index: usize) -> bool {
+        let is_active_board = self.boards.active_index() == board_index;
+        if self.boards.board_states().get(board_index).is_none() {
+            return false;
+        }
+        if is_active_board {
+            self.prepare_active_page_content_change();
+        }
         let Some(board) = self.boards.board_state_mut(board_index) else {
             return false;
         };
@@ -110,11 +123,7 @@ impl InputState {
         let page_count = board.pages.page_count();
         let board_name = board.spec.name.clone();
         let board_id = board.spec.id.clone();
-        if self.boards.active_index() == board_index {
-            self.prepare_page_switch();
-        } else {
-            self.mark_board_surface_changed();
-        }
+        self.finish_board_page_content_change(board_index);
         self.set_ui_toast(
             UiToastKind::Info,
             format!("Page added on '{board_name}' ({board_id}) ({page_num}/{page_count})"),
@@ -127,6 +136,16 @@ impl InputState {
         board_index: usize,
         page_index: usize,
     ) -> bool {
+        let is_active_board = self.boards.active_index() == board_index;
+        let Some(board) = self.boards.board_states().get(board_index) else {
+            return false;
+        };
+        if page_index >= board.pages.page_count() {
+            return false;
+        }
+        if is_active_board {
+            self.prepare_active_page_content_change();
+        }
         let Some(board) = self.boards.board_state_mut(board_index) else {
             return false;
         };
@@ -137,11 +156,7 @@ impl InputState {
         let page_count = board.pages.page_count();
         let board_name = board.spec.name.clone();
         let board_id = board.spec.id.clone();
-        if self.boards.active_index() == board_index {
-            self.prepare_page_switch();
-        } else {
-            self.mark_board_surface_changed();
-        }
+        self.finish_board_page_content_change(board_index);
         self.set_ui_toast(
             UiToastKind::Info,
             format!("Page duplicated on '{board_name}' ({board_id}) ({page_num}/{page_count})"),
@@ -155,27 +170,34 @@ impl InputState {
         page_index: usize,
         name: Option<String>,
     ) -> bool {
+        let is_active_board = self.boards.active_index() == board_index;
+        let Some(board) = self.boards.board_states().get(board_index) else {
+            return false;
+        };
+        if page_index >= board.pages.page_count() {
+            return false;
+        }
+        if is_active_board {
+            self.prepare_active_page_content_change();
+        }
         let Some(board) = self.boards.board_state_mut(board_index) else {
             return false;
         };
         if !board.pages.set_page_name(page_index, name) {
             return false;
         }
-        if self.boards.active_index() == board_index {
-            self.prepare_page_switch();
-        } else {
-            self.mark_board_surface_changed();
-        }
+        self.finish_board_page_content_change(board_index);
         self.set_ui_toast(UiToastKind::Info, "Page renamed.");
         true
     }
 
-    pub(crate) fn move_page_between_boards(
+    pub(crate) fn move_page_between_boards_with_activation(
         &mut self,
         source_board: usize,
         page_index: usize,
         target_board: usize,
         copy: bool,
+        activate_target: bool,
     ) -> bool {
         if source_board == target_board {
             return false;
@@ -183,6 +205,17 @@ impl InputState {
         let board_count = self.boards.board_count();
         if source_board >= board_count || target_board >= board_count {
             return false;
+        }
+        let Some(source) = self.boards.board_states().get(source_board) else {
+            return false;
+        };
+        if page_index >= source.pages.page_count() {
+            return false;
+        }
+        let active_board = self.boards.active_index();
+        let active_involved = source_board == active_board || target_board == active_board;
+        if active_involved {
+            self.prepare_active_page_content_change();
         }
         let (new_index, target_name, target_id, target_count) = {
             let (source, target) = if source_board < target_board {
@@ -212,6 +245,11 @@ impl InputState {
             let target_count = target.pages.page_count();
             (new_index, target_name, target_id, target_count)
         };
+        if active_involved {
+            self.finish_active_page_content_change();
+        } else {
+            self.mark_board_surface_changed();
+        }
 
         let action = if copy { "copied" } else { "moved" };
         self.set_ui_toast(
@@ -223,39 +261,52 @@ impl InputState {
             ),
         );
         self.mark_session_dirty();
+        if activate_target {
+            self.switch_board_slot(target_board);
+            if let Some(row) = self.board_picker_row_for_board(target_board) {
+                self.board_picker_set_selected(row);
+            }
+        }
         true
     }
 
     pub fn page_prev(&mut self) -> bool {
-        if self.boards.prev_page() {
-            self.prepare_page_switch();
-            true
-        } else {
-            false
+        if self.boards.active_page_index() == 0 {
+            return false;
         }
+        self.prepare_active_page_content_change();
+        let switched = self.boards.prev_page();
+        debug_assert!(switched, "preflighted previous page failed on apply");
+        self.finish_active_page_content_change();
+        true
     }
 
     pub fn page_next(&mut self) -> bool {
-        if self.boards.next_page() {
-            self.prepare_page_switch();
-            true
-        } else {
-            false
+        if self.boards.active_page_index() + 1 >= self.boards.page_count() {
+            return false;
         }
+        self.prepare_active_page_content_change();
+        let switched = self.boards.next_page();
+        debug_assert!(switched, "preflighted next page failed on apply");
+        self.finish_active_page_content_change();
+        true
     }
 
     pub fn switch_to_page(&mut self, index: usize) -> bool {
-        if self.boards.active_pages_mut().switch_to_page(index) {
-            self.prepare_page_switch();
-            true
-        } else {
-            false
+        if index >= self.boards.page_count() || index == self.boards.active_page_index() {
+            return false;
         }
+        self.prepare_active_page_content_change();
+        let switched = self.boards.active_pages_mut().switch_to_page(index);
+        debug_assert!(switched, "preflighted page switch failed on apply");
+        self.finish_active_page_content_change();
+        true
     }
 
     pub fn page_new(&mut self) {
+        self.prepare_active_page_content_change();
         self.boards.new_page();
-        self.prepare_page_switch();
+        self.finish_active_page_content_change();
         let page_num = self.boards.active_page_index() + 1;
         let page_count = self.boards.page_count();
         self.set_ui_toast(
@@ -265,8 +316,9 @@ impl InputState {
     }
 
     pub fn page_duplicate(&mut self) {
+        self.prepare_active_page_content_change();
         self.boards.duplicate_page();
-        self.prepare_page_switch();
+        self.finish_active_page_content_change();
         let page_num = self.boards.active_page_index() + 1;
         let page_count = self.boards.page_count();
         self.set_ui_toast(

--- a/src/input/state/core/board/switch.rs
+++ b/src/input/state/core/board/switch.rs
@@ -236,35 +236,4 @@ impl InputState {
     pub(super) fn remove_board_recent(&mut self, board_id: &str) {
         self.board_recent.retain(|id| id != board_id);
     }
-
-    pub(super) fn mark_board_surface_dirty(&mut self) {
-        self.dirty_tracker.mark_full();
-        self.needs_redraw = true;
-    }
-
-    pub(super) fn mark_board_surface_changed(&mut self) {
-        self.mark_board_surface_dirty();
-        self.mark_session_dirty();
-    }
-
-    fn finish_active_board_transition(&mut self) {
-        self.sync_canvas_pointer_to_current_transform();
-        self.mark_board_surface_changed();
-    }
-
-    pub(crate) fn queue_board_config_save(&mut self) {
-        if !self.boards.persist_customizations() {
-            return;
-        }
-        self.pending_board_config = Some(self.boards.to_config());
-    }
-
-    pub(super) fn prepare_page_switch(&mut self) {
-        self.cancel_active_interaction();
-        self.clear_selection();
-        self.close_context_menu();
-        self.invalidate_hit_cache();
-        self.sync_canvas_pointer_to_current_transform();
-        self.mark_board_surface_changed();
-    }
 }

--- a/src/input/state/core/board_picker/state/drag.rs
+++ b/src/input/state/core/board_picker/state/drag.rs
@@ -165,17 +165,13 @@ impl InputState {
         let target_board = drag.target_board.unwrap_or(drag.board_index);
         if target_board != drag.board_index {
             let copy = self.modifiers.alt;
-            if self.move_page_between_boards(
+            let _ = self.move_page_between_boards_with_activation(
                 drag.board_index,
                 drag.source_index,
                 target_board,
                 copy,
-            ) {
-                self.switch_board_slot(target_board);
-                if let Some(row) = self.board_picker_row_for_board(target_board) {
-                    self.board_picker_set_selected(row);
-                }
-            }
+                true,
+            );
             self.needs_redraw = true;
             return true;
         }

--- a/src/input/state/core/menus/commands.rs
+++ b/src/input/state/core/menus/commands.rs
@@ -255,17 +255,14 @@ impl InputState {
                         .board_states()
                         .iter()
                         .position(|board| board.spec.id == id)
-                        && self.move_page_between_boards(
+                    {
+                        let _ = self.move_page_between_boards_with_activation(
                             source_board,
                             page_index,
                             target_index,
                             false,
-                        )
-                    {
-                        self.switch_board_slot(target_index);
-                        if let Some(row) = self.board_picker_row_for_board(target_index) {
-                            self.board_picker_set_selected(row);
-                        }
+                            true,
+                        );
                     }
                 }
                 self.close_context_menu();

--- a/src/input/state/tests/pages.rs
+++ b/src/input/state/tests/pages.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::draw::{BoardPages, Frame};
+use crate::draw::{BoardPages, Frame, ShapeId};
 use crate::input::{BOARD_ID_BLACKBOARD, BOARD_ID_WHITEBOARD, BoardBackground};
 
 fn board_index(state: &InputState, id: &str) -> usize {
@@ -20,6 +20,35 @@ fn named_frame(name: &str) -> Frame {
 fn set_named_pages(state: &mut InputState, board_index: usize, names: &[&str], active: usize) {
     let pages = names.iter().map(|name| named_frame(name)).collect();
     state.boards.board_states_mut()[board_index].pages = BoardPages::from_pages(pages, active);
+}
+
+fn add_active_text_shape(state: &mut InputState, text: &str) -> ShapeId {
+    state.boards.active_frame_mut().add_shape(Shape::Text {
+        x: 40,
+        y: 80,
+        text: text.to_string(),
+        color: state.current_color,
+        size: state.current_font_size,
+        font_descriptor: state.font_descriptor.clone(),
+        background_enabled: state.text_background_enabled,
+        wrap_width: None,
+    })
+}
+
+fn assert_page_text(
+    state: &InputState,
+    board_index: usize,
+    page_index: usize,
+    shape_id: ShapeId,
+    expected: &str,
+) {
+    let shape = state.boards.board_states()[board_index].pages.pages()[page_index]
+        .shape(shape_id)
+        .expect("text shape");
+    match &shape.shape {
+        Shape::Text { text, .. } => assert_eq!(text, expected),
+        _ => panic!("Expected text shape"),
+    }
 }
 
 #[test]
@@ -104,7 +133,7 @@ fn move_page_between_boards_copy_preserves_source_and_adds_page_to_target() {
     set_named_pages(&mut state, source, &["Copied page"], 0);
     set_named_pages(&mut state, target, &["Target page"], 0);
 
-    assert!(state.move_page_between_boards(source, 0, target, true));
+    assert!(state.move_page_between_boards_with_activation(source, 0, target, true, false));
 
     assert_eq!(state.boards.board_states()[source].pages.page_count(), 1);
     assert_eq!(state.boards.board_states()[target].pages.page_count(), 2);
@@ -142,7 +171,7 @@ fn move_page_between_boards_move_removes_source_page_and_activates_target_copy()
     set_named_pages(&mut state, source, &["Keep", "Move me"], 1);
     set_named_pages(&mut state, target, &["Target page"], 0);
 
-    assert!(state.move_page_between_boards(source, 1, target, false));
+    assert!(state.move_page_between_boards_with_activation(source, 1, target, false, false));
 
     assert_eq!(state.boards.board_states()[source].pages.page_count(), 1);
     assert_eq!(
@@ -161,4 +190,57 @@ fn move_page_between_boards_move_removes_source_page_and_activates_target_copy()
             .as_ref()
             .is_some_and(|toast| toast.message.contains("Page moved to 'Blackboard'"))
     );
+}
+
+#[test]
+fn switch_to_page_cancels_text_edit_before_leaving_source_page() {
+    let mut state = create_test_input_state();
+    let board = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    set_named_pages(&mut state, board, &["Source", "Target"], 0);
+    let shape_id = add_active_text_shape(&mut state, "Original");
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+
+    assert!(state.switch_to_page(1));
+
+    assert_eq!(state.boards.active_page_index(), 1);
+    assert!(state.text_edit_target.is_none());
+    assert_page_text(&state, board, 0, shape_id, "Original");
+}
+
+#[test]
+fn page_duplicate_cancels_text_edit_before_cloning_source_page() {
+    let mut state = create_test_input_state();
+    let board = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    let shape_id = add_active_text_shape(&mut state, "Original");
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+
+    state.page_duplicate();
+
+    assert_eq!(state.boards.active_page_index(), 1);
+    assert!(state.text_edit_target.is_none());
+    assert_page_text(&state, board, 0, shape_id, "Original");
+    assert_page_text(&state, board, 1, shape_id, "Original");
+}
+
+#[test]
+fn cross_board_page_copy_cancels_active_source_text_edit_before_cloning() {
+    let mut state = create_test_input_state();
+    let source = board_index(&state, BOARD_ID_WHITEBOARD);
+    let target = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_WHITEBOARD);
+    set_named_pages(&mut state, source, &["Source"], 0);
+    set_named_pages(&mut state, target, &["Target"], 0);
+    let shape_id = add_active_text_shape(&mut state, "Original");
+    state.set_selection(vec![shape_id]);
+    assert!(state.edit_selected_text());
+
+    assert!(state.move_page_between_boards_with_activation(source, 0, target, true, false));
+
+    assert!(state.text_edit_target.is_none());
+    assert_page_text(&state, source, 0, shape_id, "Original");
+    assert_page_text(&state, target, 1, shape_id, "Original");
 }


### PR DESCRIPTION
## Summary

- centralizes board/page lifecycle cleanup helpers for redraw, dirty marking, pointer sync, selection/context menu cleanup, and config-save queuing
- adds deterministic `_at(now)` delete/restore entry points for boards and pages
- fixes active page mutation ordering so text edits are cancelled before page switch, duplicate, delete, or cross-board transfer mutates source content
- moves cross-board page transfer activation into the lifecycle operation instead of composing target-board switching in callers
- adds characterization tests for text-edit restoration and deterministic delete/restore expiry behavior