### PR TITLE
Fix session saves for image-heavy boards

### DIFF
--- a/src/session/snapshot/save.rs
+++ b/src/session/snapshot/save.rs
@@ -54,20 +54,28 @@ fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> 
     let backup_path = options.backup_file_path();
     let last_modified = now_rfc3339();
 
-    let Some(mut json_bytes) = payload_within_limit(snapshot, options, &last_modified)? else {
-        remove_session_file(&session_path)?;
-        return Ok(());
+    let payload = match payload_within_limit(snapshot, options, &last_modified) {
+        Ok(Some(payload)) => payload,
+        Ok(None) => {
+            remove_session_file(&session_path)?;
+            return Ok(());
+        }
+        Err(err) => {
+            if session_path.exists() {
+                warn!(
+                    "Session save failed before replacing {}; existing session file is unchanged",
+                    session_path.display()
+                );
+            }
+            return Err(err);
+        }
     };
-
-    let should_compress = match options.compression {
-        CompressionMode::Off => false,
-        CompressionMode::On => true,
-        CompressionMode::Auto => (json_bytes.len() as u64) >= options.auto_compress_threshold_bytes,
-    };
-
-    if should_compress {
-        json_bytes = compress_bytes(&json_bytes)?;
-    }
+    let PayloadCandidate {
+        bytes: payload_bytes,
+        raw_size,
+        compressed,
+    } = payload;
+    let final_size = payload_bytes.len();
 
     let tmp_path = temp_path(&session_path)?;
     {
@@ -82,7 +90,7 @@ fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> 
                 )
             })?;
         tmp_file
-            .write_all(&json_bytes)
+            .write_all(&payload_bytes)
             .context("failed to write session payload")?;
         tmp_file
             .sync_all()
@@ -115,41 +123,62 @@ fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> 
     })?;
 
     info!(
-        "Session saved to {} ({} bytes, compression={})",
+        "Session saved to {} ({} bytes written, raw={} bytes, compression={})",
         session_path.display(),
-        json_bytes.len(),
-        should_compress
+        final_size,
+        raw_size,
+        compressed
     );
 
     Ok(())
+}
+
+struct PayloadCandidate {
+    bytes: Vec<u8>,
+    raw_size: usize,
+    compressed: bool,
+}
+
+impl PayloadCandidate {
+    fn final_size(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn fits_limit(&self, options: &SessionOptions) -> bool {
+        self.final_size() as u64 <= options.max_file_size_bytes
+    }
 }
 
 fn payload_within_limit(
     snapshot: &SessionSnapshot,
     options: &SessionOptions,
     last_modified: &str,
-) -> Result<Option<Vec<u8>>> {
+) -> Result<Option<PayloadCandidate>> {
     if snapshot.is_empty() && snapshot.tool_state.is_none() {
         return Ok(None);
     }
 
-    let full_payload = serialize_payload(snapshot, last_modified)?;
-    if full_payload.len() as u64 <= options.max_file_size_bytes {
+    let full_payload = payload_candidate(snapshot, options, last_modified)?;
+    if full_payload.fits_limit(options) {
         return Ok(Some(full_payload));
     }
 
-    let full_size = full_payload.len();
+    let full_raw_size = full_payload.raw_size;
+    let full_final_size = full_payload.final_size();
     let history_depth = max_history_depth(snapshot);
     if history_depth > 0
         && let Some((depth, payload)) =
             largest_fitting_history_payload(snapshot, history_depth, options, last_modified)?
     {
         warn!(
-            "Session data size {} bytes exceeds the configured limit of {} bytes; saving recent {} undo/redo history entries per stack ({} bytes)",
-            full_size,
+            "Full session payload writes as {} bytes from {} raw bytes, exceeding the configured limit of {} bytes; saving recent {} undo/redo history entries per stack ({} bytes written from {} raw bytes, compression={})",
+            full_final_size,
+            full_raw_size,
             options.max_file_size_bytes,
             depth,
-            payload.len()
+            payload.final_size(),
+            payload.raw_size,
+            payload.compressed
         );
         return Ok(Some(payload));
     }
@@ -157,26 +186,31 @@ fn payload_within_limit(
     let visible_only = snapshot_without_history(snapshot);
     if visible_only.is_empty() && visible_only.tool_state.is_none() {
         warn!(
-            "Session data size {} bytes exceeds the configured limit of {} bytes; dropping undo/redo history leaves no visible session data, clearing saved session",
-            full_size, options.max_file_size_bytes
+            "Full session payload writes as {} bytes from {} raw bytes, exceeding the configured limit of {} bytes; dropping undo/redo history leaves no visible session data, clearing saved session",
+            full_final_size, full_raw_size, options.max_file_size_bytes
         );
         return Ok(None);
     }
 
-    let visible_payload = serialize_payload(&visible_only, last_modified)?;
-    if visible_payload.len() as u64 <= options.max_file_size_bytes {
+    let visible_payload = payload_candidate(&visible_only, options, last_modified)?;
+    if visible_payload.fits_limit(options) {
         warn!(
-            "Session data size {} bytes exceeds the configured limit of {} bytes; saving visible data without undo/redo history ({} bytes)",
-            full_size,
+            "Full session payload writes as {} bytes from {} raw bytes, exceeding the configured limit of {} bytes; saving visible data without undo/redo history ({} bytes written from {} raw bytes, compression={})",
+            full_final_size,
+            full_raw_size,
             options.max_file_size_bytes,
-            visible_payload.len()
+            visible_payload.final_size(),
+            visible_payload.raw_size,
+            visible_payload.compressed
         );
         return Ok(Some(visible_payload));
     }
 
     Err(anyhow!(
-        "Session data size {} bytes exceeds the configured limit of {} bytes; skipping save",
-        visible_payload.len(),
+        "Session data writes as {} bytes from {} raw bytes with compression={} which exceeds the configured limit of {} bytes; skipping save",
+        visible_payload.final_size(),
+        visible_payload.raw_size,
+        visible_payload.compressed,
         options.max_file_size_bytes
     ))
 }
@@ -186,27 +220,45 @@ fn largest_fitting_history_payload(
     max_depth: usize,
     options: &SessionOptions,
     last_modified: &str,
-) -> Result<Option<(usize, Vec<u8>)>> {
-    let mut low = 1;
-    let mut high = max_depth;
-    let mut best = None;
-
-    while low <= high {
-        let depth = low + (high - low) / 2;
+) -> Result<Option<(usize, PayloadCandidate)>> {
+    for depth in (1..=max_depth).rev() {
         let candidate = snapshot_with_history_depth(snapshot, depth);
-        let payload = serialize_payload(&candidate, last_modified)?;
-
-        if payload.len() as u64 <= options.max_file_size_bytes {
-            best = Some((depth, payload));
-            low = depth.saturating_add(1);
-        } else if depth == 1 {
-            break;
-        } else {
-            high = depth - 1;
+        let payload = payload_candidate(&candidate, options, last_modified)?;
+        if payload.fits_limit(options) {
+            return Ok(Some((depth, payload)));
         }
     }
 
-    Ok(best)
+    Ok(None)
+}
+
+fn payload_candidate(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    last_modified: &str,
+) -> Result<PayloadCandidate> {
+    let raw_bytes = serialize_payload(snapshot, last_modified)?;
+    let raw_size = raw_bytes.len();
+    let compressed = should_compress_payload(raw_size, options);
+    let bytes = if compressed {
+        compress_bytes(&raw_bytes)?
+    } else {
+        raw_bytes
+    };
+
+    Ok(PayloadCandidate {
+        bytes,
+        raw_size,
+        compressed,
+    })
+}
+
+fn should_compress_payload(raw_size: usize, options: &SessionOptions) -> bool {
+    match options.compression {
+        CompressionMode::Off => false,
+        CompressionMode::On => true,
+        CompressionMode::Auto => raw_size as u64 >= options.auto_compress_threshold_bytes,
+    }
 }
 
 fn serialize_payload(snapshot: &SessionSnapshot, last_modified: &str) -> Result<Vec<u8>> {

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -1,8 +1,8 @@
 use super::super::*;
 use super::helpers::dummy_input_state;
 use crate::draw::frame::{ShapeSnapshot, UndoAction};
-use crate::draw::{Color, FontDescriptor, Shape};
-use crate::input::EraserMode;
+use crate::draw::{Color, EmbeddedImage, FontDescriptor, Shape};
+use crate::input::{BOARD_ID_WHITEBOARD, EraserMode};
 use std::fs;
 use std::path::Path;
 
@@ -132,6 +132,83 @@ fn load_snapshot_truncates_shapes_when_exceeding_max_shapes_per_frame() {
         2,
         "frame should be truncated to max_shapes_per_frame"
     );
+}
+
+#[test]
+fn save_snapshot_allows_compressed_payload_that_fits_limit() {
+    const PAGE_COUNT: usize = 12;
+    const ACTIVE_PAGE: usize = 10;
+    const IMAGE_BYTES: usize = 64 * 1024;
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "display-compressed-fit");
+    options.persist_whiteboard = true;
+    options.persist_history = true;
+    options.restore_tool_state = false;
+    options.compression = CompressionMode::On;
+    options.max_file_size_bytes = 20 * 1024;
+    options.backup_retention = 0;
+
+    let mut input = dummy_input_state();
+    input.switch_board(BOARD_ID_WHITEBOARD);
+    for page_index in 0..PAGE_COUNT {
+        if page_index > 0 {
+            input.page_new();
+        }
+        add_image_and_annotations(input.boards.active_frame_mut(), page_index, IMAGE_BYTES);
+    }
+    assert!(input.switch_to_page(ACTIVE_PAGE));
+
+    let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
+    save_snapshot(&snapshot, &options).expect("compressed payload should fit and save");
+
+    let saved_size = fs::metadata(options.session_file_path())
+        .expect("session metadata")
+        .len();
+    assert!(
+        saved_size <= options.max_file_size_bytes,
+        "compressed session should fit configured limit"
+    );
+
+    let loaded = load_snapshot(&options)
+        .expect("load_snapshot should succeed")
+        .expect("snapshot should be present");
+
+    let mut restored = dummy_input_state();
+    apply_snapshot(&mut restored, loaded, &options);
+    restored.switch_board_force(BOARD_ID_WHITEBOARD);
+
+    let pages = restored.boards.active_pages();
+    assert_eq!(pages.page_count(), PAGE_COUNT);
+    assert_eq!(pages.active_index(), ACTIVE_PAGE);
+    for (page_index, page) in pages.pages().iter().enumerate() {
+        assert_eq!(page.shapes.len(), 3, "page {page_index} shape count");
+        assert_eq!(page.undo_stack_len(), 1, "page {page_index} undo depth");
+        match &page.shapes[0].shape {
+            Shape::Image { data, .. } => {
+                assert_eq!(data.bytes.len(), IMAGE_BYTES);
+                assert_eq!(data.width, 640);
+                assert_eq!(data.height, 360);
+            }
+            other => panic!("expected image on page {page_index}, got {other:?}"),
+        }
+        match &page.shapes[1].shape {
+            Shape::Freehand { points, .. } => {
+                assert_eq!(points.len(), 3);
+                assert_eq!(
+                    points[0],
+                    (i32::try_from(page_index).expect("page index fits i32"), 20)
+                );
+            }
+            other => panic!("expected annotation stroke on page {page_index}, got {other:?}"),
+        }
+        match &page.shapes[2].shape {
+            Shape::Text { text, .. } => {
+                assert_eq!(text, &format!("note-{page_index}"));
+            }
+            other => panic!("expected text annotation on page {page_index}, got {other:?}"),
+        }
+    }
 }
 
 #[test]
@@ -309,6 +386,62 @@ fn save_snapshot_keeps_largest_recent_history_depth_that_fits() {
         "save should keep the largest recent undo depth that fits"
     );
     assert_eq!(frame.redo_stack_len(), 0);
+}
+
+fn add_image_and_annotations(frame: &mut crate::draw::Frame, page_index: usize, bytes: usize) {
+    let image_id = frame.add_shape(Shape::Image {
+        x: 12,
+        y: 16,
+        w: 320,
+        h: 180,
+        data: EmbeddedImage {
+            mime_type: "image/png".to_string(),
+            width: 640,
+            height: 360,
+            bytes: vec![0x5a; bytes],
+        },
+    });
+    let (image_index, image_shape) = frame
+        .find_index(image_id)
+        .and_then(|index| frame.shape(image_id).map(|shape| (index, shape.clone())))
+        .expect("stored image shape");
+    frame.push_undo_action(
+        UndoAction::Create {
+            shapes: vec![(image_index, image_shape)],
+        },
+        usize::MAX,
+    );
+
+    let y = 20 + i32::try_from(page_index).expect("page index fits i32");
+    frame.add_shape(Shape::Freehand {
+        points: vec![
+            (i32::try_from(page_index).expect("page index fits i32"), 20),
+            (40, y),
+            (80, y + 8),
+        ],
+        color: Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 3.0,
+    });
+    frame.add_shape(Shape::Text {
+        x: 24,
+        y: 48 + i32::try_from(page_index).expect("page index fits i32"),
+        text: format!("note-{page_index}"),
+        color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        size: 20.0,
+        font_descriptor: FontDescriptor::default(),
+        background_enabled: true,
+        wrap_width: None,
+    });
 }
 
 fn limit_test_options(base_dir: &Path, display_id: &str, persist_history: bool) -> SessionOptions {

--- a/src/session/tests/roundtrip.rs
+++ b/src/session/tests/roundtrip.rs
@@ -83,6 +83,62 @@ fn session_roundtrip_preserves_shapes_across_frames() {
 }
 
 #[test]
+fn session_roundtrip_preserves_pages_beyond_visible_shortcuts() {
+    const PAGE_COUNT: usize = 12;
+    const ACTIVE_PAGE: usize = 10;
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "display-many-pages");
+    options.persist_whiteboard = true;
+
+    let mut input = dummy_input_state();
+    input.switch_board(BOARD_ID_WHITEBOARD);
+    for page_index in 0..PAGE_COUNT {
+        if page_index > 0 {
+            input.page_new();
+        }
+        input.boards.active_frame_mut().add_shape(Shape::Text {
+            x: 10,
+            y: 20,
+            text: format!("page-{page_index}"),
+            color: Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            size: 18.0,
+            font_descriptor: FontDescriptor::default(),
+            background_enabled: false,
+            wrap_width: None,
+        });
+    }
+    assert!(input.switch_to_page(ACTIVE_PAGE));
+
+    let snapshot = snapshot_from_input(&input, &options).expect("snapshot produced");
+    save_snapshot(&snapshot, &options).expect("save snapshot");
+
+    let loaded_snapshot = load_snapshot(&options)
+        .expect("load snapshot result")
+        .expect("snapshot present");
+
+    let mut fresh_input = dummy_input_state();
+    apply_snapshot(&mut fresh_input, loaded_snapshot, &options);
+    fresh_input.switch_board_force(BOARD_ID_WHITEBOARD);
+
+    let pages = fresh_input.boards.active_pages();
+    assert_eq!(pages.page_count(), PAGE_COUNT);
+    assert_eq!(pages.active_index(), ACTIVE_PAGE);
+    for (page_index, page) in pages.pages().iter().enumerate() {
+        assert_eq!(page.shapes.len(), 1, "page {page_index} shape count");
+        match &page.shapes[0].shape {
+            Shape::Text { text, .. } => assert_eq!(text, &format!("page-{page_index}")),
+            other => panic!("expected text on page {page_index}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn save_snapshot_rotates_backup_when_enabled() {
     let temp = tempfile::tempdir().unwrap();
     let mut options = SessionOptions::new(temp.path().to_path_buf(), "display-backup");


### PR DESCRIPTION
Fixes #220

## Summary

Fixes session persistence for large boards that contain embedded images and annotations.

Session saves now check the final bytes that will actually be written, after the configured compression mode is applied. This prevents image-heavy sessions from being rejected just because their raw JSON representation exceeds `session.max_file_size_mb` when the compressed session file would fit.

## Changes

- Apply `session.max_file_size_mb` to final written payload bytes instead of raw JSON bytes
- Keep existing fallback behavior:
  - full snapshot when it fits
  - trimmed undo/redo history when full history does not fit
  - visible-only snapshot when history cannot fit
  - error only when visible data still cannot fit
- Preserve all board pages; no 9-page persistence cap is introduced
- Add regression coverage for 12-page image-heavy sessions with annotations
- Add a roundtrip guard for pages beyond the visible 1-9 shortcuts