### PR TITLE
Refactor board workspace lifecycle and harden delete confirmations

### DIFF
--- a/src/backend/wayland/handlers/pointer/press.rs
+++ b/src/backend/wayland/handlers/pointer/press.rs
@@ -99,6 +99,17 @@ impl WaylandState {
             self.set_toolbar_dragging(false);
             return;
         }
+
+        if button == BTN_LEFT {
+            let screen_x = event.position.0.round() as i32;
+            let screen_y = event.position.1.round() as i32;
+            self.set_pending_toast_press(false);
+            if self.input_state.toast_contains(screen_x, screen_y) {
+                self.set_pending_toast_press(true);
+                return;
+            }
+        }
+
         debug!(
             "Button {} pressed at ({}, {})",
             button, event.position.0, event.position.1

--- a/src/backend/wayland/handlers/pointer/release.rs
+++ b/src/backend/wayland/handlers/pointer/release.rs
@@ -16,12 +16,31 @@ impl WaylandState {
     ) {
         // Swallow releases after modal clicks (e.g., palette dismiss)
         if self.take_suppress_next_release() {
+            self.set_pending_toast_press(false);
             return;
         }
 
         // Block pointer input when modal overlays are active
         if self.input_state.command_palette_open || self.input_state.tour_active {
             // For command palette, press handles the click - release is a no-op
+            self.set_pending_toast_press(false);
+            return;
+        }
+
+        if button == BTN_LEFT && self.take_pending_toast_press() {
+            let screen_position = if on_toolbar {
+                self.toolbar_surface_screen_coords(&event.surface, event.position)
+            } else {
+                Some(event.position)
+            };
+            if let Some((screen_x, screen_y)) = screen_position {
+                let (hit, action) = self
+                    .input_state
+                    .check_toast_click(screen_x.round() as i32, screen_y.round() as i32);
+                if hit && let Some(action) = action {
+                    self.input_state.handle_action(action);
+                }
+            }
             return;
         }
 
@@ -108,19 +127,6 @@ impl WaylandState {
             BTN_RIGHT => MouseButton::Right,
             _ => return,
         };
-
-        // Check for toast click before other handling (toast uses screen coords)
-        if mb == MouseButton::Left {
-            let screen_x = event.position.0 as i32;
-            let screen_y = event.position.1 as i32;
-            let (hit, action) = self.input_state.check_toast_click(screen_x, screen_y);
-            if hit {
-                if let Some(action) = action {
-                    self.input_state.handle_action(action);
-                }
-                return;
-            }
-        }
 
         let screen_x = event.position.0.round() as i32;
         let screen_y = event.position.1.round() as i32;

--- a/src/backend/wayland/state/data.rs
+++ b/src/backend/wayland/state/data.rs
@@ -88,6 +88,8 @@ pub struct StateData {
     pub(super) overlay_ready: bool,
     /// Suppress the next pointer release after a modal click (e.g., command palette).
     pub(super) suppress_next_release: bool,
+    /// True when a left press began inside the main-surface toast.
+    pub(super) pending_toast_press: bool,
     /// Suppress overlay exit on focus loss for a short window (e.g., clipboard helpers).
     pub(super) suppress_focus_exit_until: Option<Instant>,
     /// Short guard window after xdg focus loss where compositor close requests are ignored
@@ -156,6 +158,7 @@ impl StateData {
             overlay_clickthrough: false,
             overlay_ready: false,
             suppress_next_release: false,
+            pending_toast_press: false,
             suppress_focus_exit_until: None,
             xdg_close_guard_until: None,
             xdg_explicit_close_requested: false,

--- a/src/backend/wayland/state/toolbar/visibility/access.rs
+++ b/src/backend/wayland/state/toolbar/visibility/access.rs
@@ -91,4 +91,14 @@ impl WaylandState {
         self.data.suppress_next_release = false;
         value
     }
+
+    pub(in crate::backend::wayland) fn set_pending_toast_press(&mut self, value: bool) {
+        self.data.pending_toast_press = value;
+    }
+
+    pub(in crate::backend::wayland) fn take_pending_toast_press(&mut self) -> bool {
+        let value = self.data.pending_toast_press;
+        self.data.pending_toast_press = false;
+        value
+    }
 }

--- a/src/config/tests/validate.rs
+++ b/src/config/tests/validate.rs
@@ -58,6 +58,84 @@ fn validate_and_clamp_clamps_out_of_range_values() {
 }
 
 #[test]
+fn validate_boards_uses_boundary_id_normalization() {
+    let mut config = Config {
+        boards: Some(BoardsConfig {
+            max_count: 4,
+            auto_create: true,
+            show_board_badge: true,
+            pan_enabled: true,
+            show_pan_badge: true,
+            persist_customizations: true,
+            default_board: "transparent".to_string(),
+            items: vec![
+                BoardItemConfig {
+                    id: " Transparent ".to_string(),
+                    name: "Overlay".to_string(),
+                    background: BoardBackgroundConfig::Transparent("transparent".to_string()),
+                    default_pen_color: None,
+                    auto_adjust_pen: false,
+                    persist: true,
+                    pinned: false,
+                },
+                BoardItemConfig {
+                    id: "  BOARD-A ".to_string(),
+                    name: "A".to_string(),
+                    background: BoardBackgroundConfig::Color(BoardColorConfig::Rgb([
+                        1.2, 0.5, -0.1,
+                    ])),
+                    default_pen_color: Some(BoardColorConfig::Rgb([0.2, 1.4, 0.6])),
+                    auto_adjust_pen: true,
+                    persist: true,
+                    pinned: false,
+                },
+                BoardItemConfig {
+                    id: "board-a".to_string(),
+                    name: "Duplicate".to_string(),
+                    background: BoardBackgroundConfig::Color(BoardColorConfig::Rgb([
+                        0.2, 0.3, 0.4,
+                    ])),
+                    default_pen_color: None,
+                    auto_adjust_pen: true,
+                    persist: true,
+                    pinned: false,
+                },
+                BoardItemConfig {
+                    id: "   ".to_string(),
+                    name: "Defaulted".to_string(),
+                    background: BoardBackgroundConfig::Color(BoardColorConfig::Rgb([
+                        0.2, 0.3, 0.4,
+                    ])),
+                    default_pen_color: None,
+                    auto_adjust_pen: true,
+                    persist: true,
+                    pinned: false,
+                },
+            ],
+        }),
+        ..Config::default()
+    };
+
+    config.validate_and_clamp();
+
+    let boards = config.boards.as_ref().expect("boards");
+    let ids: Vec<_> = boards.items.iter().map(|item| item.id.as_str()).collect();
+    assert_eq!(ids, vec!["transparent", "board-a", "board-a-2", "board-4"]);
+    match &boards.items[1].background {
+        BoardBackgroundConfig::Color(color) => assert_eq!(color.rgb(), [1.0, 0.5, 0.0]),
+        BoardBackgroundConfig::Transparent(_) => panic!("expected color background"),
+    }
+    assert_eq!(
+        boards.items[1]
+            .default_pen_color
+            .as_ref()
+            .expect("pen")
+            .rgb(),
+        [0.2, 1.0, 0.6]
+    );
+}
+
+#[test]
 fn validate_clamps_history_delays() {
     let mut config = Config::default();
     config.history.undo_all_delay_ms = 0;

--- a/src/config/validate/boards.rs
+++ b/src/config/validate/boards.rs
@@ -1,6 +1,6 @@
 use crate::config::types::{BoardBackgroundConfig, BoardColorConfig, BoardsConfig};
+use crate::input::boards::{BoundaryBoardIdSet, clamp_board_rgb};
 use log::warn;
-use std::collections::HashSet;
 
 use super::Config;
 
@@ -19,28 +19,24 @@ impl Config {
             boards.max_count = 1;
         }
 
-        let mut seen = HashSet::new();
+        let mut seen = BoundaryBoardIdSet::new();
         for (index, item) in boards.items.iter_mut().enumerate() {
-            let trimmed = item.id.trim();
-            let mut normalized = trimmed.to_lowercase();
-            if normalized.is_empty() {
-                normalized = format!("board-{}", index + 1);
-                warn!("Board id was empty; using '{}'", normalized);
-            } else if normalized != trimmed {
-                warn!("Board id '{}' normalized to '{}'", trimmed, normalized);
+            let raw_id = item.id.clone();
+            let normalized = seen.normalize_unique(&raw_id, index);
+            if normalized.changes.defaulted_empty {
+                warn!("Board id was empty; using '{}'", normalized.value);
+            } else {
+                if normalized.changes.trimmed || normalized.changes.lowercased {
+                    warn!("Board id '{}' normalized to '{}'", raw_id, normalized.value);
+                }
+                if normalized.changes.deduplicated {
+                    warn!(
+                        "Board id '{}' deduplicated to '{}'",
+                        raw_id, normalized.value
+                    );
+                }
             }
-
-            let base = normalized.clone();
-            let mut suffix = 2;
-            while seen.contains(&normalized) {
-                normalized = format!("{base}-{suffix}");
-                suffix += 1;
-            }
-            if normalized != item.id {
-                warn!("Board id '{}' updated to '{}'", item.id, normalized);
-            }
-            item.id = normalized.clone();
-            seen.insert(normalized);
+            item.id = normalized.value;
 
             if item.name.trim().is_empty() {
                 item.name = format!("Board {}", index + 1);
@@ -129,14 +125,16 @@ fn normalize_background(background: &mut BoardBackgroundConfig, id: &str) {
 }
 
 fn clamp_color(color: &mut BoardColorConfig, label: &str) {
-    let mut rgb = color.rgb();
-    for (i, component) in rgb.iter_mut().enumerate() {
-        if !(0.0..=1.0).contains(component) {
-            warn!(
-                "Invalid {}[{}] = {:.3}, clamping to 0.0-1.0",
-                label, i, *component
-            );
-            *component = (*component).clamp(0.0, 1.0);
+    let original = color.rgb();
+    let (rgb, clamped) = clamp_board_rgb(original);
+    if clamped {
+        for (i, (before, after)) in original.iter().zip(rgb.iter()).enumerate() {
+            if before != after {
+                warn!(
+                    "Invalid {}[{}] = {:.3}, clamping to 0.0-1.0",
+                    label, i, *before
+                );
+            }
         }
     }
     *color = BoardColorConfig::Rgb(rgb);

--- a/src/draw/canvas_set/pages.rs
+++ b/src/draw/canvas_set/pages.rs
@@ -126,13 +126,21 @@ impl BoardPages {
     }
 
     /// Insert a page after the current position.
+    #[allow(dead_code)]
     pub fn insert_page(&mut self, page: Frame) {
         let insert_at = (self.active + 1).min(self.pages.len());
+        self.insert_page_at(insert_at, page);
+    }
+
+    pub fn insert_page_at(&mut self, index: usize, page: Frame) -> usize {
+        let insert_at = index.min(self.pages.len());
         self.pages.insert(insert_at, page);
         self.active = insert_at;
         self.bump_generation();
+        insert_at
     }
 
+    #[allow(dead_code)]
     pub fn delete_page(&mut self) -> PageDeleteOutcome {
         if self.pages.len() == 1 {
             self.pages[0].clear();
@@ -267,5 +275,50 @@ impl BoardPages {
 
     pub fn pages_mut(&mut self) -> &mut Vec<Frame> {
         &mut self.pages
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::draw::{RED, Shape};
+
+    #[test]
+    fn page_generation_changes_on_identity_or_order_updates() {
+        let mut pages = BoardPages::new();
+        let start = pages.generation();
+
+        pages.new_page();
+        assert_ne!(pages.generation(), start);
+        let after_new = pages.generation();
+
+        assert!(pages.move_page(1, 0));
+        assert_ne!(pages.generation(), after_new);
+        let after_move = pages.generation();
+
+        let _ = pages.delete_page();
+        assert_ne!(pages.generation(), after_move);
+    }
+
+    #[test]
+    fn page_generation_does_not_change_for_rejected_noop_content_or_rename_updates() {
+        let mut pages = BoardPages::new();
+        let start = pages.generation();
+
+        assert!(!pages.switch_to_page(0));
+        assert!(!pages.move_page(0, 9));
+        assert_eq!(pages.delete_page_at(9), PageDeleteOutcome::Pending);
+        assert_eq!(pages.generation(), start);
+
+        assert!(pages.set_page_name(0, Some("Notes".to_string())));
+        pages.active_frame_mut().add_shape(Shape::Line {
+            x1: 0,
+            y1: 0,
+            x2: 10,
+            y2: 10,
+            color: RED,
+            thick: 2.0,
+        });
+        assert_eq!(pages.generation(), start);
     }
 }

--- a/src/input/boards.rs
+++ b/src/input/boards.rs
@@ -1,8 +1,30 @@
+mod color;
 mod core;
+mod identity;
 mod mapping;
 mod naming;
+mod operations;
+#[cfg(test)]
+mod tests;
 
 use crate::draw::{BoardPages, Color};
+
+#[allow(unused_imports)]
+pub use color::{
+    board_color_from_config, board_color_to_config, clamp_board_rgb, runtime_contrast_pen_color,
+    runtime_contrast_pen_rgb,
+};
+#[allow(unused_imports)]
+pub use identity::{
+    BoardIdChangeSet, BoardIdentityGeneration, BoundaryBoardId, BoundaryBoardIdSet,
+};
+pub use operations::{
+    BoardDeleteConfirmation, BoardDeleteOutcome, BoardDeleteRejection, BoardDeleteRequest,
+    BoardDeleteTarget, BoardRestoreOutcome, BoardRestoreRejection, BoardRestoreRequest,
+    PageDeleteBoardTarget, PageDeleteConfirmation, PageDeleteOutcome, PageDeleteRequest,
+    PageDeleteTarget, PageOperationRejection, PageRestoreOutcome, PageRestorePlacement,
+    PageRestoreRejection, PageRestoreRequest,
+};
 
 pub const BOARD_ID_TRANSPARENT: &str = "transparent";
 pub const BOARD_ID_WHITEBOARD: &str = "whiteboard";
@@ -46,7 +68,7 @@ impl BoardState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BoardManager {
     boards: Vec<BoardState>,
     active_index: usize,
@@ -58,4 +80,23 @@ pub struct BoardManager {
     persist_customizations: bool,
     default_board_id: String,
     template: BoardSpec,
+    identity_generation: BoardIdentityGeneration,
+}
+
+impl Clone for BoardManager {
+    fn clone(&self) -> Self {
+        Self {
+            boards: self.boards.clone(),
+            active_index: self.active_index,
+            max_count: self.max_count,
+            auto_create: self.auto_create,
+            show_badge: self.show_badge,
+            pan_enabled: self.pan_enabled,
+            show_pan_badge: self.show_pan_badge,
+            persist_customizations: self.persist_customizations,
+            default_board_id: self.default_board_id.clone(),
+            template: self.template.clone(),
+            identity_generation: BoardIdentityGeneration::fresh(),
+        }
+    }
 }

--- a/src/input/boards/color.rs
+++ b/src/input/boards/color.rs
@@ -1,0 +1,61 @@
+use crate::config::BoardColorConfig;
+use crate::draw::{BLACK, Color, WHITE};
+
+pub fn runtime_contrast_pen_color(background: Color) -> Color {
+    let [r, g, b] = runtime_contrast_pen_rgb([background.r, background.g, background.b]);
+    Color { r, g, b, a: 1.0 }
+}
+
+pub fn runtime_contrast_pen_rgb(background: [f64; 3]) -> [f64; 3] {
+    let luminance = 0.2126 * background[0] + 0.7152 * background[1] + 0.0722 * background[2];
+    if luminance > 0.5 {
+        [BLACK.r, BLACK.g, BLACK.b]
+    } else {
+        [WHITE.r, WHITE.g, WHITE.b]
+    }
+}
+
+pub fn board_color_from_config(config: &BoardColorConfig) -> Color {
+    let rgb = config.rgb();
+    Color {
+        r: rgb[0],
+        g: rgb[1],
+        b: rgb[2],
+        a: 1.0,
+    }
+}
+
+pub fn board_color_to_config(color: Color) -> BoardColorConfig {
+    BoardColorConfig::Rgb([color.r, color.g, color.b])
+}
+
+pub fn clamp_board_rgb(mut rgb: [f64; 3]) -> ([f64; 3], bool) {
+    let mut clamped = false;
+    for component in &mut rgb {
+        if !(0.0..=1.0).contains(component) {
+            *component = (*component).clamp(0.0, 1.0);
+            clamped = true;
+        }
+    }
+    (rgb, clamped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_contrast_uses_weighted_luminance_threshold() {
+        assert_eq!(runtime_contrast_pen_rgb([0.5, 0.5, 0.5]), [1.0, 1.0, 1.0]);
+        assert_eq!(
+            runtime_contrast_pen_rgb([0.51, 0.51, 0.51]),
+            [0.0, 0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn clamp_board_rgb_reports_whether_any_component_changed() {
+        assert_eq!(clamp_board_rgb([0.2, 0.3, 0.4]), ([0.2, 0.3, 0.4], false));
+        assert_eq!(clamp_board_rgb([-0.5, 0.3, 1.4]), ([0.0, 0.3, 1.0], true));
+    }
+}

--- a/src/input/boards/core.rs
+++ b/src/input/boards/core.rs
@@ -1,5 +1,8 @@
-use super::{BOARD_ID_TRANSPARENT, BoardBackground, BoardManager, BoardSpec, BoardState};
-use crate::draw::{BoardPages, Frame, PageDeleteOutcome};
+use super::{
+    BOARD_ID_TRANSPARENT, BoardBackground, BoardIdentityGeneration, BoardManager, BoardSpec,
+    BoardState,
+};
+use crate::draw::{BoardPages, Frame, PageDeleteOutcome as CanvasPageDeleteOutcome};
 
 impl BoardManager {
     pub fn board_count(&self) -> usize {
@@ -8,6 +11,15 @@ impl BoardManager {
 
     pub fn active_index(&self) -> usize {
         self.active_index
+    }
+
+    pub fn board_identity_generation(&self) -> BoardIdentityGeneration {
+        self.identity_generation
+    }
+
+    pub(crate) fn bump_board_identity_generation(&mut self) -> BoardIdentityGeneration {
+        self.identity_generation = BoardIdentityGeneration::fresh();
+        self.identity_generation
     }
 
     pub fn active_board(&self) -> &BoardState {
@@ -103,11 +115,13 @@ impl BoardManager {
         self.active_pages_mut().duplicate_page();
     }
 
+    #[allow(dead_code)]
     pub fn insert_page(&mut self, page: Frame) {
         self.active_pages_mut().insert_page(page);
     }
 
-    pub fn delete_page(&mut self) -> PageDeleteOutcome {
+    #[allow(dead_code)]
+    pub fn delete_active_page(&mut self) -> CanvasPageDeleteOutcome {
         self.active_pages_mut().delete_page()
     }
 
@@ -155,6 +169,7 @@ impl BoardManager {
         self.boards.iter_mut().find(|board| board.spec.id == id)
     }
 
+    #[allow(dead_code)]
     pub fn remove_active_board(&mut self) -> bool {
         if self.boards.len() <= 1 {
             return false;
@@ -170,6 +185,7 @@ impl BoardManager {
                 |board| board.spec.id.clone(),
             );
         }
+        self.bump_board_identity_generation();
         true
     }
 
@@ -200,6 +216,7 @@ impl BoardManager {
 
     /// Insert a board at the given index.
     /// Returns true if successful, false if the board limit is reached.
+    #[allow(dead_code)]
     pub fn insert_board(&mut self, index: usize, mut board: BoardState) -> bool {
         if self.boards.len() >= self.max_count {
             return false;
@@ -208,6 +225,7 @@ impl BoardManager {
         let insert_at = index.min(self.boards.len());
         self.boards.insert(insert_at, board);
         self.active_index = insert_at;
+        self.bump_board_identity_generation();
         true
     }
 }

--- a/src/input/boards/identity.rs
+++ b/src/input/boards/identity.rs
@@ -1,0 +1,97 @@
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_BOARD_IDENTITY_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BoardIdentityGeneration(pub u64);
+
+impl BoardIdentityGeneration {
+    pub(crate) fn fresh() -> Self {
+        Self(NEXT_BOARD_IDENTITY_GENERATION.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+pub struct BoundaryBoardId {
+    pub value: String,
+    pub changes: BoardIdChangeSet,
+}
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BoardIdChangeSet {
+    pub trimmed: bool,
+    pub lowercased: bool,
+    pub defaulted_empty: bool,
+    pub deduplicated: bool,
+}
+
+#[derive(Default)]
+pub struct BoundaryBoardIdSet {
+    seen: HashSet<String>,
+}
+
+impl BoundaryBoardIdSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn normalize_unique(&mut self, raw: &str, index: usize) -> BoundaryBoardId {
+        let trimmed = raw.trim();
+        let lowercased = trimmed.to_lowercase();
+        let mut changes = BoardIdChangeSet {
+            trimmed: trimmed != raw,
+            lowercased: lowercased != trimmed,
+            ..BoardIdChangeSet::default()
+        };
+
+        let mut candidate = lowercased;
+        if candidate.is_empty() {
+            candidate = format!("board-{}", index + 1);
+            changes.defaulted_empty = true;
+        }
+
+        let base = candidate.clone();
+        let mut suffix = 2;
+        while self.seen.contains(&candidate) {
+            candidate = format!("{base}-{suffix}");
+            suffix += 1;
+            changes.deduplicated = true;
+        }
+
+        self.seen.insert(candidate.clone());
+        BoundaryBoardId {
+            value: candidate,
+            changes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boundary_board_ids_trim_lowercase_default_and_dedupe() {
+        let mut ids = BoundaryBoardIdSet::new();
+
+        let first = ids.normalize_unique("  Board-A  ", 0);
+        assert_eq!(first.value, "board-a");
+        assert_eq!(
+            first.changes,
+            BoardIdChangeSet {
+                trimmed: true,
+                lowercased: true,
+                defaulted_empty: false,
+                deduplicated: false,
+            }
+        );
+
+        let second = ids.normalize_unique("board-a", 1);
+        assert_eq!(second.value, "board-a-2");
+        assert!(second.changes.deduplicated);
+
+        let third = ids.normalize_unique("   ", 2);
+        assert_eq!(third.value, "board-3");
+        assert!(third.changes.defaulted_empty);
+    }
+}

--- a/src/input/boards/mapping.rs
+++ b/src/input/boards/mapping.rs
@@ -1,7 +1,9 @@
 use super::{
-    BOARD_ID_TRANSPARENT, BOARD_ID_WHITEBOARD, BoardBackground, BoardManager, BoardSpec, BoardState,
+    BOARD_ID_TRANSPARENT, BOARD_ID_WHITEBOARD, BoardBackground, BoardIdentityGeneration,
+    BoardManager, BoardSpec, BoardState, board_color_from_config, board_color_to_config,
+    runtime_contrast_pen_color,
 };
-use crate::config::{BoardBackgroundConfig, BoardColorConfig, BoardItemConfig, BoardsConfig};
+use crate::config::{BoardBackgroundConfig, BoardItemConfig, BoardsConfig};
 use crate::draw::Color;
 
 impl BoardSpec {
@@ -27,7 +29,7 @@ impl BoardSpec {
         }
 
         match self.background {
-            BoardBackground::Solid(color) => Some(contrast_color(color)),
+            BoardBackground::Solid(color) => Some(runtime_contrast_pen_color(color)),
             BoardBackground::Transparent => None,
         }
     }
@@ -64,6 +66,7 @@ impl BoardManager {
             persist_customizations: config.persist_customizations,
             default_board_id: config.default_board,
             template,
+            identity_generation: BoardIdentityGeneration::fresh(),
         }
     }
 
@@ -83,10 +86,7 @@ impl BoardManager {
                     id: board.spec.id.clone(),
                     name: board.spec.name.clone(),
                     background: board_background_to_config(&board.spec.background),
-                    default_pen_color: board
-                        .spec
-                        .default_pen_color
-                        .map(|color| BoardColorConfig::Rgb([color.r, color.g, color.b])),
+                    default_pen_color: board.spec.default_pen_color.map(board_color_to_config),
                     auto_adjust_pen: board.spec.auto_adjust_pen,
                     persist: board.spec.persist,
                     pinned: board.spec.pinned,
@@ -123,36 +123,7 @@ fn board_background_to_config(background: &BoardBackground) -> BoardBackgroundCo
             BoardBackgroundConfig::Transparent("transparent".to_string())
         }
         BoardBackground::Solid(color) => {
-            BoardBackgroundConfig::Color(BoardColorConfig::Rgb([color.r, color.g, color.b]))
-        }
-    }
-}
-
-fn board_color_from_config(config: &BoardColorConfig) -> Color {
-    let rgb = config.rgb();
-    Color {
-        r: rgb[0],
-        g: rgb[1],
-        b: rgb[2],
-        a: 1.0,
-    }
-}
-
-fn contrast_color(background: Color) -> Color {
-    let luminance = 0.2126 * background.r + 0.7152 * background.g + 0.0722 * background.b;
-    if luminance > 0.5 {
-        Color {
-            r: 0.0,
-            g: 0.0,
-            b: 0.0,
-            a: 1.0,
-        }
-    } else {
-        Color {
-            r: 1.0,
-            g: 1.0,
-            b: 1.0,
-            a: 1.0,
+            BoardBackgroundConfig::Color(board_color_to_config(*color))
         }
     }
 }

--- a/src/input/boards/naming.rs
+++ b/src/input/boards/naming.rs
@@ -50,6 +50,7 @@ impl BoardManager {
         }
 
         self.active_index = slot;
+        self.bump_board_identity_generation();
         true
     }
 
@@ -103,6 +104,7 @@ impl BoardManager {
         spec.name = name_from_id(id);
         self.boards.push(BoardState::new(spec));
         let index = self.boards.len() - 1;
+        self.bump_board_identity_generation();
         Some(&mut self.boards[index])
     }
 
@@ -114,6 +116,7 @@ impl BoardManager {
         let new_spec = self.template_for_slot(index);
         self.boards.push(BoardState::new(new_spec));
         self.active_index = index;
+        self.bump_board_identity_generation();
         true
     }
 
@@ -136,6 +139,7 @@ impl BoardManager {
         let insert_at = self.active_index + 1;
         self.boards.insert(insert_at, new_board);
         self.active_index = insert_at;
+        self.bump_board_identity_generation();
         Some(new_spec.id)
     }
 

--- a/src/input/boards/operations.rs
+++ b/src/input/boards/operations.rs
@@ -1,0 +1,457 @@
+use super::{BoardIdentityGeneration, BoardManager, BoardState};
+use crate::draw::Frame;
+
+#[derive(Clone, Debug)]
+pub enum BoardDeleteRequest {
+    Request(BoardDeleteTarget),
+    Confirm(BoardDeleteConfirmation),
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum BoardDeleteTarget {
+    Active,
+    BoardIndex(usize),
+    BoardId(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct BoardDeleteConfirmation {
+    pub board_id: String,
+    pub board_name: String,
+    pub board_identity_generation: BoardIdentityGeneration,
+}
+
+impl BoardDeleteConfirmation {
+    pub fn matches_identity(&self, board_id: &str, generation: BoardIdentityGeneration) -> bool {
+        self.board_id == board_id && self.board_identity_generation == generation
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "workspace contract returns the deleted board without extra indirection"
+)]
+pub enum BoardDeleteOutcome {
+    RequiresConfirmation {
+        confirmation: BoardDeleteConfirmation,
+    },
+    Deleted {
+        deleted_board: BoardState,
+        deleted_id: String,
+        deleted_name: String,
+        active_id: String,
+        active_index: usize,
+        board_identity_generation: BoardIdentityGeneration,
+    },
+    Rejected(BoardDeleteRejection),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoardDeleteRejection {
+    MissingBoard,
+    StaleConfirmation,
+    TransparentBoard,
+    LastBoard,
+}
+
+#[derive(Clone, Debug)]
+pub enum PageDeleteRequest {
+    Request(PageDeleteTarget),
+    Confirm(PageDeleteConfirmation),
+}
+
+#[derive(Clone, Debug)]
+pub struct PageDeleteTarget {
+    pub board: PageDeleteBoardTarget,
+    pub page_index: usize,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum PageDeleteBoardTarget {
+    ActiveBoard,
+    BoardIndex(usize),
+    BoardId(String),
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct PageDeleteConfirmation {
+    pub board_id: String,
+    pub board_name: String,
+    pub board_identity_generation: BoardIdentityGeneration,
+    pub page_index: usize,
+    pub page_count: usize,
+    pub page_generation: u64,
+}
+
+impl PageDeleteConfirmation {
+    pub fn matches_identity(
+        &self,
+        board_id: &str,
+        board_identity_generation: BoardIdentityGeneration,
+        page_index: usize,
+        page_count: usize,
+        page_generation: u64,
+    ) -> bool {
+        self.board_id == board_id
+            && self.board_identity_generation == board_identity_generation
+            && self.page_index == page_index
+            && self.page_count == page_count
+            && self.page_generation == page_generation
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum PageDeleteOutcome {
+    RequiresConfirmation {
+        confirmation: PageDeleteConfirmation,
+    },
+    ClearedLastPage {
+        board_id: String,
+        board_name: String,
+        page_index: usize,
+        cleared_page: Frame,
+        new_page_count: usize,
+        new_page_generation: u64,
+    },
+    Removed {
+        board_id: String,
+        board_name: String,
+        page_index: usize,
+        deleted_page: Frame,
+        new_page_index: usize,
+        new_page_count: usize,
+        new_page_generation: u64,
+    },
+    Rejected(PageOperationRejection),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PageOperationRejection {
+    MissingBoard,
+    MissingPage,
+    StaleConfirmation,
+}
+
+#[derive(Clone, Debug)]
+pub struct BoardRestoreRequest {
+    pub board: BoardState,
+    pub preferred_index: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum BoardRestoreOutcome {
+    Restored {
+        restored_id: String,
+        restored_name: String,
+        restored_index: usize,
+        active_id: String,
+        active_index: usize,
+        id_changed: bool,
+        board_identity_generation: BoardIdentityGeneration,
+    },
+    Rejected(BoardRestoreRejection),
+}
+
+#[derive(Clone, Debug)]
+pub enum BoardRestoreRejection {
+    MaxCountReached { request: BoardRestoreRequest },
+}
+
+#[derive(Clone, Debug)]
+pub struct PageRestoreRequest {
+    pub board_id: String,
+    pub page: Frame,
+    pub placement: PageRestorePlacement,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum PageRestorePlacement {
+    AfterActivePage,
+    AtIndex(usize),
+    Append,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum PageRestoreOutcome {
+    Restored {
+        board_id: String,
+        board_name: String,
+        page_index: usize,
+        active_page_index: usize,
+        page_count: usize,
+        page_generation: u64,
+    },
+    Rejected(PageRestoreRejection),
+}
+
+#[derive(Clone, Debug)]
+pub enum PageRestoreRejection {
+    MissingBoard { request: PageRestoreRequest },
+}
+
+impl BoardManager {
+    pub fn delete_board(&mut self, request: BoardDeleteRequest) -> BoardDeleteOutcome {
+        match request {
+            BoardDeleteRequest::Request(target) => self.request_board_delete(target),
+            BoardDeleteRequest::Confirm(confirmation) => self.confirm_board_delete(confirmation),
+        }
+    }
+
+    pub fn delete_page(&mut self, request: PageDeleteRequest) -> PageDeleteOutcome {
+        match request {
+            PageDeleteRequest::Request(target) => self.request_page_delete(target),
+            PageDeleteRequest::Confirm(confirmation) => self.confirm_page_delete(confirmation),
+        }
+    }
+
+    pub fn restore_board(&mut self, request: BoardRestoreRequest) -> BoardRestoreOutcome {
+        if self.boards.len() >= self.max_count {
+            return BoardRestoreOutcome::Rejected(BoardRestoreRejection::MaxCountReached {
+                request,
+            });
+        }
+
+        let original_id = request.board.spec.id.clone();
+        let mut board = request.board;
+        board.spec.id = self.unique_board_id(board.spec.id.clone());
+        let restored_id = board.spec.id.clone();
+        let restored_name = board.spec.name.clone();
+        let restored_index = request
+            .preferred_index
+            .filter(|index| *index <= self.boards.len())
+            .unwrap_or(self.boards.len());
+
+        self.boards.insert(restored_index, board);
+        self.active_index = restored_index;
+        let board_identity_generation = self.bump_board_identity_generation();
+
+        BoardRestoreOutcome::Restored {
+            restored_id: restored_id.clone(),
+            restored_name,
+            restored_index,
+            active_id: restored_id,
+            active_index: restored_index,
+            id_changed: original_id != self.boards[restored_index].spec.id,
+            board_identity_generation,
+        }
+    }
+
+    pub fn restore_page(&mut self, request: PageRestoreRequest) -> PageRestoreOutcome {
+        let Some(board_index) = self.board_index_by_id(&request.board_id) else {
+            return PageRestoreOutcome::Rejected(PageRestoreRejection::MissingBoard { request });
+        };
+
+        let board = &mut self.boards[board_index];
+        let board_id = board.spec.id.clone();
+        let board_name = board.spec.name.clone();
+        let page_count = board.pages.page_count();
+        let insert_at = match request.placement {
+            PageRestorePlacement::AfterActivePage => {
+                (board.pages.active_index() + 1).min(page_count)
+            }
+            PageRestorePlacement::AtIndex(index) => index.min(page_count),
+            PageRestorePlacement::Append => page_count,
+        };
+        let page_index = board.pages.insert_page_at(insert_at, request.page);
+
+        PageRestoreOutcome::Restored {
+            board_id,
+            board_name,
+            page_index,
+            active_page_index: board.pages.active_index(),
+            page_count: board.pages.page_count(),
+            page_generation: board.pages.generation(),
+        }
+    }
+
+    fn request_board_delete(&self, target: BoardDeleteTarget) -> BoardDeleteOutcome {
+        let Some(index) = self.board_index_for_delete_target(target) else {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::MissingBoard);
+        };
+        let board = &self.boards[index];
+        if board.spec.background.is_transparent() {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::TransparentBoard);
+        }
+        if self.boards.len() <= 1 {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::LastBoard);
+        }
+        BoardDeleteOutcome::RequiresConfirmation {
+            confirmation: BoardDeleteConfirmation {
+                board_id: board.spec.id.clone(),
+                board_name: board.spec.name.clone(),
+                board_identity_generation: self.identity_generation,
+            },
+        }
+    }
+
+    fn confirm_board_delete(
+        &mut self,
+        confirmation: BoardDeleteConfirmation,
+    ) -> BoardDeleteOutcome {
+        if confirmation.board_identity_generation != self.identity_generation {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::StaleConfirmation);
+        }
+        let Some(index) = self.board_index_by_id(&confirmation.board_id) else {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::MissingBoard);
+        };
+        let board = &self.boards[index];
+        if !confirmation.matches_identity(&board.spec.id, self.identity_generation) {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::StaleConfirmation);
+        }
+        if board.spec.background.is_transparent() {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::TransparentBoard);
+        }
+        if self.boards.len() <= 1 {
+            return BoardDeleteOutcome::Rejected(BoardDeleteRejection::LastBoard);
+        }
+
+        let deleted_board = self.boards.remove(index);
+        let deleted_id = deleted_board.spec.id.clone();
+        let deleted_name = deleted_board.spec.name.clone();
+        if self.active_index == index {
+            self.active_index = self.active_index.min(self.boards.len().saturating_sub(1));
+        } else if self.active_index > index {
+            self.active_index -= 1;
+        }
+        self.repair_default_board_after_removal(&deleted_id);
+        let board_identity_generation = self.bump_board_identity_generation();
+        let active_id = self.active_board_id().to_string();
+        let active_index = self.active_index;
+
+        BoardDeleteOutcome::Deleted {
+            deleted_board,
+            deleted_id,
+            deleted_name,
+            active_id,
+            active_index,
+            board_identity_generation,
+        }
+    }
+
+    fn request_page_delete(&mut self, target: PageDeleteTarget) -> PageDeleteOutcome {
+        let Some(board_index) = self.board_index_for_page_delete_target(&target.board) else {
+            return PageDeleteOutcome::Rejected(PageOperationRejection::MissingBoard);
+        };
+        let board = &mut self.boards[board_index];
+        if target.page_index >= board.pages.page_count() {
+            return PageDeleteOutcome::Rejected(PageOperationRejection::MissingPage);
+        }
+        let board_id = board.spec.id.clone();
+        let board_name = board.spec.name.clone();
+        let page_count = board.pages.page_count();
+        let page_generation = board.pages.generation();
+
+        if page_count <= 1 {
+            let cleared_page = board.pages.pages()[target.page_index].clone();
+            let _ = board.pages.delete_page_at(target.page_index);
+            return PageDeleteOutcome::ClearedLastPage {
+                board_id,
+                board_name,
+                page_index: target.page_index,
+                cleared_page,
+                new_page_count: board.pages.page_count(),
+                new_page_generation: board.pages.generation(),
+            };
+        }
+
+        PageDeleteOutcome::RequiresConfirmation {
+            confirmation: PageDeleteConfirmation {
+                board_id,
+                board_name,
+                board_identity_generation: self.identity_generation,
+                page_index: target.page_index,
+                page_count,
+                page_generation,
+            },
+        }
+    }
+
+    fn confirm_page_delete(&mut self, confirmation: PageDeleteConfirmation) -> PageDeleteOutcome {
+        if confirmation.board_identity_generation != self.identity_generation {
+            return PageDeleteOutcome::Rejected(PageOperationRejection::StaleConfirmation);
+        }
+        let Some(board_index) = self.board_index_by_id(&confirmation.board_id) else {
+            return PageDeleteOutcome::Rejected(PageOperationRejection::MissingBoard);
+        };
+        let board = &mut self.boards[board_index];
+        let page_count = board.pages.page_count();
+        let page_generation = board.pages.generation();
+        if !confirmation.matches_identity(
+            &board.spec.id,
+            self.identity_generation,
+            confirmation.page_index,
+            page_count,
+            page_generation,
+        ) {
+            return PageDeleteOutcome::Rejected(PageOperationRejection::StaleConfirmation);
+        }
+        if confirmation.page_index >= page_count {
+            return PageDeleteOutcome::Rejected(PageOperationRejection::MissingPage);
+        }
+
+        let board_id = board.spec.id.clone();
+        let board_name = board.spec.name.clone();
+        if page_count <= 1 {
+            let cleared_page = board.pages.pages()[confirmation.page_index].clone();
+            let _ = board.pages.delete_page_at(confirmation.page_index);
+            return PageDeleteOutcome::ClearedLastPage {
+                board_id,
+                board_name,
+                page_index: confirmation.page_index,
+                cleared_page,
+                new_page_count: board.pages.page_count(),
+                new_page_generation: board.pages.generation(),
+            };
+        }
+
+        let deleted_page = board.pages.pages()[confirmation.page_index].clone();
+        let _ = board.pages.delete_page_at(confirmation.page_index);
+        PageDeleteOutcome::Removed {
+            board_id,
+            board_name,
+            page_index: confirmation.page_index,
+            deleted_page,
+            new_page_index: board.pages.active_index(),
+            new_page_count: board.pages.page_count(),
+            new_page_generation: board.pages.generation(),
+        }
+    }
+
+    fn board_index_for_delete_target(&self, target: BoardDeleteTarget) -> Option<usize> {
+        match target {
+            BoardDeleteTarget::Active => Some(self.active_index),
+            BoardDeleteTarget::BoardIndex(index) => self.boards.get(index).map(|_| index),
+            BoardDeleteTarget::BoardId(id) => self.board_index_by_id(&id),
+        }
+    }
+
+    fn board_index_for_page_delete_target(&self, target: &PageDeleteBoardTarget) -> Option<usize> {
+        match target {
+            PageDeleteBoardTarget::ActiveBoard => Some(self.active_index),
+            PageDeleteBoardTarget::BoardIndex(index) => self.boards.get(*index).map(|_| *index),
+            PageDeleteBoardTarget::BoardId(id) => self.board_index_by_id(id),
+        }
+    }
+
+    fn board_index_by_id(&self, id: &str) -> Option<usize> {
+        self.boards.iter().position(|board| board.spec.id == id)
+    }
+
+    fn repair_default_board_after_removal(&mut self, removed_id: &str) {
+        if self.default_board_id == removed_id {
+            self.default_board_id = self.boards.get(self.active_index).map_or_else(
+                || super::BOARD_ID_TRANSPARENT.to_string(),
+                |board| board.spec.id.clone(),
+            );
+        }
+    }
+}

--- a/src/input/boards/tests.rs
+++ b/src/input/boards/tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+use crate::config::BoardsConfig;
+use crate::draw::{BoardPages, Frame};
+
+fn manager() -> BoardManager {
+    BoardManager::from_config(BoardsConfig::default())
+}
+
+fn board_index(boards: &BoardManager, id: &str) -> usize {
+    boards
+        .board_states()
+        .iter()
+        .position(|board| board.spec.id == id)
+        .expect("board index")
+}
+
+fn two_named_pages(first: &str, second: &str) -> BoardPages {
+    let mut a = Frame::new();
+    a.set_page_name(Some(first.to_string()));
+    let mut b = Frame::new();
+    b.set_page_name(Some(second.to_string()));
+    BoardPages::from_pages(vec![a, b], 0)
+}
+
+fn board_delete_confirmation(boards: &mut BoardManager, id: &str) -> BoardDeleteConfirmation {
+    let BoardDeleteOutcome::RequiresConfirmation { confirmation } = boards.delete_board(
+        BoardDeleteRequest::Request(BoardDeleteTarget::BoardId(id.to_string())),
+    ) else {
+        panic!("expected board delete confirmation");
+    };
+    confirmation
+}
+
+fn page_delete_confirmation(
+    boards: &mut BoardManager,
+    board_id: &str,
+    page_index: usize,
+) -> PageDeleteConfirmation {
+    let PageDeleteOutcome::RequiresConfirmation { confirmation } =
+        boards.delete_page(PageDeleteRequest::Request(PageDeleteTarget {
+            board: PageDeleteBoardTarget::BoardId(board_id.to_string()),
+            page_index,
+        }))
+    else {
+        panic!("expected page delete confirmation");
+    };
+    confirmation
+}
+
+#[test]
+fn board_identity_generation_changes_only_for_identity_mutations() {
+    let mut boards = manager();
+    let initial = boards.board_identity_generation();
+    assert!(boards.switch_to_id(BOARD_ID_WHITEBOARD));
+    assert_eq!(boards.board_identity_generation(), initial);
+
+    let renamed = board_index(&boards, BOARD_ID_WHITEBOARD);
+    boards.board_states_mut()[renamed].spec.name = "Renamed".to_string();
+    assert_eq!(boards.board_identity_generation(), initial);
+
+    boards.new_page();
+    assert_eq!(boards.board_identity_generation(), initial);
+
+    assert!(boards.move_board(1, 2));
+    assert_eq!(boards.board_identity_generation(), initial);
+
+    assert!(boards.create_board());
+    let after_create = boards.board_identity_generation();
+    assert_ne!(after_create, initial);
+
+    assert!(boards.duplicate_active_board().is_some());
+    let after_duplicate = boards.board_identity_generation();
+    assert_ne!(after_duplicate, after_create);
+}
+
+#[test]
+fn confirmed_board_delete_uses_id_after_active_drift_and_reorder() {
+    let mut boards = manager();
+    let confirmation = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+
+    assert!(boards.switch_to_id(BOARD_ID_WHITEBOARD));
+    let blackboard = board_index(&boards, BOARD_ID_BLACKBOARD);
+    assert!(boards.move_board(blackboard, 1));
+
+    let BoardDeleteOutcome::Deleted { deleted_id, .. } =
+        boards.delete_board(BoardDeleteRequest::Confirm(confirmation))
+    else {
+        panic!("expected delete");
+    };
+    assert_eq!(deleted_id, BOARD_ID_BLACKBOARD);
+    assert!(!boards.has_board(BOARD_ID_BLACKBOARD));
+    assert_eq!(boards.active_board_id(), BOARD_ID_WHITEBOARD);
+}
+
+#[test]
+fn board_rename_does_not_stale_board_delete_confirmation() {
+    let mut boards = manager();
+    let confirmation = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+    let index = board_index(&boards, BOARD_ID_BLACKBOARD);
+    boards.board_states_mut()[index].spec.name = "New display name".to_string();
+
+    assert!(matches!(
+        boards.delete_board(BoardDeleteRequest::Confirm(confirmation)),
+        BoardDeleteOutcome::Deleted { .. }
+    ));
+}
+
+#[test]
+fn board_identity_change_rejects_stale_board_delete_confirmation() {
+    let mut boards = manager();
+    let confirmation = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+
+    assert!(boards.create_board());
+
+    assert!(matches!(
+        boards.delete_board(BoardDeleteRequest::Confirm(confirmation)),
+        BoardDeleteOutcome::Rejected(BoardDeleteRejection::StaleConfirmation)
+    ));
+}
+
+#[test]
+fn cloned_board_manager_gets_fresh_identity_generation() {
+    let boards = manager();
+    let clone = boards.clone();
+
+    assert_ne!(
+        clone.board_identity_generation(),
+        boards.board_identity_generation()
+    );
+}
+
+#[test]
+fn deleted_and_reused_board_id_rejects_stale_board_delete_confirmation() {
+    let mut boards = manager();
+    let stale = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+    let current = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+
+    let BoardDeleteOutcome::Deleted { deleted_board, .. } =
+        boards.delete_board(BoardDeleteRequest::Confirm(current))
+    else {
+        panic!("expected delete");
+    };
+    assert!(matches!(
+        boards.restore_board(BoardRestoreRequest {
+            board: deleted_board,
+            preferred_index: None,
+        }),
+        BoardRestoreOutcome::Restored {
+            id_changed: false,
+            ..
+        }
+    ));
+    assert!(boards.has_board(BOARD_ID_BLACKBOARD));
+
+    assert!(matches!(
+        boards.delete_board(BoardDeleteRequest::Confirm(stale)),
+        BoardDeleteOutcome::Rejected(BoardDeleteRejection::StaleConfirmation)
+    ));
+}
+
+#[test]
+fn full_board_manager_replacement_rejects_same_id_confirmation() {
+    let mut boards = manager();
+    let confirmation = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+
+    let mut replacement = manager();
+
+    assert!(matches!(
+        replacement.delete_board(BoardDeleteRequest::Confirm(confirmation)),
+        BoardDeleteOutcome::Rejected(BoardDeleteRejection::StaleConfirmation)
+    ));
+}
+
+#[test]
+fn confirmation_identity_ignores_display_board_name() {
+    let mut boards = manager();
+    let board_confirmation = board_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD);
+    let mut renamed_board_confirmation = board_confirmation.clone();
+    renamed_board_confirmation.board_name = "Different prompt text".to_string();
+    assert!(renamed_board_confirmation.matches_identity(
+        &board_confirmation.board_id,
+        board_confirmation.board_identity_generation
+    ));
+
+    let index = board_index(&boards, BOARD_ID_BLACKBOARD);
+    boards.board_states_mut()[index].pages = two_named_pages("one", "two");
+    let page_confirmation = page_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD, 0);
+    let mut renamed_page_confirmation = page_confirmation.clone();
+    renamed_page_confirmation.board_name = "Different prompt text".to_string();
+    assert!(renamed_page_confirmation.matches_identity(
+        &page_confirmation.board_id,
+        page_confirmation.board_identity_generation,
+        page_confirmation.page_index,
+        page_confirmation.page_count,
+        page_confirmation.page_generation
+    ));
+}
+
+#[test]
+fn page_delete_confirmation_validates_board_generation_page_count_and_page_generation() {
+    let mut boards = manager();
+    let index = board_index(&boards, BOARD_ID_BLACKBOARD);
+    boards.board_states_mut()[index].pages = two_named_pages("one", "two");
+    let confirmation = page_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD, 0);
+
+    boards.board_states_mut()[index].pages.new_page();
+
+    assert!(matches!(
+        boards.delete_page(PageDeleteRequest::Confirm(confirmation)),
+        PageDeleteOutcome::Rejected(PageOperationRejection::StaleConfirmation)
+    ));
+}
+
+#[test]
+fn board_identity_change_rejects_stale_page_delete_confirmation() {
+    let mut boards = manager();
+    let index = board_index(&boards, BOARD_ID_BLACKBOARD);
+    boards.board_states_mut()[index].pages = two_named_pages("one", "two");
+    let confirmation = page_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD, 0);
+
+    assert!(boards.create_board());
+
+    assert!(matches!(
+        boards.delete_page(PageDeleteRequest::Confirm(confirmation)),
+        PageDeleteOutcome::Rejected(PageOperationRejection::StaleConfirmation)
+    ));
+}
+
+#[test]
+fn page_rename_does_not_stale_page_delete_confirmation() {
+    let mut boards = manager();
+    let index = board_index(&boards, BOARD_ID_BLACKBOARD);
+    boards.board_states_mut()[index].pages = two_named_pages("one", "two");
+    let confirmation = page_delete_confirmation(&mut boards, BOARD_ID_BLACKBOARD, 0);
+
+    assert!(
+        boards.board_states_mut()[index]
+            .pages
+            .set_page_name(0, Some("renamed".to_string()))
+    );
+
+    assert!(matches!(
+        boards.delete_page(PageDeleteRequest::Confirm(confirmation)),
+        PageDeleteOutcome::Removed { .. }
+    ));
+}
+
+#[test]
+fn restore_rejections_return_original_requests() {
+    let mut boards = manager();
+    let request = BoardRestoreRequest {
+        board: boards.active_board().clone(),
+        preferred_index: Some(3),
+    };
+    boards.max_count = boards.board_count();
+    let BoardRestoreOutcome::Rejected(BoardRestoreRejection::MaxCountReached { request }) =
+        boards.restore_board(request)
+    else {
+        panic!("expected max-count rejection");
+    };
+    assert_eq!(request.board.spec.id, BOARD_ID_TRANSPARENT);
+    assert_eq!(request.preferred_index, Some(3));
+
+    let page_request = PageRestoreRequest {
+        board_id: "missing".to_string(),
+        page: Frame::new(),
+        placement: PageRestorePlacement::AtIndex(99),
+    };
+    let PageRestoreOutcome::Rejected(PageRestoreRejection::MissingBoard { request }) =
+        boards.restore_page(page_request)
+    else {
+        panic!("expected missing-board rejection");
+    };
+    assert_eq!(request.board_id, "missing");
+    assert_eq!(request.placement, PageRestorePlacement::AtIndex(99));
+}
+
+#[test]
+fn page_restore_at_index_clamps_to_append_and_returns_active_index() {
+    let mut boards = manager();
+    let PageRestoreOutcome::Restored {
+        page_index,
+        active_page_index,
+        page_count,
+        ..
+    } = boards.restore_page(PageRestoreRequest {
+        board_id: BOARD_ID_BLACKBOARD.to_string(),
+        page: Frame::new(),
+        placement: PageRestorePlacement::AtIndex(99),
+    })
+    else {
+        panic!("expected page restore");
+    };
+
+    assert_eq!(page_index, 1);
+    assert_eq!(active_page_index, 1);
+    assert_eq!(page_count, 2);
+}
+
+#[test]
+fn last_page_clear_returns_cleared_page() {
+    let mut boards = manager();
+    let index = board_index(&boards, BOARD_ID_BLACKBOARD);
+    boards.board_states_mut()[index]
+        .pages
+        .active_frame_mut()
+        .set_page_name(Some("saved".to_string()));
+
+    let PageDeleteOutcome::ClearedLastPage { cleared_page, .. } =
+        boards.delete_page(PageDeleteRequest::Request(PageDeleteTarget {
+            board: PageDeleteBoardTarget::BoardId(BOARD_ID_BLACKBOARD.to_string()),
+            page_index: 0,
+        }))
+    else {
+        panic!("expected last-page clear");
+    };
+
+    assert_eq!(cleared_page.page_name(), Some("saved"));
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -17,7 +17,7 @@ pub mod tool;
 #[allow(unused_imports)]
 pub use boards::{
     BOARD_ID_BLACKBOARD, BOARD_ID_TRANSPARENT, BOARD_ID_WHITEBOARD, BoardBackground, BoardManager,
-    BoardSpec,
+    BoardSpec, runtime_contrast_pen_color,
 };
 pub use events::{Key, MouseButton};
 pub use state::{

--- a/src/input/state/core/base/state/structs.rs
+++ b/src/input/state/core/base/state/structs.rs
@@ -24,7 +24,7 @@ use crate::config::{
 use crate::draw::frame::ShapeSnapshot;
 use crate::draw::{Color, DirtyTracker, EraserKind, FontDescriptor, Shape, ShapeId};
 use crate::input::BoardManager;
-use crate::input::boards::BoardState;
+use crate::input::boards::{BoardRestoreRequest, PageRestoreRequest};
 use crate::input::state::highlight::ClickHighlightState;
 use crate::input::{
     MouseButton,
@@ -210,7 +210,7 @@ pub struct InputState {
     /// Pending confirmation for deleting a page
     pub(in crate::input::state::core) pending_page_delete: Option<PendingPageDelete>,
     /// Recently deleted pages (for undo), with expiration timestamps
-    pub(in crate::input::state::core) deleted_pages: Vec<(String, crate::draw::Frame, Instant)>,
+    pub(in crate::input::state::core) deleted_pages: Vec<(PageRestoreRequest, Instant)>,
     /// Tracks dirty regions between renders
     pub(crate) dirty_tracker: DirtyTracker,
     /// Cached bounds for the current provisional shape (if any)
@@ -413,7 +413,7 @@ pub struct InputState {
     /// Pending clipboard fallback for failed copy operations
     pub(crate) pending_clipboard_fallback: Option<PendingClipboardFallback>,
     /// Recently deleted boards available for undo (with deletion timestamp)
-    pub(in crate::input::state::core) deleted_boards: Vec<(BoardState, Instant)>,
+    pub(in crate::input::state::core) deleted_boards: Vec<(BoardRestoreRequest, Instant)>,
     /// Status bar change highlight animation state
     #[allow(dead_code)]
     pub(crate) status_change_highlight: Option<StatusChangeHighlight>,

--- a/src/input/state/core/base/types.rs
+++ b/src/input/state/core/base/types.rs
@@ -384,15 +384,14 @@ pub(crate) struct ClipboardPasteRequest {
 /// Pending board deletion confirmation state.
 #[derive(Debug, Clone)]
 pub(crate) struct PendingBoardDelete {
-    pub board_id: String,
+    pub confirmation: crate::input::boards::BoardDeleteConfirmation,
     pub expires_at: Instant,
 }
 
 /// Pending page deletion confirmation state.
 #[derive(Debug, Clone)]
 pub(crate) struct PendingPageDelete {
-    pub board_id: String,
-    pub page_index: usize,
+    pub confirmation: crate::input::boards::PageDeleteConfirmation,
     pub expires_at: Instant,
 }
 

--- a/src/input/state/core/board.rs
+++ b/src/input/state/core/board.rs
@@ -3,25 +3,4 @@ mod lifecycle;
 mod pages;
 mod switch;
 
-use crate::draw::Color;
-
 const BOARD_RECENT_LIMIT: usize = 5;
-
-fn contrast_color(background: Color) -> Color {
-    let luminance = 0.2126 * background.r + 0.7152 * background.g + 0.0722 * background.b;
-    if luminance > 0.5 {
-        Color {
-            r: 0.0,
-            g: 0.0,
-            b: 0.0,
-            a: 1.0,
-        }
-    } else {
-        Color {
-            r: 1.0,
-            g: 1.0,
-            b: 1.0,
-            a: 1.0,
-        }
-    }
-}

--- a/src/input/state/core/board/delete_restore.rs
+++ b/src/input/state/core/board/delete_restore.rs
@@ -3,6 +3,14 @@ use super::super::base::{
     PAGE_UNDO_EXPIRE_MS, PendingBoardDelete, PendingPageDelete, UiToastKind,
 };
 use crate::config::Action;
+use crate::draw::PageDeleteOutcome as CanvasPageDeleteOutcome;
+use crate::input::boards::{
+    BoardDeleteOutcome, BoardDeleteRejection, BoardDeleteRequest, BoardDeleteTarget,
+    BoardIdentityGeneration, BoardRestoreOutcome, BoardRestoreRejection, BoardRestoreRequest,
+    PageDeleteBoardTarget, PageDeleteOutcome, PageDeleteRequest, PageDeleteTarget,
+    PageOperationRejection, PageRestoreOutcome, PageRestorePlacement, PageRestoreRejection,
+    PageRestoreRequest,
+};
 use std::time::{Duration, Instant};
 
 impl InputState {
@@ -34,23 +42,25 @@ impl InputState {
         }
     }
 
+    pub(crate) fn clear_pending_delete_confirmations(&mut self) {
+        self.pending_board_delete = None;
+        self.pending_page_delete = None;
+        if self.ui_toast.as_ref().is_some_and(|toast| {
+            toast.action.as_ref().is_some_and(|action| {
+                matches!(action.action, Action::BoardDelete | Action::PageDelete)
+            })
+        }) {
+            self.ui_toast = None;
+            self.ui_toast_bounds = None;
+            self.needs_redraw = true;
+        }
+    }
+
     pub fn delete_active_board(&mut self) {
         self.delete_active_board_at(Instant::now());
     }
 
     pub(crate) fn delete_active_board_at(&mut self, now: Instant) {
-        if self.board_is_transparent() {
-            self.set_ui_toast(UiToastKind::Info, "Overlay board cannot be deleted.");
-            self.pending_board_delete = None;
-            return;
-        }
-        if self.boards.board_count() <= 1 {
-            self.set_ui_toast(UiToastKind::Info, "At least one board must remain.");
-            self.pending_board_delete = None;
-            return;
-        }
-
-        let current_id = self.boards.active_board_id().to_string();
         if self
             .pending_board_delete
             .as_ref()
@@ -58,51 +68,112 @@ impl InputState {
         {
             self.pending_board_delete = None;
         }
-        let confirmed = self
+
+        let request = self
             .pending_board_delete
             .as_ref()
-            .is_some_and(|pending| pending.board_id == current_id && now <= pending.expires_at);
-        if !confirmed {
-            let name = self.boards.active_board_name();
-            self.pending_board_delete = Some(PendingBoardDelete {
-                board_id: current_id,
-                expires_at: now + Duration::from_millis(BOARD_DELETE_CONFIRM_MS),
-            });
-            self.set_ui_toast_with_action_and_duration(
-                UiToastKind::Warning,
-                format!("Delete board '{name}'? Click to confirm."),
-                "Delete",
-                Action::BoardDelete,
-                BOARD_DELETE_CONFIRM_MS,
-            );
-            return;
+            .map(|pending| BoardDeleteRequest::Confirm(pending.confirmation.clone()))
+            .unwrap_or(BoardDeleteRequest::Request(BoardDeleteTarget::Active));
+
+        let active_id_before = self.boards.active_board_id().to_string();
+        let current_spec = self.boards.active_board().spec.clone();
+        let generation_before = self.boards.board_identity_generation();
+        let deleted_index = match &request {
+            BoardDeleteRequest::Confirm(confirmation) => self
+                .boards
+                .board_states()
+                .iter()
+                .position(|board| board.spec.id == confirmation.board_id),
+            BoardDeleteRequest::Request(BoardDeleteTarget::Active) => {
+                Some(self.boards.active_index())
+            }
+            BoardDeleteRequest::Request(BoardDeleteTarget::BoardIndex(index)) => Some(*index),
+            BoardDeleteRequest::Request(BoardDeleteTarget::BoardId(id)) => self
+                .boards
+                .board_states()
+                .iter()
+                .position(|board| board.spec.id == *id),
+        };
+        let deleting_active = match &request {
+            BoardDeleteRequest::Confirm(confirmation) => confirmation.board_id == active_id_before,
+            _ => true,
+        };
+        if deleting_active && matches!(request, BoardDeleteRequest::Confirm(_)) {
+            self.cancel_active_interaction();
         }
-        self.pending_board_delete = None;
 
-        self.cancel_active_interaction();
+        match self.boards.delete_board(request) {
+            BoardDeleteOutcome::RequiresConfirmation { confirmation } => {
+                let name = confirmation.board_name.clone();
+                self.pending_board_delete = Some(PendingBoardDelete {
+                    confirmation,
+                    expires_at: now + Duration::from_millis(BOARD_DELETE_CONFIRM_MS),
+                });
+                self.set_ui_toast_with_action_and_duration(
+                    UiToastKind::Warning,
+                    format!("Delete board '{name}'? Click to confirm."),
+                    "Delete",
+                    Action::BoardDelete,
+                    BOARD_DELETE_CONFIRM_MS,
+                );
+            }
+            BoardDeleteOutcome::Deleted {
+                deleted_board,
+                deleted_id,
+                deleted_name,
+                ..
+            } => {
+                self.pending_board_delete = None;
+                self.clear_pending_deletes_after_board_generation_change(generation_before);
+                self.remove_board_recent(&deleted_id);
+                self.queue_board_config_save();
+                self.deleted_boards.push((
+                    BoardRestoreRequest {
+                        board: deleted_board,
+                        preferred_index: deleted_index,
+                    },
+                    now,
+                ));
+                self.set_ui_toast_with_action(
+                    UiToastKind::Info,
+                    format!("Board deleted: {deleted_name}"),
+                    "Undo",
+                    Action::BoardRestoreDeleted,
+                );
 
-        // Save board state after cancellation for potential undo.
-        let deleted_board = self.boards.active_board().clone();
-        let deleted_name = deleted_board.spec.name.clone();
+                if self.boards.active_board_id() != active_id_before {
+                    self.finish_board_transition_from(current_spec, &active_id_before, false);
+                } else {
+                    self.mark_board_surface_changed();
+                }
+            }
+            BoardDeleteOutcome::Rejected(rejection) => {
+                self.pending_board_delete = None;
+                self.set_board_delete_rejection_toast(rejection);
+            }
+        }
+    }
 
-        if self.switch_board_with(
-            |boards| boards.board_count() > 1,
-            |boards| boards.remove_active_board(),
-            &current_id,
-        ) {
-            self.remove_board_recent(&current_id);
-            self.queue_board_config_save();
+    fn set_board_delete_rejection_toast(&mut self, rejection: BoardDeleteRejection) {
+        match rejection {
+            BoardDeleteRejection::MissingBoard | BoardDeleteRejection::StaleConfirmation => {
+                self.set_ui_toast(UiToastKind::Warning, "Board deletion changed; try again.");
+            }
+            BoardDeleteRejection::TransparentBoard => {
+                self.set_ui_toast(UiToastKind::Info, "Overlay board cannot be deleted.");
+            }
+            BoardDeleteRejection::LastBoard => {
+                self.set_ui_toast(UiToastKind::Info, "At least one board must remain.");
+            }
+        }
+    }
 
-            // Store for undo
-            self.deleted_boards.push((deleted_board, now));
-
-            // Show toast with undo action
-            self.set_ui_toast_with_action(
-                UiToastKind::Info,
-                format!("Board deleted: {deleted_name}"),
-                "Undo",
-                Action::BoardRestoreDeleted,
-            );
+    pub(crate) fn clear_pending_deletes_after_board_generation_change(
+        &mut self,
+        before: BoardIdentityGeneration,
+    ) {
+        if self.boards.board_identity_generation() != before {
+            self.clear_pending_delete_confirmations();
         }
     }
 
@@ -115,31 +186,36 @@ impl InputState {
         // Expire old entries first
         self.expire_deleted_boards_at(now);
 
-        let Some((board, timestamp)) = self.deleted_boards.pop() else {
+        let Some((request, timestamp)) = self.deleted_boards.pop() else {
             self.set_ui_toast(UiToastKind::Info, "No deleted board to restore.");
             return;
         };
 
-        let name = board.spec.name.clone();
         let current_id = self.boards.active_board_id().to_string();
+        let current_spec = self.boards.active_board().spec.clone();
+        let generation_before = self.boards.board_identity_generation();
 
-        if self.switch_board_with(
-            |boards| boards.board_count() < boards.max_count(),
-            |boards| boards.insert_board(boards.board_count(), board.clone()),
-            &current_id,
-        ) {
-            self.queue_board_config_save();
-            self.set_ui_toast(UiToastKind::Info, format!("Board restored: {name}"));
-        } else {
-            self.deleted_boards.push((board, timestamp));
-            self.set_ui_toast(UiToastKind::Warning, "Board limit reached; cannot restore.");
+        match self.boards.restore_board(request) {
+            BoardRestoreOutcome::Restored { restored_name, .. } => {
+                self.clear_pending_deletes_after_board_generation_change(generation_before);
+                self.queue_board_config_save();
+                self.finish_board_transition_from(current_spec, &current_id, false);
+                self.set_ui_toast(
+                    UiToastKind::Info,
+                    format!("Board restored: {restored_name}"),
+                );
+            }
+            BoardRestoreOutcome::Rejected(BoardRestoreRejection::MaxCountReached { request }) => {
+                self.deleted_boards.push((request, timestamp));
+                self.set_ui_toast(UiToastKind::Warning, "Board limit reached; cannot restore.");
+            }
         }
     }
 
     /// Remove deleted boards that have expired (older than BOARD_UNDO_EXPIRE_MS).
     fn expire_deleted_boards_at(&mut self, now: Instant) {
         let expire_duration = std::time::Duration::from_millis(BOARD_UNDO_EXPIRE_MS);
-        self.deleted_boards.retain(|(_board, timestamp)| {
+        self.deleted_boards.retain(|(_request, timestamp)| {
             now.saturating_duration_since(*timestamp) < expire_duration
         });
     }
@@ -148,7 +224,7 @@ impl InputState {
         &mut self,
         board_index: usize,
         page_index: usize,
-    ) -> crate::draw::PageDeleteOutcome {
+    ) -> CanvasPageDeleteOutcome {
         self.delete_page_in_board_at(board_index, page_index, Instant::now())
     }
 
@@ -157,37 +233,106 @@ impl InputState {
         board_index: usize,
         page_index: usize,
         now: Instant,
-    ) -> crate::draw::PageDeleteOutcome {
+    ) -> CanvasPageDeleteOutcome {
         let is_active_board = self.boards.active_index() == board_index;
-        let Some(board) = self.boards.board_state_mut(board_index) else {
-            return crate::draw::PageDeleteOutcome::Pending;
+        let Some(board) = self.boards.board_states().get(board_index) else {
+            return CanvasPageDeleteOutcome::Pending;
         };
         let page_count = board.pages.page_count();
         if page_index >= page_count {
-            return crate::draw::PageDeleteOutcome::Pending;
+            return CanvasPageDeleteOutcome::Pending;
         }
         let board_name = board.spec.name.clone();
         let board_id = board.spec.id.clone();
 
-        if page_count <= 1 {
-            if is_active_board {
-                self.prepare_active_page_content_change();
-            }
-            let Some(board) = self.boards.board_state_mut(board_index) else {
-                return crate::draw::PageDeleteOutcome::Pending;
-            };
-            let outcome = board.pages.delete_page_at(page_index);
-            if is_active_board {
-                self.finish_active_page_content_change();
-            } else {
-                self.mark_board_surface_changed();
-            }
-            self.set_ui_toast(
-                UiToastKind::Info,
-                format!("Page cleared on '{board_name}' ({board_id})"),
-            );
-            return outcome;
+        if self
+            .pending_page_delete
+            .as_ref()
+            .is_some_and(|pending| now > pending.expires_at)
+        {
+            self.pending_page_delete = None;
         }
+
+        let request = self
+            .pending_page_delete
+            .as_ref()
+            .filter(|pending| {
+                pending.confirmation.board_id == board_id
+                    && pending.confirmation.page_index == page_index
+            })
+            .map(|pending| PageDeleteRequest::Confirm(pending.confirmation.clone()))
+            .unwrap_or_else(|| {
+                PageDeleteRequest::Request(PageDeleteTarget {
+                    board: PageDeleteBoardTarget::BoardIndex(board_index),
+                    page_index,
+                })
+            });
+        let confirmation_is_current = matches!(&request, PageDeleteRequest::Confirm(confirmation) if self.page_delete_confirmation_is_current(confirmation));
+        let should_prepare_active = is_active_board
+            && ((matches!(&request, PageDeleteRequest::Request(_)) && page_count <= 1)
+                || confirmation_is_current);
+        if should_prepare_active {
+            self.prepare_active_page_content_change();
+        }
+
+        match self.boards.delete_page(request) {
+            PageDeleteOutcome::RequiresConfirmation { confirmation } => {
+                self.pending_page_delete = Some(PendingPageDelete {
+                    confirmation,
+                    expires_at: now + Duration::from_millis(PAGE_DELETE_CONFIRM_MS),
+                });
+                self.set_ui_toast_with_duration(
+                    UiToastKind::Warning,
+                    format!(
+                        "Delete page {}/{} on '{board_name}' ({board_id})? Click delete again to confirm.",
+                        page_index + 1,
+                        page_count
+                    ),
+                    PAGE_DELETE_CONFIRM_MS,
+                );
+                CanvasPageDeleteOutcome::Pending
+            }
+            PageDeleteOutcome::ClearedLastPage { .. } => {
+                self.pending_page_delete = None;
+                self.finish_page_delete_surface_change(is_active_board);
+                self.set_ui_toast(
+                    UiToastKind::Info,
+                    format!("Page cleared on '{board_name}' ({board_id})"),
+                );
+                CanvasPageDeleteOutcome::Cleared
+            }
+            PageDeleteOutcome::Removed {
+                new_page_index,
+                new_page_count,
+                ..
+            } => {
+                self.pending_page_delete = None;
+                self.finish_page_delete_surface_change(is_active_board);
+                self.set_ui_toast(
+                    UiToastKind::Info,
+                    format!(
+                        "Page deleted on '{board_name}' ({board_id}) ({}/{})",
+                        new_page_index + 1,
+                        new_page_count
+                    ),
+                );
+                CanvasPageDeleteOutcome::Removed
+            }
+            PageDeleteOutcome::Rejected(rejection) => {
+                self.pending_page_delete = None;
+                self.set_page_delete_rejection_toast(rejection);
+                CanvasPageDeleteOutcome::Pending
+            }
+        }
+    }
+
+    pub fn page_delete(&mut self) -> CanvasPageDeleteOutcome {
+        self.delete_active_page_at(Instant::now())
+    }
+
+    pub(crate) fn delete_active_page_at(&mut self, now: Instant) -> CanvasPageDeleteOutcome {
+        let page_count = self.boards.page_count();
+        let page_index = self.boards.active_page_index();
 
         if self
             .pending_page_delete
@@ -196,137 +341,123 @@ impl InputState {
         {
             self.pending_page_delete = None;
         }
-        let confirmed = self.pending_page_delete.as_ref().is_some_and(|pending| {
-            pending.board_id == board_id
-                && pending.page_index == page_index
-                && now <= pending.expires_at
-        });
-        if !confirmed {
-            self.pending_page_delete = Some(PendingPageDelete {
-                board_id: board_id.clone(),
-                page_index,
-                expires_at: now + Duration::from_millis(PAGE_DELETE_CONFIRM_MS),
-            });
-            self.set_ui_toast_with_duration(
-                UiToastKind::Warning,
-                format!(
-                    "Delete page {}/{} on '{board_name}' ({board_id})? Click delete again to confirm.",
-                    page_index + 1,
-                    page_count
-                ),
-                PAGE_DELETE_CONFIRM_MS,
-            );
-            return crate::draw::PageDeleteOutcome::Pending;
-        }
 
-        self.pending_page_delete = None;
-        if is_active_board {
+        let request = self
+            .pending_page_delete
+            .as_ref()
+            .map(|pending| PageDeleteRequest::Confirm(pending.confirmation.clone()))
+            .unwrap_or_else(|| {
+                PageDeleteRequest::Request(PageDeleteTarget {
+                    board: PageDeleteBoardTarget::ActiveBoard,
+                    page_index,
+                })
+            });
+        let active_target = match &request {
+            PageDeleteRequest::Confirm(confirmation) => {
+                confirmation.board_id == self.boards.active_board_id()
+            }
+            PageDeleteRequest::Request(_) => true,
+        };
+        let confirmation_is_current = matches!(&request, PageDeleteRequest::Confirm(confirmation) if self.page_delete_confirmation_is_current(confirmation));
+        let should_prepare_active = active_target
+            && ((matches!(&request, PageDeleteRequest::Request(_)) && page_count <= 1)
+                || confirmation_is_current);
+        if should_prepare_active {
             self.prepare_active_page_content_change();
         }
-        let Some(board) = self.boards.board_state_mut(board_index) else {
-            return crate::draw::PageDeleteOutcome::Pending;
-        };
-        let outcome = board.pages.delete_page_at(page_index);
-        let new_page_num = board.pages.active_index() + 1;
-        let new_page_count = board.pages.page_count();
-        if is_active_board {
+
+        match self.boards.delete_page(request) {
+            PageDeleteOutcome::RequiresConfirmation { confirmation } => {
+                self.pending_page_delete = Some(PendingPageDelete {
+                    confirmation,
+                    expires_at: now + Duration::from_millis(PAGE_DELETE_CONFIRM_MS),
+                });
+                self.set_ui_toast_with_action_and_duration(
+                    UiToastKind::Warning,
+                    format!(
+                        "Delete page {}/{}? Click to confirm.",
+                        page_index + 1,
+                        page_count
+                    ),
+                    "Delete",
+                    Action::PageDelete,
+                    PAGE_DELETE_CONFIRM_MS,
+                );
+                CanvasPageDeleteOutcome::Pending
+            }
+            PageDeleteOutcome::ClearedLastPage { .. } => {
+                self.pending_page_delete = None;
+                self.finish_page_delete_surface_change(active_target);
+                self.set_ui_toast(UiToastKind::Info, "Page cleared (last page)");
+                CanvasPageDeleteOutcome::Cleared
+            }
+            PageDeleteOutcome::Removed {
+                board_id,
+                deleted_page,
+                new_page_index,
+                new_page_count,
+                ..
+            } => {
+                self.pending_page_delete = None;
+                self.finish_page_delete_surface_change(active_target);
+                self.deleted_pages.push((
+                    PageRestoreRequest {
+                        board_id,
+                        page: deleted_page,
+                        placement: PageRestorePlacement::AfterActivePage,
+                    },
+                    now,
+                ));
+                self.set_ui_toast_with_action(
+                    UiToastKind::Info,
+                    format!("Page deleted ({}/{new_page_count})", new_page_index + 1),
+                    "Undo",
+                    Action::PageRestoreDeleted,
+                );
+                CanvasPageDeleteOutcome::Removed
+            }
+            PageDeleteOutcome::Rejected(rejection) => {
+                self.pending_page_delete = None;
+                self.set_page_delete_rejection_toast(rejection);
+                CanvasPageDeleteOutcome::Pending
+            }
+        }
+    }
+
+    fn finish_page_delete_surface_change(&mut self, active_target: bool) {
+        if active_target {
             self.finish_active_page_content_change();
         } else {
             self.mark_board_surface_changed();
         }
-        if matches!(outcome, crate::draw::PageDeleteOutcome::Removed) {
-            self.set_ui_toast(
-                UiToastKind::Info,
-                format!(
-                    "Page deleted on '{board_name}' ({board_id}) ({new_page_num}/{new_page_count})"
-                ),
-            );
-        }
-        outcome
     }
 
-    pub fn page_delete(&mut self) -> crate::draw::PageDeleteOutcome {
-        self.delete_active_page_at(Instant::now())
+    fn page_delete_confirmation_is_current(
+        &self,
+        confirmation: &crate::input::boards::PageDeleteConfirmation,
+    ) -> bool {
+        if confirmation.board_identity_generation != self.boards.board_identity_generation() {
+            return false;
+        }
+        self.boards
+            .board_states()
+            .iter()
+            .find(|board| board.spec.id == confirmation.board_id)
+            .is_some_and(|board| {
+                confirmation.matches_identity(
+                    &board.spec.id,
+                    self.boards.board_identity_generation(),
+                    confirmation.page_index,
+                    board.pages.page_count(),
+                    board.pages.generation(),
+                ) && confirmation.page_index < board.pages.page_count()
+            })
     }
 
-    pub(crate) fn delete_active_page_at(&mut self, now: Instant) -> crate::draw::PageDeleteOutcome {
-        let page_count = self.boards.page_count();
-        let page_index = self.boards.active_page_index();
-        let board_id = self.boards.active_board_id().to_string();
-
-        // If this is the last page, skip confirmation (just clears)
-        if page_count <= 1 {
-            self.prepare_active_page_content_change();
-            let outcome = self.boards.delete_page();
-            self.finish_active_page_content_change();
-            self.set_ui_toast(UiToastKind::Info, "Page cleared (last page)");
-            return outcome;
+    fn set_page_delete_rejection_toast(&mut self, rejection: PageOperationRejection) {
+        if matches!(rejection, PageOperationRejection::StaleConfirmation) {
+            self.set_ui_toast(UiToastKind::Warning, "Page deletion changed; try again.");
         }
-
-        // Expire old pending confirmation
-        if self
-            .pending_page_delete
-            .as_ref()
-            .is_some_and(|pending| now > pending.expires_at)
-        {
-            self.pending_page_delete = None;
-        }
-
-        // Check if we have a valid pending confirmation
-        let confirmed = self.pending_page_delete.as_ref().is_some_and(|pending| {
-            pending.board_id == board_id
-                && pending.page_index == page_index
-                && now <= pending.expires_at
-        });
-
-        if !confirmed {
-            // First press: request confirmation
-            self.pending_page_delete = Some(PendingPageDelete {
-                board_id,
-                page_index,
-                expires_at: now + Duration::from_millis(PAGE_DELETE_CONFIRM_MS),
-            });
-            self.set_ui_toast_with_action_and_duration(
-                UiToastKind::Warning,
-                format!(
-                    "Delete page {}/{}? Click to confirm.",
-                    page_index + 1,
-                    page_count
-                ),
-                "Delete",
-                Action::PageDelete,
-                PAGE_DELETE_CONFIRM_MS,
-            );
-            return crate::draw::PageDeleteOutcome::Pending;
-        }
-
-        // Confirmed: proceed with deletion
-        self.pending_page_delete = None;
-
-        self.prepare_active_page_content_change();
-
-        // Save page after cancellation for undo.
-        let deleted_page = self.boards.active_pages().active_frame().clone();
-
-        let outcome = self.boards.delete_page();
-        self.finish_active_page_content_change();
-        let new_page_num = self.boards.active_page_index() + 1;
-        let new_page_count = self.boards.page_count();
-
-        if matches!(outcome, crate::draw::PageDeleteOutcome::Removed) {
-            // Store for undo
-            let board_id = self.boards.active_board_id().to_string();
-            self.deleted_pages.push((board_id, deleted_page, now));
-
-            // Show toast with undo action
-            self.set_ui_toast_with_action(
-                UiToastKind::Info,
-                format!("Page deleted ({new_page_num}/{new_page_count})"),
-                "Undo",
-                Action::PageRestoreDeleted,
-            );
-        }
-        outcome
     }
 
     /// Restore the most recently deleted page.
@@ -337,28 +468,35 @@ impl InputState {
     pub(crate) fn restore_deleted_page_at(&mut self, now: Instant) {
         // Expire old entries
         let expire_duration = Duration::from_millis(PAGE_UNDO_EXPIRE_MS);
-        self.deleted_pages.retain(|(_, _, deleted_at)| {
-            now.saturating_duration_since(*deleted_at) < expire_duration
-        });
+        self.deleted_pages
+            .retain(|(_, deleted_at)| now.saturating_duration_since(*deleted_at) < expire_duration);
 
-        // Get the most recent deleted page for the current board
-        let board_id = self.boards.active_board_id().to_string();
-        let position = self
-            .deleted_pages
-            .iter()
-            .rposition(|(id, _, _)| id == &board_id);
-
-        if let Some(idx) = position {
-            let (_, page, _) = self.deleted_pages.remove(idx);
-            self.prepare_active_page_content_change();
-            self.boards.insert_page(page);
-            self.finish_active_page_content_change();
-            let page_num = self.boards.active_page_index() + 1;
-            let page_count = self.boards.page_count();
-            self.set_ui_toast(
-                UiToastKind::Info,
-                format!("Page restored ({page_num}/{page_count})"),
-            );
+        if let Some((request, deleted_at)) = self.deleted_pages.pop() {
+            let active_target = request.board_id == self.boards.active_board_id();
+            if active_target {
+                self.prepare_active_page_content_change();
+            }
+            match self.boards.restore_page(request) {
+                PageRestoreOutcome::Restored {
+                    page_index,
+                    page_count,
+                    ..
+                } => {
+                    if active_target {
+                        self.finish_active_page_content_change();
+                    } else {
+                        self.mark_board_surface_changed();
+                    }
+                    self.set_ui_toast(
+                        UiToastKind::Info,
+                        format!("Page restored ({}/{page_count})", page_index + 1),
+                    );
+                }
+                PageRestoreOutcome::Rejected(PageRestoreRejection::MissingBoard { request }) => {
+                    self.deleted_pages.push((request, deleted_at));
+                    self.set_ui_toast(UiToastKind::Warning, "Board missing; cannot restore page.");
+                }
+            }
         } else {
             self.set_ui_toast(UiToastKind::Info, "No deleted page to restore.");
         }
@@ -466,7 +604,7 @@ mod tests {
             crate::draw::PageDeleteOutcome::Removed
         );
 
-        let (_, _, deleted_at) = state.deleted_pages.last().expect("deleted page undo");
+        let (_, deleted_at) = state.deleted_pages.last().expect("deleted page undo");
         assert_eq!(*deleted_at, confirmed_at);
     }
 

--- a/src/input/state/core/board/pages.rs
+++ b/src/input/state/core/board/pages.rs
@@ -1,6 +1,6 @@
 use super::super::base::{InputState, UiToastKind};
 use crate::draw::Color;
-use crate::input::BoardBackground;
+use crate::input::{BoardBackground, runtime_contrast_pen_color};
 
 impl InputState {
     pub(crate) fn reset_active_canvas_position(&mut self) -> bool {
@@ -49,7 +49,7 @@ impl InputState {
 
         board.spec.background = BoardBackground::Solid(color);
         let active_pen_color = if board.spec.auto_adjust_pen {
-            board.spec.default_pen_color = Some(super::contrast_color(color));
+            board.spec.default_pen_color = Some(runtime_contrast_pen_color(color));
             is_active.then(|| board.spec.effective_pen_color().unwrap_or(color))
         } else {
             None

--- a/src/input/state/core/board/switch.rs
+++ b/src/input/state/core/board/switch.rs
@@ -1,5 +1,5 @@
 use super::super::base::{InputState, UiToastKind};
-use crate::input::BOARD_ID_TRANSPARENT;
+use crate::input::{BOARD_ID_TRANSPARENT, BoardSpec};
 
 impl InputState {
     /// Returns the active board id.
@@ -110,7 +110,9 @@ impl InputState {
         }
 
         self.cancel_active_interaction();
+        let generation_before = self.boards.board_identity_generation();
         if let Some(new_id) = self.boards.duplicate_active_board() {
+            self.clear_pending_deletes_after_board_generation_change(generation_before);
             self.record_board_recent(&new_id);
             self.queue_board_config_save();
             let name = self.boards.active_board_name();
@@ -161,6 +163,7 @@ impl InputState {
 
         let current_spec = self.boards.active_board().spec.clone();
         let prev_count = self.boards.board_count();
+        let generation_before = self.boards.board_identity_generation();
         self.cancel_active_interaction();
         let switched = switch(&mut self.boards);
         debug_assert!(switched, "preflighted board transition failed on apply");
@@ -173,10 +176,21 @@ impl InputState {
         if target_spec.id == current_id {
             return false;
         }
-        self.pending_board_delete = None;
         if self.boards.board_count() > prev_count {
             self.queue_board_config_save();
         }
+        self.clear_pending_deletes_after_board_generation_change(generation_before);
+        self.finish_board_transition_from(current_spec, current_id, true);
+        true
+    }
+
+    pub(super) fn finish_board_transition_from(
+        &mut self,
+        current_spec: BoardSpec,
+        current_id: &str,
+        log_switch: bool,
+    ) {
+        let target_spec = self.boards.active_board().spec.clone();
         self.record_board_recent(&target_spec.id);
 
         let current_auto =
@@ -217,12 +231,13 @@ impl InputState {
 
         self.finish_active_board_transition();
 
-        log::info!(
-            "Switched from '{}' to '{}' board",
-            current_id,
-            target_spec.id
-        );
-        true
+        if log_switch {
+            log::info!(
+                "Switched from '{}' to '{}' board",
+                current_id,
+                target_spec.id
+            );
+        }
     }
 
     fn record_board_recent(&mut self, board_id: &str) {

--- a/src/input/state/core/board_picker/mod.rs
+++ b/src/input/state/core/board_picker/mod.rs
@@ -7,6 +7,7 @@ mod state;
 use std::time::Duration;
 
 use crate::draw::{BLACK, BLUE, Color, GREEN, ORANGE, PINK, RED, WHITE, YELLOW};
+use crate::input::runtime_contrast_pen_color;
 
 const TITLE_FONT_SIZE: f64 = 17.0;
 const BODY_FONT_SIZE: f64 = 14.0;
@@ -220,22 +221,7 @@ fn color_to_hex(color: Color) -> String {
 }
 
 fn contrast_color(background: Color) -> Color {
-    let luminance = 0.2126 * background.r + 0.7152 * background.g + 0.0722 * background.b;
-    if luminance > 0.5 {
-        Color {
-            r: 0.0,
-            g: 0.0,
-            b: 0.0,
-            a: 1.0,
-        }
-    } else {
-        Color {
-            r: 1.0,
-            g: 1.0,
-            b: 1.0,
-            a: 1.0,
-        }
-    }
+    runtime_contrast_pen_color(background)
 }
 
 const BOARD_PALETTE: [Color; 11] = [

--- a/src/input/state/core/utility/toasts.rs
+++ b/src/input/state/core/utility/toasts.rs
@@ -18,6 +18,7 @@ impl InputState {
         message: impl Into<String>,
         duration_ms: u64,
     ) {
+        self.ui_toast_bounds = None;
         self.ui_toast = Some(UiToastState {
             kind,
             message: message.into(),
@@ -36,6 +37,7 @@ impl InputState {
         action_label: impl Into<String>,
         action: Action,
     ) {
+        self.ui_toast_bounds = None;
         self.ui_toast = Some(UiToastState {
             kind,
             message: message.into(),
@@ -57,6 +59,7 @@ impl InputState {
         action: Action,
         duration_ms: u64,
     ) {
+        self.ui_toast_bounds = None;
         self.ui_toast = Some(UiToastState {
             kind,
             message: message.into(),
@@ -118,18 +121,11 @@ impl InputState {
     /// whether it was hit plus any associated action.
     #[allow(dead_code)] // Called from WaylandState pointer release handler
     pub(crate) fn check_toast_click(&mut self, x: i32, y: i32) -> (bool, Option<Action>) {
-        let Some(bounds) = self.ui_toast_bounds else {
-            return (false, None);
-        };
         let Some(toast) = self.ui_toast.as_ref() else {
             return (false, None);
         };
 
-        // Check if click is within toast bounds
-        let (bx, by, bw, bh) = bounds;
-        let xf = x as f64;
-        let yf = y as f64;
-        if xf >= bx && xf <= bx + bw && yf >= by && yf <= by + bh {
+        if self.toast_contains(x, y) {
             // Click is within toast
             let action = toast.action.as_ref().map(|action| action.action);
             // Dismiss the toast
@@ -139,6 +135,15 @@ impl InputState {
             return (true, action);
         }
         (false, None)
+    }
+
+    pub(crate) fn toast_contains(&self, x: i32, y: i32) -> bool {
+        self.ui_toast.is_some()
+            && self.ui_toast_bounds.is_some_and(|(bx, by, bw, bh)| {
+                let xf = x as f64;
+                let yf = y as f64;
+                xf >= bx && xf <= bx + bw && yf >= by && yf <= by + bh
+            })
     }
 
     /// Trigger the blocked action visual feedback (red flash on screen edges).
@@ -331,6 +336,36 @@ mod tests {
         assert_eq!(action, Some(Action::OpenCaptureFolder));
         assert!(state.ui_toast.is_none());
         assert!(state.ui_toast_bounds.is_none());
+    }
+
+    #[test]
+    fn toast_contains_reports_hit_without_dismissing() {
+        let mut state = make_state();
+        state.set_ui_toast(UiToastKind::Info, "Saved");
+        state.ui_toast_bounds = Some((10.0, 20.0, 100.0, 40.0));
+
+        assert!(state.toast_contains(50, 40));
+        assert!(state.ui_toast.is_some());
+        assert!(state.ui_toast_bounds.is_some());
+    }
+
+    #[test]
+    fn replacing_toast_clears_stale_click_bounds() {
+        let mut state = make_state();
+        state.set_ui_toast(UiToastKind::Info, "Saved");
+        state.ui_toast_bounds = Some((10.0, 20.0, 100.0, 40.0));
+
+        state.set_ui_toast_with_action(
+            UiToastKind::Warning,
+            "Delete page?",
+            "Confirm",
+            Action::PageDelete,
+        );
+
+        assert!(state.ui_toast.is_some());
+        assert!(state.ui_toast_bounds.is_none());
+        assert!(!state.toast_contains(50, 40));
+        assert_eq!(state.check_toast_click(50, 40), (false, None));
     }
 
     #[test]

--- a/src/input/state/tests/delete_restore.rs
+++ b/src/input/state/tests/delete_restore.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::draw::{Frame, PageDeleteOutcome, ShapeId};
 use crate::input::{BOARD_ID_BLACKBOARD, BOARD_ID_TRANSPARENT};
+use std::time::{Duration, Instant};
 
 fn board_index(state: &InputState, id: &str) -> usize {
     state
@@ -235,4 +236,183 @@ fn page_delete_on_last_page_clears_shapes_without_removing_page() {
         state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
         Some("Page cleared (last page)")
     );
+}
+
+#[test]
+fn pending_board_delete_survives_active_drift_and_deletes_original_board() {
+    let mut state = create_test_input_state();
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    let requested_at = Instant::now();
+
+    state.delete_active_board_at(requested_at);
+    state.switch_board("whiteboard");
+    state.delete_active_board_at(requested_at + Duration::from_millis(1));
+
+    assert_eq!(state.board_id(), "whiteboard");
+    assert!(!state.boards.has_board(BOARD_ID_BLACKBOARD));
+    assert!(!state.has_pending_board_delete());
+}
+
+#[test]
+fn board_rename_does_not_stale_pending_board_delete() {
+    let mut state = create_test_input_state();
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    let requested_at = Instant::now();
+
+    state.delete_active_board_at(requested_at);
+    let index = board_index(&state, BOARD_ID_BLACKBOARD);
+    assert!(state.set_board_name(index, "Renamed Board".to_string()));
+    state.delete_active_board_at(requested_at + Duration::from_millis(1));
+
+    assert!(!state.boards.has_board(BOARD_ID_BLACKBOARD));
+    assert_eq!(
+        state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
+        Some("Board deleted: Renamed Board")
+    );
+}
+
+#[test]
+fn page_content_edit_does_not_stale_pending_page_delete() {
+    let mut state = create_test_input_state();
+    let board = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    set_page_count(&mut state, board, 2);
+    let requested_at = Instant::now();
+
+    assert_eq!(state.page_delete(), PageDeleteOutcome::Pending);
+    state.boards.active_frame_mut().add_shape(Shape::Rect {
+        x: 0,
+        y: 0,
+        w: 10,
+        h: 10,
+        fill: false,
+        color: state.current_color,
+        thick: state.current_thickness,
+    });
+    assert_eq!(
+        state.delete_active_page_at(requested_at + Duration::from_millis(1)),
+        PageDeleteOutcome::Removed
+    );
+
+    assert_eq!(state.boards.page_count(), 1);
+}
+
+#[test]
+fn pending_page_delete_survives_active_board_drift_and_deletes_original_page() {
+    let mut state = create_test_input_state();
+    let blackboard = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    set_page_count(&mut state, blackboard, 2);
+    let requested_at = Instant::now();
+
+    assert_eq!(
+        state.delete_active_page_at(requested_at),
+        PageDeleteOutcome::Pending
+    );
+    state.switch_board(BOARD_ID_TRANSPARENT);
+    assert_eq!(
+        state.delete_active_page_at(requested_at + Duration::from_millis(1)),
+        PageDeleteOutcome::Removed
+    );
+
+    assert_eq!(state.board_id(), BOARD_ID_TRANSPARENT);
+    assert_eq!(
+        state.boards.board_states()[blackboard].pages.page_count(),
+        1
+    );
+    assert!(!state.has_pending_page_delete());
+
+    state.state = DrawingState::Drawing {
+        tool: Tool::Pen,
+        start_x: 10,
+        start_y: 20,
+        points: vec![(10, 20), (30, 40)],
+        point_thicknesses: vec![1.0, 1.0],
+    };
+    state.begin_pointer_drag(MouseButton::Left, None);
+    state.restore_deleted_page();
+
+    assert_eq!(state.board_id(), BOARD_ID_TRANSPARENT);
+    assert_eq!(
+        state.boards.board_states()[blackboard].pages.page_count(),
+        2
+    );
+    assert_eq!(
+        state.ui_toast.as_ref().map(|toast| toast.message.as_str()),
+        Some("Page restored (2/2)")
+    );
+    assert!(matches!(state.state, DrawingState::Drawing { .. }));
+    assert_eq!(state.active_drag_button, Some(MouseButton::Left));
+}
+
+#[test]
+fn stale_active_page_delete_confirmation_does_not_cancel_active_interaction() {
+    let mut state = create_test_input_state();
+    let board = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    set_page_count(&mut state, board, 2);
+    let requested_at = Instant::now();
+
+    assert_eq!(
+        state.delete_active_page_at(requested_at),
+        PageDeleteOutcome::Pending
+    );
+    assert_eq!(
+        state.boards.active_pages_mut().delete_page_at(1),
+        PageDeleteOutcome::Removed
+    );
+    state.state = DrawingState::Drawing {
+        tool: Tool::Pen,
+        start_x: 10,
+        start_y: 20,
+        points: vec![(10, 20), (30, 40)],
+        point_thicknesses: vec![1.0, 1.0],
+    };
+    state.begin_pointer_drag(MouseButton::Left, None);
+
+    assert_eq!(
+        state.delete_active_page_at(requested_at + Duration::from_millis(1)),
+        PageDeleteOutcome::Pending
+    );
+
+    assert!(matches!(state.state, DrawingState::Drawing { .. }));
+    assert_eq!(state.active_drag_button, Some(MouseButton::Left));
+    assert!(!state.has_pending_page_delete());
+}
+
+#[test]
+fn stale_board_panel_page_delete_confirmation_does_not_cancel_active_interaction() {
+    let mut state = create_test_input_state();
+    let board = board_index(&state, BOARD_ID_BLACKBOARD);
+    state.switch_board(BOARD_ID_BLACKBOARD);
+    set_page_count(&mut state, board, 2);
+    let requested_at = Instant::now();
+
+    assert_eq!(
+        state.delete_page_in_board_at(board, 0, requested_at),
+        PageDeleteOutcome::Pending
+    );
+    assert_eq!(
+        state.boards.board_states_mut()[board]
+            .pages
+            .delete_page_at(1),
+        PageDeleteOutcome::Removed
+    );
+    state.state = DrawingState::Drawing {
+        tool: Tool::Pen,
+        start_x: 10,
+        start_y: 20,
+        points: vec![(10, 20), (30, 40)],
+        point_thicknesses: vec![1.0, 1.0],
+    };
+    state.begin_pointer_drag(MouseButton::Left, None);
+
+    assert_eq!(
+        state.delete_page_in_board_at(board, 0, requested_at + Duration::from_millis(1)),
+        PageDeleteOutcome::Pending
+    );
+
+    assert!(matches!(state.state, DrawingState::Drawing { .. }));
+    assert_eq!(state.active_drag_button, Some(MouseButton::Left));
+    assert!(!state.has_pending_page_delete());
 }

--- a/src/session/snapshot/apply.rs
+++ b/src/session/snapshot/apply.rs
@@ -7,6 +7,8 @@ use crate::session::options::SessionOptions;
 /// Apply a session snapshot to the live [`InputState`].
 pub fn apply_snapshot(input: &mut InputState, snapshot: SessionSnapshot, options: &SessionOptions) {
     let runtime_history_limit = options.effective_history_limit(input.undo_stack_limit);
+    let board_generation_before = input.boards.board_identity_generation();
+    input.clear_pending_delete_confirmations();
 
     for board in &snapshot.boards {
         let pages = snapshot_to_board_pages(board.pages.clone());
@@ -20,6 +22,7 @@ pub fn apply_snapshot(input: &mut InputState, snapshot: SessionSnapshot, options
             clamp_runtime_history(&mut board_state.pages, runtime_history_limit);
         }
     }
+    input.clear_pending_deletes_after_board_generation_change(board_generation_before);
 
     if input.boards.has_board(&snapshot.active_board_id) {
         input.switch_board_force(&snapshot.active_board_id);

--- a/src/session/tests/snapshot.rs
+++ b/src/session/tests/snapshot.rs
@@ -1,7 +1,8 @@
 use super::super::*;
 use super::helpers::dummy_input_state;
 use crate::config::Action;
-use crate::draw::{Color, FontDescriptor, Frame, Shape};
+use crate::draw::{Color, FontDescriptor, Frame, PageDeleteOutcome, Shape};
+use crate::input::BOARD_ID_BLACKBOARD;
 use crate::input::state::{MAX_STROKE_THICKNESS, MIN_STROKE_THICKNESS};
 use crate::input::{EraserMode, PerToolDrawingSettings, Tool};
 use std::path::PathBuf;
@@ -322,4 +323,82 @@ fn apply_snapshot_keeps_current_board_when_active_board_is_missing() {
     apply_snapshot(&mut input, snapshot, &options);
 
     assert_eq!(input.board_id(), "whiteboard");
+}
+
+#[test]
+fn apply_snapshot_clears_pending_board_delete_confirmation() {
+    let options = SessionOptions::new(PathBuf::from("/tmp"), "display-board-confirm");
+    let mut input = dummy_input_state();
+    input.switch_board_force(BOARD_ID_BLACKBOARD);
+    let board_count = input.boards.board_count();
+
+    input.delete_active_board();
+    assert!(input.has_pending_board_delete());
+    assert!(
+        input
+            .ui_toast
+            .as_ref()
+            .and_then(|toast| toast.action.as_ref())
+            .is_some_and(|action| action.action == Action::BoardDelete)
+    );
+    input.ui_toast_bounds = Some((10.0, 20.0, 100.0, 40.0));
+
+    let snapshot = SessionSnapshot {
+        active_board_id: BOARD_ID_BLACKBOARD.to_string(),
+        boards: vec![BoardSnapshot {
+            id: BOARD_ID_BLACKBOARD.to_string(),
+            pages: BoardPagesSnapshot {
+                pages: vec![Frame::new()],
+                active: 0,
+            },
+        }],
+        tool_state: None,
+    };
+
+    apply_snapshot(&mut input, snapshot, &options);
+
+    assert!(!input.has_pending_board_delete());
+    assert!(input.ui_toast.is_none());
+    assert!(input.ui_toast_bounds.is_none());
+    input.delete_active_board();
+    assert_eq!(input.boards.board_count(), board_count);
+    assert!(input.has_pending_board_delete());
+}
+
+#[test]
+fn apply_snapshot_clears_pending_page_delete_confirmation() {
+    let options = SessionOptions::new(PathBuf::from("/tmp"), "display-page-confirm");
+    let mut input = dummy_input_state();
+    input.switch_board_force(BOARD_ID_BLACKBOARD);
+    input.page_new();
+
+    assert_eq!(input.page_delete(), PageDeleteOutcome::Pending);
+    assert!(input.has_pending_page_delete());
+    assert!(
+        input
+            .ui_toast
+            .as_ref()
+            .and_then(|toast| toast.action.as_ref())
+            .is_some_and(|action| action.action == Action::PageDelete)
+    );
+    input.ui_toast_bounds = Some((10.0, 20.0, 100.0, 40.0));
+
+    let snapshot = SessionSnapshot {
+        active_board_id: BOARD_ID_BLACKBOARD.to_string(),
+        boards: vec![BoardSnapshot {
+            id: BOARD_ID_BLACKBOARD.to_string(),
+            pages: BoardPagesSnapshot {
+                pages: vec![Frame::new()],
+                active: 0,
+            },
+        }],
+        tool_state: None,
+    };
+
+    apply_snapshot(&mut input, snapshot, &options);
+
+    assert!(!input.has_pending_page_delete());
+    assert!(input.ui_toast.is_none());
+    assert!(input.ui_toast_bounds.is_none());
+    assert_eq!(input.boards.page_count(), 1);
 }


### PR DESCRIPTION
 ## Summary

- Refactor board workspace behavior into focused color, identity, and operation modules.
- Add generation-backed board/page delete confirmations so stale confirmations are rejected after topology changes.
- Clear pending delete confirmations and actionable delete toasts when applying session snapshots.
- Fix page undo restoration after confirming a delete while another board is active.
- Make actionable toast clicks target-stable across press/release so undo/delete clicks do not also start canvas input or transfer to a replacement toast.
- Clear stale toast bounds when replacing toasts so old geometry cannot activate a new toast.