### PR TITLE
Make light mode click highlights configurable

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -457,6 +457,10 @@ outline_color = [1.0, 0.6, 0.0, 0.9]
 # Note: active highlights update immediately when the pen color changes
 use_pen_color = true
 
+# Force-enable click highlights when entering light mode.
+# Set false to keep the current click highlight state on light mode entry.
+force_in_light_mode = true
+
 [ui.context_menu]
 # Enable right-click / keyboard context menus
 enabled = true

--- a/configurator/src/app/view/ui/click_highlight.rs
+++ b/configurator/src/app/view/ui/click_highlight.rs
@@ -32,6 +32,12 @@ impl ConfiguratorApp {
                 self.defaults.click_highlight_use_pen_color,
                 ToggleField::UiClickHighlightUsePenColor,
             ),
+            toggle_row(
+                "Force on when entering light mode",
+                self.draft.click_highlight_force_in_light_mode,
+                self.defaults.click_highlight_force_in_light_mode,
+                ToggleField::UiClickHighlightForceInLightMode,
+            ),
             row![
                 labeled_input_with_feedback(
                     "Radius",

--- a/configurator/src/models/config/draft/from_config.rs
+++ b/configurator/src/models/config/draft/from_config.rs
@@ -127,6 +127,7 @@ impl ConfigDraft {
                 .click_highlight
                 .show_on_highlight_tool,
             click_highlight_use_pen_color: config.ui.click_highlight.use_pen_color,
+            click_highlight_force_in_light_mode: config.ui.click_highlight.force_in_light_mode,
             click_highlight_radius: format_float(config.ui.click_highlight.radius),
             click_highlight_outline_thickness: format_float(
                 config.ui.click_highlight.outline_thickness,

--- a/configurator/src/models/config/draft/mod.rs
+++ b/configurator/src/models/config/draft/mod.rs
@@ -101,6 +101,7 @@ pub struct ConfigDraft {
     pub click_highlight_enabled: bool,
     pub click_highlight_show_on_highlight_tool: bool,
     pub click_highlight_use_pen_color: bool,
+    pub click_highlight_force_in_light_mode: bool,
     pub click_highlight_radius: String,
     pub click_highlight_outline_thickness: String,
     pub click_highlight_duration_ms: String,

--- a/configurator/src/models/config/setters.rs
+++ b/configurator/src/models/config/setters.rs
@@ -170,6 +170,9 @@ impl ConfigDraft {
                 self.click_highlight_show_on_highlight_tool = value;
             }
             ToggleField::UiClickHighlightUsePenColor => self.click_highlight_use_pen_color = value,
+            ToggleField::UiClickHighlightForceInLightMode => {
+                self.click_highlight_force_in_light_mode = value;
+            }
             ToggleField::PresenterHideStatusBar => self.presenter_hide_status_bar = value,
             ToggleField::PresenterHideToolbars => self.presenter_hide_toolbars = value,
             ToggleField::PresenterHideToolPreview => self.presenter_hide_tool_preview = value,

--- a/configurator/src/models/config/tests.rs
+++ b/configurator/src/models/config/tests.rs
@@ -45,6 +45,20 @@ fn config_draft_to_config_trims_custom_directory() {
 }
 
 #[test]
+fn config_draft_round_trips_light_mode_click_highlight_policy() {
+    let mut config = Config::default();
+    config.ui.click_highlight.force_in_light_mode = false;
+
+    let draft = ConfigDraft::from_config(&config);
+    assert!(!draft.click_highlight_force_in_light_mode);
+
+    let round_trip = draft
+        .to_config(&Config::default())
+        .expect("expected config to round trip");
+    assert!(!round_trip.ui.click_highlight.force_in_light_mode);
+}
+
+#[test]
 fn setters_update_draft_state() {
     let mut draft = ConfigDraft::from_config(&Config::default());
 

--- a/configurator/src/models/config/to_config/ui.rs
+++ b/configurator/src/models/config/to_config/ui.rs
@@ -112,6 +112,7 @@ impl ConfigDraft {
         config.ui.click_highlight.show_on_highlight_tool =
             self.click_highlight_show_on_highlight_tool;
         config.ui.click_highlight.use_pen_color = self.click_highlight_use_pen_color;
+        config.ui.click_highlight.force_in_light_mode = self.click_highlight_force_in_light_mode;
         parse_field(
             &self.click_highlight_radius,
             "ui.click_highlight.radius",

--- a/configurator/src/models/fields/toggles.rs
+++ b/configurator/src/models/fields/toggles.rs
@@ -31,6 +31,7 @@ pub enum ToggleField {
     UiClickHighlightEnabled,
     UiClickHighlightShowOnHighlightTool,
     UiClickHighlightUsePenColor,
+    UiClickHighlightForceInLightMode,
     UiShowStatusBoardBadge,
     UiShowStatusPageBadge,
     UiShowPageBadgeWithStatusBar,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -354,6 +354,7 @@ duration_ms = 750
 fill_color = [1.0, 0.8, 0.0, 0.35]
 outline_color = [1.0, 0.6, 0.0, 0.9]
 use_pen_color = true  # Existing highlights update immediately when you change pen color
+force_in_light_mode = true  # Force-enable click highlights when entering light mode
 
 # Context menu visibility
 [ui.context_menu]
@@ -377,6 +378,7 @@ enabled = true
 - **Layout**: Padding, line height, dot size, border width all configurable
 - **Click highlight**: Enable presenter-style click halos with adjustable radius, colors, and duration; by default the halo follows your current pen color (set `use_pen_color = false` to keep a fixed color)
 - **Highlight tool ring**: `show_on_highlight_tool = true` keeps a persistent halo visible while the highlight tool is active
+- **Light mode**: `force_in_light_mode = true` preserves the default behavior of enabling click highlights on light mode entry; set it to `false` to keep the current click highlight state
 - **Context menu**: `ui.context_menu.enabled` toggles right-click / keyboard menus
 - **Output focus**: `multi_monitor_enabled` controls output-cycling shortcuts; `active_output_badge` shows the current monitor in the status bar
 - **GNOME fallback**: `preferred_output` pins the xdg-shell overlay to a specific monitor; `xdg_fullscreen` requests fullscreen instead of maximized; `xdg_focus_loss_behavior` controls whether losing focus closes (`exit`) or keeps (`stay`) the overlay

--- a/src/config/tests/load.rs
+++ b/src/config/tests/load.rs
@@ -38,6 +38,17 @@ fn load_parses_xdg_focus_loss_behavior_stay() {
 }
 
 #[test]
+fn click_highlight_force_in_light_mode_defaults_true_and_parses_false() {
+    let config: Config = toml::from_str("[ui.click_highlight]\nenabled = false\n")
+        .expect("missing force_in_light_mode should use default");
+    assert!(config.ui.click_highlight.force_in_light_mode);
+
+    let config: Config = toml::from_str("[ui.click_highlight]\nforce_in_light_mode = false\n")
+        .expect("explicit force_in_light_mode should parse");
+    assert!(!config.ui.click_highlight.force_in_light_mode);
+}
+
+#[test]
 fn load_parses_mouse_button_drag_tool_bindings() {
     with_temp_config_home(|config_root| {
         let primary_dir = config_root.join(PRIMARY_CONFIG_DIR);

--- a/src/config/types/click_highlight.rs
+++ b/src/config/types/click_highlight.rs
@@ -35,6 +35,10 @@ pub struct ClickHighlightConfig {
     /// Derive highlight color from current pen color
     #[serde(default = "default_click_highlight_use_pen_color")]
     pub use_pen_color: bool,
+
+    /// Force-enable click highlights when entering light mode
+    #[serde(default = "default_click_highlight_force_in_light_mode")]
+    pub force_in_light_mode: bool,
 }
 
 impl Default for ClickHighlightConfig {
@@ -48,6 +52,7 @@ impl Default for ClickHighlightConfig {
             fill_color: default_click_highlight_fill_color(),
             outline_color: default_click_highlight_outline_color(),
             use_pen_color: default_click_highlight_use_pen_color(),
+            force_in_light_mode: default_click_highlight_force_in_light_mode(),
         }
     }
 }
@@ -81,5 +86,9 @@ fn default_click_highlight_outline_color() -> [f64; 4] {
 }
 
 fn default_click_highlight_use_pen_color() -> bool {
+    true
+}
+
+fn default_click_highlight_force_in_light_mode() -> bool {
     true
 }

--- a/src/input/state/core/highlight_controls.rs
+++ b/src/input/state/core/highlight_controls.rs
@@ -10,6 +10,11 @@ impl InputState {
         self.click_highlight.enabled()
     }
 
+    /// Returns whether light mode should force-enable click highlights on entry.
+    pub fn click_highlight_forced_in_light_mode(&self) -> bool {
+        self.click_highlight.force_in_light_mode()
+    }
+
     /// Returns whether the persistent highlight ring is enabled.
     pub fn highlight_tool_ring_enabled(&self) -> bool {
         self.click_highlight.show_on_highlight_tool()

--- a/src/input/state/core/utility/light_mode.rs
+++ b/src/input/state/core/utility/light_mode.rs
@@ -142,7 +142,7 @@ impl InputState {
         self.toolbar_top_visible = false;
         self.toolbar_side_visible = false;
         self.set_tool_override(Some(Tool::Pen));
-        if !self.click_highlight_enabled() {
+        if self.click_highlight_forced_in_light_mode() && !self.click_highlight_enabled() {
             self.toggle_click_highlight();
         }
 

--- a/src/input/state/highlight/settings.rs
+++ b/src/input/state/highlight/settings.rs
@@ -16,6 +16,7 @@ pub struct ClickHighlightSettings {
     pub base_fill_color: Color,
     pub base_outline_color: Color,
     pub use_pen_color: bool,
+    pub force_in_light_mode: bool,
 }
 
 impl ClickHighlightSettings {
@@ -44,6 +45,7 @@ impl ClickHighlightSettings {
             base_fill_color: base_fill,
             base_outline_color: base_outline,
             use_pen_color: true,
+            force_in_light_mode: true,
         }
     }
 }
@@ -73,6 +75,7 @@ impl From<&ClickHighlightConfig> for ClickHighlightSettings {
             base_fill_color: fill,
             base_outline_color: outline,
             use_pen_color: cfg.use_pen_color,
+            force_in_light_mode: cfg.force_in_light_mode,
         }
     }
 }

--- a/src/input/state/highlight/state/mod.rs
+++ b/src/input/state/highlight/state/mod.rs
@@ -51,6 +51,10 @@ impl ClickHighlightState {
         self.settings.use_pen_color
     }
 
+    pub fn force_in_light_mode(&self) -> bool {
+        self.settings.force_in_light_mode
+    }
+
     pub fn show_on_highlight_tool(&self) -> bool {
         self.settings.show_on_highlight_tool
     }

--- a/src/input/state/tests/helpers.rs
+++ b/src/input/state/tests/helpers.rs
@@ -4,8 +4,27 @@ pub(super) fn create_test_input_state() -> InputState {
     create_test_input_state_with_keybindings(crate::config::KeybindingsConfig::default())
 }
 
+pub(super) fn create_test_input_state_with_click_highlight(
+    click_highlight_settings: ClickHighlightSettings,
+) -> InputState {
+    create_test_input_state_with_keybindings_and_click_highlight(
+        crate::config::KeybindingsConfig::default(),
+        click_highlight_settings,
+    )
+}
+
 pub(super) fn create_test_input_state_with_keybindings(
     keybindings: crate::config::KeybindingsConfig,
+) -> InputState {
+    create_test_input_state_with_keybindings_and_click_highlight(
+        keybindings,
+        ClickHighlightSettings::disabled(),
+    )
+}
+
+fn create_test_input_state_with_keybindings_and_click_highlight(
+    keybindings: crate::config::KeybindingsConfig,
+    click_highlight_settings: ClickHighlightSettings,
 ) -> InputState {
     let action_map = keybindings.build_action_map().unwrap();
     let action_bindings = keybindings.build_action_bindings().unwrap();
@@ -36,7 +55,7 @@ pub(super) fn create_test_input_state_with_keybindings(
         BoardsConfig::default(), // boards_config
         action_map,              // action_map
         usize::MAX,
-        ClickHighlightSettings::disabled(),
+        click_highlight_settings,
         0,
         0,
         false, // custom_section_enabled

--- a/src/input/state/tests/light_mode.rs
+++ b/src/input/state/tests/light_mode.rs
@@ -1,9 +1,17 @@
-use super::create_test_input_state;
+use super::{create_test_input_state, create_test_input_state_with_click_highlight};
 use crate::config::Action;
-use crate::input::Tool;
+use crate::input::{ClickHighlightSettings, Tool};
 
 fn create_light_mode_test_state() -> crate::input::InputState {
     let mut state = create_test_input_state();
+    state.compositor_capabilities.layer_shell = true;
+    state
+}
+
+fn create_light_mode_test_state_with_click_highlight(
+    click_highlight_settings: ClickHighlightSettings,
+) -> crate::input::InputState {
+    let mut state = create_test_input_state_with_click_highlight(click_highlight_settings);
     state.compositor_capabilities.layer_shell = true;
     state
 }
@@ -81,6 +89,39 @@ fn light_mode_restores_previous_ui_and_tool_on_exit() {
     assert!(state.toolbar_side_visible);
     assert!(state.show_tool_preview);
     assert_eq!(state.tool_override(), Some(Tool::Marker));
+}
+
+#[test]
+fn light_mode_force_enables_click_highlight_by_default_and_restores_on_exit() {
+    let mut state = create_light_mode_test_state();
+    assert!(!state.click_highlight_enabled());
+
+    state.handle_action(Action::ToggleLightMode);
+
+    assert!(state.light_mode);
+    assert!(state.click_highlight_enabled());
+
+    state.handle_action(Action::ToggleLightMode);
+
+    assert!(!state.light_mode);
+    assert!(!state.click_highlight_enabled());
+}
+
+#[test]
+fn light_mode_can_leave_click_highlight_disabled() {
+    let mut settings = ClickHighlightSettings::disabled();
+    settings.force_in_light_mode = false;
+    let mut state = create_light_mode_test_state_with_click_highlight(settings);
+
+    state.handle_action(Action::ToggleLightMode);
+
+    assert!(state.light_mode);
+    assert!(!state.click_highlight_enabled());
+
+    state.handle_action(Action::ToggleLightModeDrawing);
+
+    assert!(state.light_mode_drawing);
+    assert!(!state.click_highlight_enabled());
 }
 
 #[test]

--- a/src/input/state/tests/mod.rs
+++ b/src/input/state/tests/mod.rs
@@ -6,7 +6,10 @@ use crate::input::{ClickHighlightSettings, EraserMode, Key, MouseButton, Tool};
 use crate::util;
 
 mod helpers;
-use helpers::{create_test_input_state, create_test_input_state_with_keybindings};
+use helpers::{
+    create_test_input_state, create_test_input_state_with_click_highlight,
+    create_test_input_state_with_keybindings,
+};
 
 mod action_bindings;
 mod arrow_labels;


### PR DESCRIPTION
 ## Summary

- Add `[ui.click_highlight].force_in_light_mode` with default `true`
- Let users keep click highlights disabled when entering light mode by setting it to `false`
- Expose the option in the configurator Click Highlight tab
- Document the new setting in `config.example.toml` and `docs/CONFIG.md`

Fixes the follow-up request in #195.