### PR TITLE
Fix image-heavy session persistence limits and warnings

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -652,7 +652,7 @@ max_shapes_per_frame = 10000
 # max_persisted_undo_depth = 200
 
 # Maximum session file size (in megabytes); larger files are ignored
-max_file_size_mb = 10
+max_file_size_mb = 50
 
 # Compression mode: "auto", "on", or "off"
 compress = "auto"

--- a/config.example.toml
+++ b/config.example.toml
@@ -651,7 +651,7 @@ max_shapes_per_frame = 10000
 # Optional cap for serialized undo history (defaults to runtime undo limit)
 # max_persisted_undo_depth = 200
 
-# Maximum session file size (in megabytes); larger files are ignored
+# Maximum session file size (in megabytes); image paste and autosave warn near this cap
 max_file_size_mb = 50
 
 # Compression mode: "auto", "on", or "off"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -748,7 +748,7 @@ backup_retention = 1
 - `custom_directory` — absolute path used when `storage = "custom"`; supports `~`
 - `per_output` — when `true` (default) keep a separate session file for each monitor; set to `false` to share one file per Wayland display as in earlier releases
 - `max_shapes_per_frame` — trims older shapes if a frame grows beyond this count when loading/saving
-- `max_file_size_mb` — skips loading and writing session files beyond this size cap; autosave warns near the cap
+- `max_file_size_mb` — skips loading and writing session files beyond this size cap; image paste and autosave warn near the cap
 - `compress` — `auto` (gzip files above the threshold), `on`, or `off`
 - `auto_compress_threshold_kb` — size threshold for `compress = "auto"`
 - `backup_retention` — how many rotated `.bak` files to keep (set to 0 to disable backups)
@@ -765,6 +765,7 @@ Session overrides and recovery:
 
 - CLI flags: `--resume-session` forces persistence on, `--no-resume-session` forces it off for the current run. The environment variable `WAYSCRIBER_RESUME_SESSION=1/0` does the same.
 - Size fallback: if visible drawings fit but persisted undo/redo history would exceed save or restore safety limits, autosave saves the drawings and warns once per run that history was trimmed or omitted.
+- Image paste guard: when a pasted image would push visible session data over `max_file_size_mb`, Wayscriber blocks the paste and points you to `[session] max_file_size_mb`; when only undo history is at risk, the paste is allowed with a warning.
 - Load safety: compressed session files are checked against an internal expanded-size cap while saving and loading. If an existing file expands beyond that cap, wayscriber refuses to load it, leaves the primary session file unchanged, and avoids overwriting it until session data changes.
 - Recovery: if a session file is corrupt or cannot be parsed/decompressed, wayscriber logs a warning, writes a `.bak` copy of the bad file, removes the corrupt file, and continues with defaults. Overrides above still apply after recovery.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -734,7 +734,7 @@ storage = "auto"
 # custom_directory = "/absolute/path"
 per_output = true
 max_shapes_per_frame = 10000
-max_file_size_mb = 10
+max_file_size_mb = 50
 compress = "auto"
 auto_compress_threshold_kb = 100
 backup_retention = 1
@@ -748,7 +748,7 @@ backup_retention = 1
 - `custom_directory` — absolute path used when `storage = "custom"`; supports `~`
 - `per_output` — when `true` (default) keep a separate session file for each monitor; set to `false` to share one file per Wayland display as in earlier releases
 - `max_shapes_per_frame` — trims older shapes if a frame grows beyond this count when loading/saving
-- `max_file_size_mb` — skips loading and writing session files beyond this size cap
+- `max_file_size_mb` — skips loading and writing session files beyond this size cap; autosave warns near the cap
 - `compress` — `auto` (gzip files above the threshold), `on`, or `off`
 - `auto_compress_threshold_kb` — size threshold for `compress = "auto"`
 - `backup_retention` — how many rotated `.bak` files to keep (set to 0 to disable backups)
@@ -764,6 +764,8 @@ Use the CLI helpers for quick maintenance:
 Session overrides and recovery:
 
 - CLI flags: `--resume-session` forces persistence on, `--no-resume-session` forces it off for the current run. The environment variable `WAYSCRIBER_RESUME_SESSION=1/0` does the same.
+- Size fallback: if visible drawings fit but persisted undo/redo history would exceed save or restore safety limits, autosave saves the drawings and warns once per run that history was trimmed or omitted.
+- Load safety: compressed session files are checked against an internal expanded-size cap while saving and loading. If an existing file expands beyond that cap, wayscriber refuses to load it, leaves the primary session file unchanged, and avoids overwriting it until session data changes.
 - Recovery: if a session file is corrupt or cannot be parsed/decompressed, wayscriber logs a warning, writes a `.bak` copy of the bad file, removes the corrupt file, and continues with defaults. Overrides above still apply after recovery.
 
 ### `[keybindings]` - Custom Keybindings

--- a/src/backend/wayland/backend/event_loop/session_save.rs
+++ b/src/backend/wayland/backend/event_loop/session_save.rs
@@ -1,11 +1,19 @@
 use super::super::super::state::WaylandState;
-use crate::{notification, session};
+use crate::{
+    backend::wayland::session::SessionState,
+    notification, session,
+    session::{SaveSnapshotOutcome, SaveSnapshotReport},
+};
 use std::time::{Duration, Instant};
 
 pub(super) fn persist_session(state: &WaylandState) -> Result<(), anyhow::Error> {
     let Some(options) = state.session_options() else {
         return Ok(());
     };
+
+    if should_skip_protected_session_save(state, options) {
+        return Ok(());
+    }
 
     let snapshot = session::snapshot_from_input(&state.input_state, options);
     let _ = save_snapshot_or_clear(state, options, snapshot)?;
@@ -34,7 +42,10 @@ pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<
         &options,
         session::snapshot_from_input(&state.input_state, &options),
     ) {
-        Ok(saved) => record_autosave_success(&mut state.session, now, saved),
+        Ok(report) => {
+            notify_session_save_report(state, report.as_ref());
+            record_autosave_success(&mut state.session, now, report.is_some());
+        }
         Err(err) => {
             if record_autosave_failure(&mut state.session, now, &options) {
                 notify_session_failure(state, &err);
@@ -49,14 +60,17 @@ fn save_snapshot_or_clear(
     state: &WaylandState,
     options: &session::SessionOptions,
     snapshot: Option<session::SessionSnapshot>,
-) -> Result<bool, anyhow::Error> {
+) -> Result<Option<SaveSnapshotReport>, anyhow::Error> {
+    if should_skip_protected_session_save(state, options) {
+        return Ok(None);
+    }
+
     if let Some(snapshot) = snapshot {
-        session::save_snapshot(&snapshot, options)?;
-        return Ok(true);
+        return session::save_snapshot_with_report(&snapshot, options);
     }
 
     if !persistence_enabled(options) {
-        return Ok(false);
+        return Ok(None);
     }
 
     let empty_snapshot = session::SessionSnapshot {
@@ -64,26 +78,125 @@ fn save_snapshot_or_clear(
         boards: Vec::new(),
         tool_state: None,
     };
-    session::save_snapshot(&empty_snapshot, options)?;
-    Ok(true)
+    session::save_snapshot_with_report(&empty_snapshot, options)
 }
 
 fn persistence_enabled(options: &session::SessionOptions) -> bool {
     options.any_enabled() || options.restore_tool_state || options.persist_history
 }
 
-fn record_autosave_success(
-    session_state: &mut crate::backend::wayland::session::SessionState,
-    now: Instant,
-    saved: bool,
-) {
+fn should_skip_protected_session_save(
+    state: &WaylandState,
+    options: &session::SessionOptions,
+) -> bool {
+    let session_path = options.session_file_path();
+    let skip = state
+        .session
+        .should_skip_save_for_protected_path(&session_path, state.input_state.is_session_dirty());
+    if skip {
+        log::info!(
+            "Skipping session save to {} because a previous oversized compressed session was left protected and no session changes have been made",
+            session_path.display()
+        );
+    }
+    skip
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionSaveNotification {
+    NearLimit,
+    TrimmedHistory { depth: usize },
+    VisibleOnly,
+}
+
+fn pending_save_notifications(
+    session_state: &mut SessionState,
+    report: &SaveSnapshotReport,
+) -> Vec<SessionSaveNotification> {
+    let mut notifications = Vec::new();
+    match report.outcome {
+        SaveSnapshotOutcome::Full => {
+            if report.is_near_limit() && session_state.mark_near_limit_notified(&report.path) {
+                notifications.push(SessionSaveNotification::NearLimit);
+            }
+        }
+        SaveSnapshotOutcome::TrimmedHistory { depth } => {
+            if session_state.mark_trimmed_history_notified() {
+                notifications.push(SessionSaveNotification::TrimmedHistory { depth });
+            }
+        }
+        SaveSnapshotOutcome::VisibleOnly => {
+            if session_state.mark_visible_only_notified() {
+                notifications.push(SessionSaveNotification::VisibleOnly);
+            }
+        }
+        SaveSnapshotOutcome::ClearedEmpty => {}
+    }
+    notifications
+}
+
+fn notify_session_save_report(state: &mut WaylandState, report: Option<&SaveSnapshotReport>) {
+    let Some(report) = report else {
+        return;
+    };
+
+    for notification in pending_save_notifications(&mut state.session, report) {
+        let (summary, body) = session_save_notification_text(notification, report);
+        notification::send_notification_async(
+            &state.tokio_handle,
+            summary,
+            body,
+            Some("dialog-warning".to_string()),
+        );
+    }
+}
+
+fn session_save_notification_text(
+    notification: SessionSaveNotification,
+    report: &SaveSnapshotReport,
+) -> (String, String) {
+    let written = format_bytes(report.written_size as u64);
+    let limit = format_bytes(report.max_file_size_bytes);
+    match notification {
+        SessionSaveNotification::NearLimit => (
+            "Session Storage Nearly Full".to_string(),
+            format!(
+                "Session save is using {written} of the {limit} cap. Image-heavy sessions can grow quickly; consider disabling persisted history or increasing session.max_file_size_mb."
+            ),
+        ),
+        SessionSaveNotification::TrimmedHistory { depth } => (
+            "Session Undo History Trimmed".to_string(),
+            format!(
+                "Your drawings were saved, but undo/redo history was trimmed to {depth} entries per stack to keep the session within save and restore safety limits."
+            ),
+        ),
+        SessionSaveNotification::VisibleOnly => (
+            "Session Undo History Not Saved".to_string(),
+            "Your drawings were saved, but undo/redo history was omitted to keep the session within save and restore safety limits.".to_string(),
+        ),
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+fn record_autosave_success(session_state: &mut SessionState, now: Instant, saved: bool) {
     if saved {
         session_state.mark_saved(now);
     }
 }
 
 fn record_autosave_failure(
-    session_state: &mut crate::backend::wayland::session::SessionState,
+    session_state: &mut SessionState,
     now: Instant,
     options: &session::SessionOptions,
 ) -> bool {
@@ -175,5 +288,138 @@ mod tests {
 
         record_autosave_success(&mut state, now + Duration::from_millis(2), true);
         assert!(!state.autosave_due(now + Duration::from_millis(2), &options));
+    }
+
+    #[test]
+    fn pending_save_notifications_warns_near_limit_once_per_path() {
+        let mut state = SessionState::new(None);
+        let path = PathBuf::from("/tmp/session-a.json");
+        let report = save_report(path.clone(), SaveSnapshotOutcome::Full, 90, 100);
+
+        assert_eq!(
+            pending_save_notifications(&mut state, &report),
+            vec![SessionSaveNotification::NearLimit]
+        );
+        assert!(
+            pending_save_notifications(&mut state, &report).is_empty(),
+            "same near-limit session path should not notify twice"
+        );
+
+        let other_report = save_report(
+            PathBuf::from("/tmp/session-b.json"),
+            SaveSnapshotOutcome::Full,
+            90,
+            100,
+        );
+        assert_eq!(
+            pending_save_notifications(&mut state, &other_report),
+            vec![SessionSaveNotification::NearLimit]
+        );
+
+        let below_limit = save_report(path, SaveSnapshotOutcome::Full, 89, 100);
+        assert!(pending_save_notifications(&mut state, &below_limit).is_empty());
+    }
+
+    #[test]
+    fn pending_save_notifications_reports_trimmed_history_once() {
+        let mut state = SessionState::new(None);
+        let report = save_report(
+            PathBuf::from("/tmp/session.json"),
+            SaveSnapshotOutcome::TrimmedHistory { depth: 2 },
+            50,
+            100,
+        );
+
+        assert_eq!(
+            pending_save_notifications(&mut state, &report),
+            vec![SessionSaveNotification::TrimmedHistory { depth: 2 }]
+        );
+        assert!(
+            pending_save_notifications(&mut state, &report).is_empty(),
+            "trimmed-history notification should be once per run"
+        );
+    }
+
+    #[test]
+    fn pending_save_notifications_reports_visible_only_once() {
+        let mut state = SessionState::new(None);
+        let report = save_report(
+            PathBuf::from("/tmp/session.json"),
+            SaveSnapshotOutcome::VisibleOnly,
+            50,
+            100,
+        );
+
+        assert_eq!(
+            pending_save_notifications(&mut state, &report),
+            vec![SessionSaveNotification::VisibleOnly]
+        );
+        assert!(
+            pending_save_notifications(&mut state, &report).is_empty(),
+            "visible-only notification should be once per run"
+        );
+    }
+
+    #[test]
+    fn pending_save_notifications_ignores_full_save_below_limit_and_empty_clear() {
+        let mut state = SessionState::new(None);
+        let full = save_report(
+            PathBuf::from("/tmp/session.json"),
+            SaveSnapshotOutcome::Full,
+            10,
+            100,
+        );
+        let cleared = save_report(
+            PathBuf::from("/tmp/session.json"),
+            SaveSnapshotOutcome::ClearedEmpty,
+            0,
+            100,
+        );
+
+        assert!(pending_save_notifications(&mut state, &full).is_empty());
+        assert!(pending_save_notifications(&mut state, &cleared).is_empty());
+    }
+
+    #[test]
+    fn history_fallback_notifications_do_not_blame_only_file_size_cap() {
+        let report = save_report(
+            PathBuf::from("/tmp/session.json"),
+            SaveSnapshotOutcome::TrimmedHistory { depth: 2 },
+            50,
+            100,
+        );
+        let (_, trimmed_body) = session_save_notification_text(
+            SessionSaveNotification::TrimmedHistory { depth: 2 },
+            &report,
+        );
+        assert!(trimmed_body.contains("save and restore safety limits"));
+        assert!(!trimmed_body.contains("session.max_file_size_mb"));
+
+        let report = save_report(
+            PathBuf::from("/tmp/session.json"),
+            SaveSnapshotOutcome::VisibleOnly,
+            50,
+            100,
+        );
+        let (_, visible_body) =
+            session_save_notification_text(SessionSaveNotification::VisibleOnly, &report);
+        assert!(visible_body.contains("save and restore safety limits"));
+        assert!(!visible_body.contains("session.max_file_size_mb"));
+    }
+
+    fn save_report(
+        path: PathBuf,
+        outcome: SaveSnapshotOutcome,
+        written_size: usize,
+        max_file_size_bytes: u64,
+    ) -> SaveSnapshotReport {
+        SaveSnapshotReport {
+            path,
+            outcome,
+            raw_size: written_size,
+            written_size,
+            max_file_size_bytes,
+            compressed: false,
+        }
     }
 }

--- a/src/backend/wayland/backend/event_loop/session_save.rs
+++ b/src/backend/wayland/backend/event_loop/session_save.rs
@@ -1,10 +1,15 @@
 use super::super::super::state::WaylandState;
 use crate::{
     backend::wayland::session::SessionState,
+    config::{Action, Config},
+    input::state::UiToastKind,
     notification, session,
     session::{SaveSnapshotOutcome, SaveSnapshotReport},
 };
 use std::time::{Duration, Instant};
+
+const SESSION_SAVE_WARNING_TOAST_MS: u64 = 20_000;
+const SESSION_SAVE_NOTIFICATION_TIMEOUT_MS: i32 = 15_000;
 
 pub(super) fn persist_session(state: &WaylandState) -> Result<(), anyhow::Error> {
     let Some(options) = state.session_options() else {
@@ -15,8 +20,26 @@ pub(super) fn persist_session(state: &WaylandState) -> Result<(), anyhow::Error>
         return Ok(());
     }
 
+    let started = Instant::now();
+    log::info!(
+        "Starting {} session persistence to {}",
+        SessionSaveReason::Shutdown.label(),
+        options.session_file_path().display()
+    );
+    let snapshot_started = Instant::now();
     let snapshot = session::snapshot_from_input(&state.input_state, options);
-    let _ = save_snapshot_or_clear(state, options, snapshot)?;
+    log_snapshot_capture(
+        SessionSaveReason::Shutdown,
+        options,
+        snapshot.as_ref(),
+        snapshot_started.elapsed(),
+    );
+    let report = save_snapshot_or_clear(state, options, snapshot)?;
+    log_session_save_result(
+        SessionSaveReason::Shutdown,
+        report.as_ref(),
+        started.elapsed(),
+    );
     Ok(())
 }
 
@@ -37,17 +60,29 @@ pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<
         return Ok(());
     }
 
-    match save_snapshot_or_clear(
-        state,
+    let started = Instant::now();
+    let snapshot_started = Instant::now();
+    let snapshot = session::snapshot_from_input(&state.input_state, &options);
+    log_snapshot_capture(
+        SessionSaveReason::Autosave,
         &options,
-        session::snapshot_from_input(&state.input_state, &options),
-    ) {
+        snapshot.as_ref(),
+        snapshot_started.elapsed(),
+    );
+
+    match save_snapshot_or_clear(state, &options, snapshot) {
         Ok(report) => {
+            log_session_save_result(
+                SessionSaveReason::Autosave,
+                report.as_ref(),
+                started.elapsed(),
+            );
             notify_session_save_report(state, report.as_ref());
             record_autosave_success(&mut state.session, now, report.is_some());
         }
         Err(err) => {
             if record_autosave_failure(&mut state.session, now, &options) {
+                show_session_failure_toast(state);
                 notify_session_failure(state, &err);
             }
             return Err(err);
@@ -79,6 +114,123 @@ fn save_snapshot_or_clear(
         tool_state: None,
     };
     session::save_snapshot_with_report(&empty_snapshot, options)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionSaveReason {
+    Autosave,
+    Shutdown,
+}
+
+impl SessionSaveReason {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Autosave => "autosave",
+            Self::Shutdown => "shutdown",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SnapshotSummary {
+    boards: usize,
+    pages: usize,
+    shapes: usize,
+    undo_entries: usize,
+    redo_entries: usize,
+    visible_image_shapes: usize,
+    visible_image_bytes: usize,
+    max_history_depth: usize,
+    tool_state: bool,
+}
+
+impl SnapshotSummary {
+    fn from_snapshot(snapshot: &session::SessionSnapshot) -> Self {
+        let mut summary = Self {
+            tool_state: snapshot.tool_state.is_some(),
+            ..Self::default()
+        };
+        for board in &snapshot.boards {
+            summary.boards += 1;
+            summary.pages += board.pages.pages.len();
+            for frame in &board.pages.pages {
+                let undo = frame.undo_stack_len();
+                let redo = frame.redo_stack_len();
+                summary.shapes += frame.shapes.len();
+                summary.undo_entries += undo;
+                summary.redo_entries += redo;
+                summary.max_history_depth = summary.max_history_depth.max(undo.max(redo));
+                for drawn in &frame.shapes {
+                    if let crate::draw::Shape::Image { data, .. } = &drawn.shape {
+                        summary.visible_image_shapes += 1;
+                        summary.visible_image_bytes =
+                            summary.visible_image_bytes.saturating_add(data.bytes.len());
+                    }
+                }
+            }
+        }
+        summary
+    }
+}
+
+fn log_snapshot_capture(
+    reason: SessionSaveReason,
+    options: &session::SessionOptions,
+    snapshot: Option<&session::SessionSnapshot>,
+    elapsed: Duration,
+) {
+    let Some(snapshot) = snapshot else {
+        log::info!(
+            "Captured {} session snapshot for {} in {:?}: no persistable data",
+            reason.label(),
+            options.session_file_path().display(),
+            elapsed
+        );
+        return;
+    };
+
+    let summary = SnapshotSummary::from_snapshot(snapshot);
+    log::info!(
+        "Captured {} session snapshot for {} in {:?}: boards={}, pages={}, shapes={}, undo_entries={}, redo_entries={}, max_history_depth={}, visible_images={} ({} bytes), tool_state={}",
+        reason.label(),
+        options.session_file_path().display(),
+        elapsed,
+        summary.boards,
+        summary.pages,
+        summary.shapes,
+        summary.undo_entries,
+        summary.redo_entries,
+        summary.max_history_depth,
+        summary.visible_image_shapes,
+        summary.visible_image_bytes,
+        summary.tool_state
+    );
+}
+
+fn log_session_save_result(
+    reason: SessionSaveReason,
+    report: Option<&SaveSnapshotReport>,
+    elapsed: Duration,
+) {
+    let Some(report) = report else {
+        log::info!(
+            "Finished {} session persistence in {:?}: no file write needed",
+            reason.label(),
+            elapsed
+        );
+        return;
+    };
+
+    log::info!(
+        "Finished {} session persistence in {:?}: outcome={:?}, written={} bytes, raw={} bytes, compression={}, path={}",
+        reason.label(),
+        elapsed,
+        report.outcome,
+        report.written_size,
+        report.raw_size,
+        report.compressed,
+        report.path.display()
+    );
 }
 
 fn persistence_enabled(options: &session::SessionOptions) -> bool {
@@ -142,12 +294,40 @@ fn notify_session_save_report(state: &mut WaylandState, report: Option<&SaveSnap
 
     for notification in pending_save_notifications(&mut state.session, report) {
         let (summary, body) = session_save_notification_text(notification, report);
-        notification::send_notification_async(
+        let toast = session_save_toast_text(notification, report);
+        state.input_state.set_ui_toast_with_action_and_duration(
+            UiToastKind::Warning,
+            toast,
+            "Settings",
+            Action::OpenConfigurator,
+            SESSION_SAVE_WARNING_TOAST_MS,
+        );
+        notification::send_notification_with_timeout_async(
             &state.tokio_handle,
             summary,
             body,
             Some("dialog-warning".to_string()),
+            SESSION_SAVE_NOTIFICATION_TIMEOUT_MS,
         );
+    }
+}
+
+fn session_save_toast_text(
+    notification: SessionSaveNotification,
+    report: &SaveSnapshotReport,
+) -> String {
+    let written = format_bytes(report.written_size as u64);
+    let limit = format_bytes(report.max_file_size_bytes);
+    let suggested_limit_mb =
+        suggested_limit_mb(report.written_size as u64, report.max_file_size_bytes);
+    match notification {
+        SessionSaveNotification::NearLimit => {
+            format!("Session near limit: {written}/{limit}. Set {suggested_limit_mb} MiB.")
+        }
+        SessionSaveNotification::TrimmedHistory { depth } => {
+            format!("Session saved. Undo history trimmed to {depth} entries.")
+        }
+        SessionSaveNotification::VisibleOnly => "Session saved without undo history.".to_string(),
     }
 }
 
@@ -157,22 +337,25 @@ fn session_save_notification_text(
 ) -> (String, String) {
     let written = format_bytes(report.written_size as u64);
     let limit = format_bytes(report.max_file_size_bytes);
+    let suggested_limit_mb =
+        suggested_limit_mb(report.written_size as u64, report.max_file_size_bytes);
     match notification {
         SessionSaveNotification::NearLimit => (
             "Session Storage Nearly Full".to_string(),
             format!(
-                "Session save is using {written} of the {limit} cap. Image-heavy sessions can grow quickly; consider disabling persisted history or increasing session.max_file_size_mb."
+                "Session save is using {written} of {limit}. Open Settings > Session > Max file size and set {suggested_limit_mb} MiB, or edit {}.",
+                config_path_display()
             ),
         ),
         SessionSaveNotification::TrimmedHistory { depth } => (
             "Session Undo History Trimmed".to_string(),
             format!(
-                "Your drawings were saved, but undo/redo history was trimmed to {depth} entries per stack to keep the session within save and restore safety limits."
+                "Drawings were saved, but undo/redo history was trimmed to {depth} entries per stack to meet save and restore safety limits."
             ),
         ),
         SessionSaveNotification::VisibleOnly => (
             "Session Undo History Not Saved".to_string(),
-            "Your drawings were saved, but undo/redo history was omitted to keep the session within save and restore safety limits.".to_string(),
+            "Drawings were saved, but undo/redo history was omitted to meet save and restore safety limits.".to_string(),
         ),
     }
 }
@@ -204,12 +387,43 @@ fn record_autosave_failure(
 }
 
 pub(super) fn notify_session_failure(state: &WaylandState, err: &anyhow::Error) {
-    notification::send_notification_async(
+    notification::send_notification_with_timeout_async(
         &state.tokio_handle,
         "Failed to Save Session".to_string(),
-        format!("Your drawings may not persist: {}", err),
+        format!(
+            "Drawings may not persist. Raise Session > Max file size, remove images, or disable persisted history. Details: {}",
+            err
+        ),
         Some("dialog-error".to_string()),
+        SESSION_SAVE_NOTIFICATION_TIMEOUT_MS,
     );
+}
+
+fn show_session_failure_toast(state: &mut WaylandState) {
+    state.input_state.set_ui_toast_with_action_and_duration(
+        UiToastKind::Warning,
+        "Session save failed; drawings may not restore. Check max_file_size_mb.",
+        "Settings",
+        Action::OpenConfigurator,
+        SESSION_SAVE_WARNING_TOAST_MS,
+    );
+}
+
+fn suggested_limit_mb(projected_written_size: u64, current_limit_bytes: u64) -> u64 {
+    const MIB: u64 = 1024 * 1024;
+    let projected_mb = projected_written_size.div_ceil(MIB);
+    let current_mb = current_limit_bytes.div_ceil(MIB);
+    projected_mb
+        .saturating_mul(3)
+        .div_ceil(2)
+        .max(current_mb.saturating_mul(3).div_ceil(2))
+        .clamp(1, 1024)
+}
+
+fn config_path_display() -> String {
+    Config::get_config_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "~/.config/wayscriber/config.toml".to_string())
 }
 
 #[cfg(test)]

--- a/src/backend/wayland/clipboard/image.rs
+++ b/src/backend/wayland/clipboard/image.rs
@@ -68,7 +68,7 @@ mod tests {
     fn image_byte_cap_leaves_room_for_default_persisted_create_history() {
         let encoded_len = MAX_CLIPBOARD_IMAGE_BYTES.div_ceil(3) * 4;
         let duplicated_history_len = encoded_len * 2;
-        let default_session_budget = 10 * 1024 * 1024;
+        let default_session_budget = 50 * 1024 * 1024;
         let json_margin = 512 * 1024;
 
         assert!(duplicated_history_len + json_margin < default_session_budget);

--- a/src/backend/wayland/clipboard/image.rs
+++ b/src/backend/wayland/clipboard/image.rs
@@ -27,6 +27,7 @@ pub(super) fn choose_supported_mime(offered: &[String]) -> Option<String> {
 }
 
 pub(super) fn decode_clipboard_image(mime_type: &str, bytes: Vec<u8>) -> ClipboardPasteResult {
+    let encoded_bytes = bytes.len();
     let Some(format) = format_from_mime_or_bytes(mime_type, &bytes) else {
         return ClipboardPasteResult::DecodeFailed(format!("unsupported MIME type {}", mime_type));
     };
@@ -45,6 +46,14 @@ pub(super) fn decode_clipboard_image(mime_type: &str, bytes: Vec<u8>) -> Clipboa
     if let Err(err) = decode_rgba(format, &bytes) {
         return ClipboardPasteResult::DecodeFailed(err);
     }
+    log::info!(
+        "Decoded clipboard image: offered_mime={}, stored_mime={}, dimensions={}x{}, encoded_bytes={}",
+        mime_type,
+        canonical_image_mime_type(format),
+        dimensions.0,
+        dimensions.1,
+        encoded_bytes
+    );
     ClipboardPasteResult::Image(EmbeddedImage {
         mime_type: canonical_image_mime_type(format).to_string(),
         width: dimensions.0,

--- a/src/backend/wayland/clipboard/mod.rs
+++ b/src/backend/wayland/clipboard/mod.rs
@@ -57,6 +57,42 @@ pub(in crate::backend::wayland) enum ClipboardPasteResult {
     MalformedPrivateSelection(String),
 }
 
+impl ClipboardPasteResult {
+    pub(in crate::backend::wayland) fn summary(&self) -> String {
+        match self {
+            Self::PrivateSelection(selection) => {
+                format!("private-selection shapes={}", selection.shapes.len())
+            }
+            Self::Image(image) => format!(
+                "image mime={} dimensions={}x{} bytes={}",
+                image.mime_type,
+                image.width,
+                image.height,
+                image.bytes.len()
+            ),
+            Self::ClipboardEmpty => "clipboard-empty".to_string(),
+            Self::NoSupportedMime { offered } => {
+                format!("unsupported-mime offered={offered:?}")
+            }
+            Self::TooLarge { limit } => format!("too-large limit={limit}"),
+            Self::TooManyPixels {
+                width,
+                height,
+                limit,
+            } => {
+                format!("too-many-pixels dimensions={width}x{height} limit={limit}")
+            }
+            Self::DecodeFailed(err) => format!("decode-failed error={err}"),
+            Self::ReadTimedOut => "read-timed-out".to_string(),
+            Self::ClipboardUnavailable(err) => format!("clipboard-unavailable error={err}"),
+            Self::ClipboardError(err) => format!("clipboard-error error={err}"),
+            Self::MalformedPrivateSelection(err) => {
+                format!("malformed-private-selection error={err}")
+            }
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum ClipboardReadError {
     Empty,

--- a/src/backend/wayland/clipboard/mod.rs
+++ b/src/backend/wayland/clipboard/mod.rs
@@ -19,7 +19,7 @@ pub(in crate::backend::wayland) mod transfer;
 pub(super) const WAYSCRIBER_SELECTION_MIME: &str = "application/vnd.wayscriber.selection+json";
 
 // A pasted image is persisted in the visible frame and in the Create undo action.
-// Keep one accepted image comfortably below the default 10 MiB session JSON budget.
+// Keep one accepted image comfortably below the default 50 MiB session JSON budget.
 pub(super) const MAX_CLIPBOARD_IMAGE_BYTES: usize = 3 * 1024 * 1024;
 pub(super) const MAX_CLIPBOARD_SELECTION_BYTES: usize = 2 * 1024 * 1024;
 pub(super) const MAX_CLIPBOARD_IMAGE_PIXELS: u64 = 48_000_000;

--- a/src/backend/wayland/clipboard/transfer.rs
+++ b/src/backend/wayland/clipboard/transfer.rs
@@ -145,6 +145,11 @@ pub(in crate::backend::wayland) fn resolve_system_clipboard() -> ClipboardPasteR
     let Some(mime_type) = image::choose_supported_mime(&offered) else {
         return ClipboardPasteResult::NoSupportedMime { offered };
     };
+    log::info!(
+        "Selected clipboard MIME type '{}' from offered {:?}",
+        mime_type,
+        offered
+    );
     let limit = if mime_type == WAYSCRIBER_SELECTION_MIME {
         MAX_CLIPBOARD_SELECTION_BYTES
     } else {
@@ -156,6 +161,12 @@ pub(in crate::backend::wayland) fn resolve_system_clipboard() -> ClipboardPasteR
         Ok(bytes) => bytes,
         Err(err) => return map_read_error(err),
     };
+    log::info!(
+        "Read clipboard MIME '{}' payload: {} bytes (limit {} bytes)",
+        mime_type,
+        bytes.len(),
+        limit
+    );
 
     if mime_type == WAYSCRIBER_SELECTION_MIME {
         return serde_json::from_slice::<WayscriberClipboardSelection>(&bytes)

--- a/src/backend/wayland/handlers/compositor.rs
+++ b/src/backend/wayland/handlers/compositor.rs
@@ -203,31 +203,14 @@ impl CompositorHandler for WaylandState {
                     options.per_output,
                     options.output_identity()
                 );
-                load_result = Some(session::load_snapshot(options));
+                load_result = Some(session::load_snapshot_with_outcome(options));
                 load_requested = true;
             }
         }
 
         if let Some(result) = load_result {
-            let current_options = self.session_options().cloned();
             match result {
-                Ok(Some(snapshot)) => {
-                    if let Some(ref options) = current_options {
-                        debug!(
-                            "Restoring session from {}",
-                            options.session_file_path().display()
-                        );
-                        session::apply_snapshot(&mut self.input_state, snapshot, options);
-                    }
-                }
-                Ok(None) => {
-                    if let Some(ref options) = current_options {
-                        debug!(
-                            "No session data found for {}",
-                            options.session_file_path().display()
-                        );
-                    }
-                }
+                Ok(outcome) => self.handle_session_load_outcome(outcome, "output load"),
                 Err(err) => {
                     warn!("Failed to load session state: {}", err);
                 }

--- a/src/backend/wayland/handlers/layer.rs
+++ b/src/backend/wayland/handlers/layer.rs
@@ -115,28 +115,12 @@ impl LayerShellHandler for WaylandState {
         if !self.session.is_loaded()
             && let Some(options) = self.session_options_mut()
         {
-            let load_result = session::load_snapshot(options);
+            let load_result = session::load_snapshot_with_outcome(options);
             let mut load_succeeded = false;
-            let current_options = self.session_options().cloned();
             match load_result {
-                Ok(Some(snapshot)) => {
+                Ok(outcome) => {
                     load_succeeded = true;
-                    if let Some(ref opts) = current_options {
-                        debug!(
-                            "Restoring session (fallback) from {}",
-                            opts.session_file_path().display()
-                        );
-                        session::apply_snapshot(&mut self.input_state, snapshot, opts);
-                    }
-                }
-                Ok(None) => {
-                    load_succeeded = true;
-                    if let Some(ref opts) = current_options {
-                        debug!(
-                            "No session data found for {} (fallback load)",
-                            opts.session_file_path().display()
-                        );
-                    }
+                    self.handle_session_load_outcome(outcome, "fallback load");
                 }
                 Err(err) => {
                     warn!("Fallback session load failed: {}", err);

--- a/src/backend/wayland/handlers/xdg.rs
+++ b/src/backend/wayland/handlers/xdg.rs
@@ -141,28 +141,12 @@ impl WindowHandler for WaylandState {
         if !self.session.is_loaded()
             && let Some(options) = self.session_options_mut()
         {
-            let load_result = session::load_snapshot(options);
+            let load_result = session::load_snapshot_with_outcome(options);
             let mut load_succeeded = false;
-            let current_options = self.session_options().cloned();
             match load_result {
-                Ok(Some(snapshot)) => {
+                Ok(outcome) => {
                     load_succeeded = true;
-                    if let Some(ref opts) = current_options {
-                        debug!(
-                            "Restoring session (fallback) from {}",
-                            opts.session_file_path().display()
-                        );
-                        session::apply_snapshot(&mut self.input_state, snapshot, opts);
-                    }
-                }
-                Ok(None) => {
-                    load_succeeded = true;
-                    if let Some(ref opts) = current_options {
-                        debug!(
-                            "No session data found for {} (fallback load)",
-                            opts.session_file_path().display()
-                        );
-                    }
+                    self.handle_session_load_outcome(outcome, "fallback load");
                 }
                 Err(err) => {
                     warn!("Fallback session load failed: {}", err);

--- a/src/backend/wayland/session.rs
+++ b/src/backend/wayland/session.rs
@@ -4,6 +4,8 @@
 //! so WaylandState can coordinate persistence without storing extra fields.
 
 use crate::session::SessionOptions;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 /// Tracks session persistence state and bookkeeping for per-output snapshots.
@@ -16,6 +18,11 @@ pub struct SessionState {
     last_save_at: Option<Instant>,
     autosave_retry_at: Option<Instant>,
     notified_failure: bool,
+    notified_near_limit_paths: HashSet<PathBuf>,
+    notified_trimmed_history: bool,
+    notified_visible_only: bool,
+    protected_session_paths: HashSet<PathBuf>,
+    notified_expanded_load_paths: HashSet<PathBuf>,
 }
 
 impl SessionState {
@@ -30,6 +37,11 @@ impl SessionState {
             last_save_at: None,
             autosave_retry_at: None,
             notified_failure: false,
+            notified_near_limit_paths: HashSet::new(),
+            notified_trimmed_history: false,
+            notified_visible_only: false,
+            protected_session_paths: HashSet::new(),
+            notified_expanded_load_paths: HashSet::new(),
         }
     }
 
@@ -73,6 +85,13 @@ impl SessionState {
         self.notified_failure = false;
     }
 
+    pub fn mark_clean_after_load(&mut self) {
+        self.dirty = false;
+        self.dirty_since = None;
+        self.last_dirty_at = None;
+        self.autosave_retry_at = None;
+    }
+
     pub fn mark_autosave_failure(&mut self, now: Instant, backoff: Duration) -> bool {
         self.autosave_retry_at = Some(now + backoff);
         if self.notified_failure {
@@ -81,6 +100,40 @@ impl SessionState {
             self.notified_failure = true;
             true
         }
+    }
+
+    pub fn mark_near_limit_notified(&mut self, path: &Path) -> bool {
+        self.notified_near_limit_paths.insert(path.to_path_buf())
+    }
+
+    pub fn mark_trimmed_history_notified(&mut self) -> bool {
+        if self.notified_trimmed_history {
+            false
+        } else {
+            self.notified_trimmed_history = true;
+            true
+        }
+    }
+
+    pub fn mark_visible_only_notified(&mut self) -> bool {
+        if self.notified_visible_only {
+            false
+        } else {
+            self.notified_visible_only = true;
+            true
+        }
+    }
+
+    pub fn protect_session_path(&mut self, path: PathBuf) {
+        self.protected_session_paths.insert(path);
+    }
+
+    pub fn mark_expanded_load_notified(&mut self, path: &Path) -> bool {
+        self.notified_expanded_load_paths.insert(path.to_path_buf())
+    }
+
+    pub fn should_skip_save_for_protected_path(&self, path: &Path, input_dirty: bool) -> bool {
+        self.protected_session_paths.contains(path) && !self.dirty && !input_dirty
     }
 
     pub fn autosave_due(&self, now: Instant, options: &SessionOptions) -> bool {
@@ -166,5 +219,38 @@ mod tests {
             state.autosave_timeout(later, &options),
             Some(Duration::from_millis(0))
         );
+    }
+
+    #[test]
+    fn protected_session_path_blocks_save_until_session_is_dirty() {
+        let mut options = SessionOptions::new(PathBuf::from("/tmp"), "display");
+        options.autosave_enabled = true;
+        options.persist_transparent = true;
+        let path = options.session_file_path();
+        let mut state = SessionState::new(Some(options.clone()));
+
+        assert!(!state.should_skip_save_for_protected_path(&path, false));
+        state.protect_session_path(path.clone());
+        assert!(state.should_skip_save_for_protected_path(&path, false));
+        assert!(!state.should_skip_save_for_protected_path(&path, true));
+
+        state.record_input_dirty(Instant::now(), true);
+        assert!(!state.should_skip_save_for_protected_path(&path, false));
+    }
+
+    #[test]
+    fn load_baseline_clears_stale_dirty_before_protected_save_check() {
+        let mut options = SessionOptions::new(PathBuf::from("/tmp"), "display");
+        options.autosave_enabled = true;
+        options.persist_transparent = true;
+        let path = options.session_file_path();
+        let mut state = SessionState::new(Some(options));
+
+        state.record_input_dirty(Instant::now(), true);
+        state.protect_session_path(path.clone());
+        assert!(!state.should_skip_save_for_protected_path(&path, false));
+
+        state.mark_clean_after_load();
+        assert!(state.should_skip_save_for_protected_path(&path, false));
     }
 }

--- a/src/backend/wayland/state/clipboard.rs
+++ b/src/backend/wayland/state/clipboard.rs
@@ -8,7 +8,11 @@ use crate::backend::wayland::clipboard::{
 };
 use crate::input::state::{ClipboardPasteRequest, UiToastKind};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+mod session_paste;
+
+use session_paste::{PastePersistenceDecision, SessionPasteWarning};
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn drain_clipboard_requests(&mut self) {
@@ -71,6 +75,13 @@ impl WaylandState {
     }
 
     fn start_clipboard_paste(&mut self, request: ClipboardPasteRequest) {
+        log::info!(
+            "Starting clipboard paste request {} for board '{}' page {} generation {}",
+            request.id,
+            request.target_board_id,
+            request.target_page_index,
+            request.target_page_generation
+        );
         self.suppress_focus_exit_for(Duration::from_millis(1500));
 
         let pending_shapes = self.input_state.local_selection_shapes_for_pending_publish(
@@ -91,6 +102,12 @@ impl WaylandState {
 
     fn apply_clipboard_paste_completion(&mut self, completion: ClipboardPasteCompletion) {
         let active_request_id = self.input_state.active_clipboard_paste_request_id();
+        log::info!(
+            "Applying clipboard paste completion {} with active_request={:?}: {}",
+            completion.request.id,
+            active_request_id,
+            completion.result.summary()
+        );
         let private_payload = match &completion.result {
             ClipboardPasteResult::PrivateSelection(payload)
                 if active_request_id == Some(completion.request.id) =>
@@ -173,11 +190,54 @@ impl WaylandState {
                 }
             }
             PasteAction::ApplyExternalImage { request, image } => {
-                if !self
-                    .input_state
-                    .paste_external_image_from_request(&request, image)
+                let mime_type = image.mime_type.clone();
+                let image_width = image.width;
+                let image_height = image.height;
+                let image_bytes = image.bytes.len();
+                let persistence_warning = match self
+                    .session_paste_preflight_message(&request, &image)
                 {
+                    Ok(PastePersistenceDecision::Allow { warning }) => warning,
+                    Ok(PastePersistenceDecision::Block { warning }) => {
+                        log::warn!(
+                            "External image paste request {} rejected by session size preflight: {}",
+                            request.id,
+                            warning.log_detail
+                        );
+                        self.show_session_paste_warning(warning);
+                        self.input_state.trigger_blocked_feedback();
+                        self.input_state.finish_clipboard_paste_request(request.id);
+                        return;
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "External image paste request {} could not be checked against session size limits: {}",
+                            request.id,
+                            err
+                        );
+                        Some(SessionPasteWarning::toast_only(
+                            "Could not check session size; this image may not persist.",
+                        ))
+                    }
+                };
+                let pasted = self
+                    .input_state
+                    .paste_external_image_from_request(&request, image);
+                log::info!(
+                    "Applied external image paste request {} to board '{}' page {}: success={}, mime={}, dimensions={}x{}, bytes={}",
+                    request.id,
+                    request.target_board_id,
+                    request.target_page_index,
+                    pasted,
+                    mime_type,
+                    image_width,
+                    image_height,
+                    image_bytes
+                );
+                if !pasted {
                     self.input_state.trigger_blocked_feedback();
+                } else if let Some(warning) = persistence_warning {
+                    self.show_session_paste_warning(warning);
                 }
                 self.input_state.finish_clipboard_paste_request(request.id);
             }
@@ -208,10 +268,18 @@ impl WaylandState {
     }
 
     fn start_system_clipboard_read(&mut self, request: ClipboardPasteRequest) {
+        log::info!("Reading system clipboard for paste request {}", request.id);
         let (tx, rx) = mpsc::channel();
         self.clipboard_paste_rx = Some(rx);
         std::thread::spawn(move || {
+            let started = Instant::now();
             let result = transfer::resolve_system_clipboard();
+            log::info!(
+                "System clipboard read for paste request {} completed in {:?}: {}",
+                request.id,
+                started.elapsed(),
+                result.summary()
+            );
             let _ = tx.send(ClipboardPasteCompletion { request, result });
         });
     }

--- a/src/backend/wayland/state/clipboard/session_paste.rs
+++ b/src/backend/wayland/state/clipboard/session_paste.rs
@@ -1,0 +1,432 @@
+use super::super::WaylandState;
+use crate::config::{Action, Config};
+use crate::draw::frame::UndoAction;
+use crate::draw::{EmbeddedImage, Shape};
+use crate::input::InputState;
+use crate::input::boards::BoardState;
+use crate::input::state::{ClipboardPasteRequest, UiToastKind};
+use crate::{notification, session};
+use std::path::PathBuf;
+use std::time::Instant;
+
+const SESSION_PASTE_WARNING_TOAST_MS: u64 = 20_000;
+const SESSION_PASTE_NOTIFICATION_TIMEOUT_MS: i32 = 15_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PastePersistenceDecision {
+    Allow {
+        warning: Option<SessionPasteWarning>,
+    },
+    Block {
+        warning: SessionPasteWarning,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SessionPasteWarning {
+    pub(super) toast: String,
+    pub(super) notification: Option<(String, String)>,
+    pub(super) log_detail: String,
+}
+
+impl SessionPasteWarning {
+    pub(super) fn toast_only(message: impl Into<String>) -> Self {
+        let toast = message.into();
+        Self {
+            log_detail: toast.clone(),
+            toast,
+            notification: None,
+        }
+    }
+}
+
+impl WaylandState {
+    pub(super) fn session_paste_preflight_message(
+        &self,
+        request: &ClipboardPasteRequest,
+        image: &EmbeddedImage,
+    ) -> Result<PastePersistenceDecision, anyhow::Error> {
+        let Some(options) = self.session_options() else {
+            return Ok(PastePersistenceDecision::Allow { warning: None });
+        };
+        if !session_persistence_enabled(options) {
+            return Ok(PastePersistenceDecision::Allow { warning: None });
+        }
+        let preflight_started = Instant::now();
+        let snapshot_started = Instant::now();
+        let Some(snapshot) = self.snapshot_after_external_image_paste(request, image, options)
+        else {
+            return Ok(PastePersistenceDecision::Allow { warning: None });
+        };
+        let snapshot_elapsed = snapshot_started.elapsed();
+
+        let visible_estimate_started = Instant::now();
+        let visible_estimate =
+            session::estimate_snapshot_without_history_payload(&snapshot, options)?;
+        let visible_estimate_elapsed = visible_estimate_started.elapsed();
+        if visible_estimate.limit_exceeded.is_some() {
+            let estimate = session::SnapshotSaveEstimate {
+                full: visible_estimate,
+                visible_without_history: visible_estimate,
+            };
+            log::info!(
+                "Session paste preflight for request {} completed in {:?}: snapshot={:?}, visible_estimate={:?}, full_estimate=skipped, visible_written={} bytes, max_file_size={} bytes, visible_limit={:?}",
+                request.id,
+                preflight_started.elapsed(),
+                snapshot_elapsed,
+                visible_estimate_elapsed,
+                visible_estimate.written_size,
+                options.max_file_size_bytes,
+                visible_estimate.limit_exceeded
+            );
+            return Ok(paste_persistence_decision(&estimate, options));
+        }
+
+        let full_estimate_started = Instant::now();
+        let full_estimate = session::estimate_snapshot_payload(&snapshot, options)?;
+        let full_estimate_elapsed = full_estimate_started.elapsed();
+        let estimate = session::SnapshotSaveEstimate {
+            full: full_estimate,
+            visible_without_history: visible_estimate,
+        };
+        log::info!(
+            "Session paste preflight for request {} completed in {:?}: snapshot={:?}, visible_estimate={:?}, full_estimate={:?}, full_written={} bytes, visible_written={} bytes, max_file_size={} bytes, full_limit={:?}, visible_limit={:?}",
+            request.id,
+            preflight_started.elapsed(),
+            snapshot_elapsed,
+            visible_estimate_elapsed,
+            full_estimate_elapsed,
+            estimate.full.written_size,
+            estimate.visible_without_history.written_size,
+            options.max_file_size_bytes,
+            estimate.full.limit_exceeded,
+            estimate.visible_without_history.limit_exceeded
+        );
+        Ok(paste_persistence_decision(&estimate, options))
+    }
+
+    fn snapshot_after_external_image_paste(
+        &self,
+        request: &ClipboardPasteRequest,
+        image: &EmbeddedImage,
+        options: &session::SessionOptions,
+    ) -> Option<session::SessionSnapshot> {
+        snapshot_after_external_image_paste_from_input(&self.input_state, request, image, options)
+    }
+
+    pub(super) fn show_session_paste_warning(&mut self, warning: SessionPasteWarning) {
+        self.input_state.set_ui_toast_with_action_and_duration(
+            UiToastKind::Warning,
+            warning.toast,
+            "Settings",
+            Action::OpenConfigurator,
+            SESSION_PASTE_WARNING_TOAST_MS,
+        );
+        if let Some((summary, body)) = warning.notification {
+            notification::send_notification_with_timeout_async(
+                &self.tokio_handle,
+                summary,
+                body,
+                Some("dialog-warning".to_string()),
+                SESSION_PASTE_NOTIFICATION_TIMEOUT_MS,
+            );
+        }
+    }
+}
+
+fn snapshot_after_external_image_paste_from_input(
+    input: &InputState,
+    request: &ClipboardPasteRequest,
+    image: &EmbeddedImage,
+    options: &session::SessionOptions,
+) -> Option<session::SessionSnapshot> {
+    let target_board = input
+        .boards
+        .board_states()
+        .iter()
+        .find(|board| board.spec.id == request.target_board_id)?;
+    if target_board.pages.generation() != request.target_page_generation {
+        log::info!(
+            "Skipping session paste preflight for request {} because target board '{}' generation changed from {} to {}",
+            request.id,
+            request.target_board_id,
+            request.target_page_generation,
+            target_board.pages.generation()
+        );
+        return None;
+    }
+
+    let mut snapshot =
+        session::snapshot_from_input(input, options).unwrap_or_else(|| session::SessionSnapshot {
+            active_board_id: input.board_id().to_string(),
+            boards: Vec::new(),
+            tool_state: None,
+        });
+
+    if !snapshot
+        .boards
+        .iter()
+        .any(|board| board.id == request.target_board_id)
+    {
+        if !board_should_persist(target_board, options) {
+            return None;
+        }
+        snapshot.boards.push(session::BoardSnapshot {
+            id: target_board.spec.id.clone(),
+            pages: snapshot_pages_for_preflight(target_board, input, options),
+        });
+    }
+
+    let board = snapshot
+        .boards
+        .iter_mut()
+        .find(|board| board.id == request.target_board_id)?;
+    let frame = board.pages.pages.get_mut(request.target_page_index)?;
+    let shape = Shape::Image {
+        x: 0,
+        y: 0,
+        w: i32::try_from(image.width).unwrap_or(i32::MAX).max(1),
+        h: i32::try_from(image.height).unwrap_or(i32::MAX).max(1),
+        data: image.clone(),
+    };
+    let id = frame.try_add_shape_with_id(shape, input.max_shapes_per_frame)?;
+    let history_limit = options.effective_history_limit(input.undo_stack_limit);
+    if history_limit > 0 {
+        let (index, stored) = frame
+            .find_index(id)
+            .and_then(|index| frame.shape(id).map(|shape| (index, shape.clone())))?;
+        frame.push_undo_action(
+            UndoAction::Create {
+                shapes: vec![(index, stored)],
+            },
+            history_limit,
+        );
+    }
+    Some(snapshot)
+}
+
+fn board_should_persist(board: &BoardState, options: &session::SessionOptions) -> bool {
+    if board.spec.background.is_transparent() {
+        options.persist_transparent
+    } else {
+        (options.persist_whiteboard || options.persist_blackboard) && board.spec.persist
+    }
+}
+
+fn snapshot_pages_for_preflight(
+    board: &BoardState,
+    input: &InputState,
+    options: &session::SessionOptions,
+) -> session::BoardPagesSnapshot {
+    let history_limit = options.effective_history_limit(input.undo_stack_limit);
+    let mut pages = board.pages.pages().to_vec();
+    for page in &mut pages {
+        if history_limit == 0 {
+            page.clamp_history_depth(0);
+        } else if history_limit < usize::MAX {
+            page.clamp_history_depth(history_limit);
+        }
+    }
+    session::BoardPagesSnapshot {
+        pages,
+        active: board.pages.active_index(),
+    }
+}
+
+fn paste_persistence_decision(
+    estimate: &session::SnapshotSaveEstimate,
+    options: &session::SessionOptions,
+) -> PastePersistenceDecision {
+    let limit = format_bytes(options.max_file_size_bytes);
+    if let Some(limit_exceeded) = estimate.visible_without_history.limit_exceeded {
+        let warning = visible_limit_warning(
+            limit_exceeded,
+            &estimate.visible_without_history,
+            &limit,
+            options,
+        );
+        return PastePersistenceDecision::Block { warning };
+    }
+
+    if let Some(limit_exceeded) = estimate.full.limit_exceeded {
+        return PastePersistenceDecision::Allow {
+            warning: Some(full_limit_warning(limit_exceeded, &estimate.full, options)),
+        };
+    }
+
+    if estimate.full.is_near_limit() {
+        let written = format_bytes(estimate.full.written_size as u64);
+        let suggested_limit_mb = suggested_limit_mb(
+            estimate.full.written_size as u64,
+            options.max_file_size_bytes,
+        );
+        return PastePersistenceDecision::Allow {
+            warning: Some(SessionPasteWarning::toast_only(format!(
+                "Image pasted. Session near limit: {written}/{limit}. Consider {suggested_limit_mb} MiB."
+            ))),
+        };
+    }
+
+    PastePersistenceDecision::Allow { warning: None }
+}
+
+fn visible_limit_warning(
+    limit_exceeded: session::SaveLimitExceeded,
+    estimate: &session::SnapshotPayloadEstimate,
+    formatted_file_limit: &str,
+    options: &session::SessionOptions,
+) -> SessionPasteWarning {
+    match limit_exceeded {
+        session::SaveLimitExceeded::WrittenSize { .. } => {
+            let suggested_limit_mb =
+                suggested_limit_mb(estimate.written_size as u64, options.max_file_size_bytes);
+            let written = format_bytes(estimate.written_size as u64);
+            let toast = format!(
+                "Image blocked: {written}/{formatted_file_limit}. Set {suggested_limit_mb} MiB."
+            );
+            let body = format!(
+                "Paste would save as {written}, over the {formatted_file_limit} cap. Open Settings > Session > Max file size and set {suggested_limit_mb} MiB, or edit {}.",
+                config_path_display()
+            );
+            SessionPasteWarning {
+                toast,
+                notification: Some(("Image Paste Blocked".to_string(), body)),
+                log_detail: format!(
+                    "visible payload {}, suggested max_file_size_mb={suggested_limit_mb}",
+                    describe_limit(limit_exceeded)
+                ),
+            }
+        }
+        session::SaveLimitExceeded::ExpandedSize {
+            raw_size,
+            max_expanded_size,
+        } => {
+            let raw = format_bytes(raw_size);
+            let expanded_limit = format_bytes(max_expanded_size);
+            SessionPasteWarning {
+                toast: format!("Image blocked: restore safety {raw}/{expanded_limit}."),
+                notification: Some((
+                    "Image Paste Blocked".to_string(),
+                    format!(
+                        "Paste would expand to {raw}, over the {expanded_limit} restore safety limit. Reduce images or history; max_file_size_mb will not help."
+                    ),
+                )),
+                log_detail: format!("visible payload {}", describe_limit(limit_exceeded)),
+            }
+        }
+    }
+}
+
+fn full_limit_warning(
+    limit_exceeded: session::SaveLimitExceeded,
+    estimate: &session::SnapshotPayloadEstimate,
+    options: &session::SessionOptions,
+) -> SessionPasteWarning {
+    match limit_exceeded {
+        session::SaveLimitExceeded::WrittenSize { .. } => {
+            let suggested_limit_mb =
+                suggested_limit_mb(estimate.written_size as u64, options.max_file_size_bytes);
+            let toast =
+                format!("Image pasted. Undo history may be dropped. Set {suggested_limit_mb} MiB.");
+            let body = format!(
+                "Drawing data fits, but undo history may be dropped on save. Set Session > Max file size to {suggested_limit_mb} MiB, or edit {}.",
+                config_path_display()
+            );
+            SessionPasteWarning {
+                toast,
+                notification: Some(("Session Undo History at Risk".to_string(), body)),
+                log_detail: format!(
+                    "full payload {}, suggested max_file_size_mb={suggested_limit_mb}",
+                    describe_limit(limit_exceeded)
+                ),
+            }
+        }
+        session::SaveLimitExceeded::ExpandedSize {
+            raw_size,
+            max_expanded_size,
+        } => {
+            let raw = format_bytes(raw_size);
+            let expanded_limit = format_bytes(max_expanded_size);
+            SessionPasteWarning {
+                toast: "Image pasted. Undo history may be dropped for restore safety.".to_string(),
+                notification: Some((
+                    "Session Undo History at Risk".to_string(),
+                    format!(
+                        "Full session would expand to {raw}, over the {expanded_limit} restore safety limit. Visible drawing data can still be saved."
+                    ),
+                )),
+                log_detail: format!("full payload {}", describe_limit(limit_exceeded)),
+            }
+        }
+    }
+}
+
+fn session_persistence_enabled(options: &session::SessionOptions) -> bool {
+    options.any_enabled() || options.restore_tool_state || options.persist_history
+}
+
+fn suggested_limit_mb(projected_written_size: u64, current_limit_bytes: u64) -> u64 {
+    const MIB: u64 = 1024 * 1024;
+    let projected_mb = projected_written_size.div_ceil(MIB);
+    let current_mb = current_limit_bytes.div_ceil(MIB);
+    projected_mb
+        .saturating_mul(3)
+        .div_ceil(2)
+        .max(current_mb.saturating_mul(3).div_ceil(2))
+        .clamp(1, 1024)
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} bytes")
+    }
+}
+
+fn describe_limit(limit: session::SaveLimitExceeded) -> String {
+    match limit {
+        session::SaveLimitExceeded::WrittenSize {
+            written_size,
+            max_file_size,
+        } => format!(
+            "writes as {} and exceeds configured cap {}",
+            format_bytes(written_size),
+            format_bytes(max_file_size)
+        ),
+        session::SaveLimitExceeded::ExpandedSize {
+            raw_size,
+            max_expanded_size,
+        } => format!(
+            "expands to {} and exceeds restore safety cap {}",
+            format_bytes(raw_size),
+            format_bytes(max_expanded_size)
+        ),
+    }
+}
+
+fn config_path_display() -> String {
+    Config::get_config_path()
+        .map(compact_path)
+        .unwrap_or_else(|_| "~/.config/wayscriber/config.toml".to_string())
+}
+
+fn compact_path(path: PathBuf) -> String {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return path.display().to_string();
+    };
+    match path.strip_prefix(&home) {
+        Ok(stripped) if !stripped.as_os_str().is_empty() => {
+            format!("~/{}", stripped.display())
+        }
+        Ok(_) => "~".to_string(),
+        Err(_) => path.display().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/wayland/state/clipboard/session_paste/tests.rs
+++ b/src/backend/wayland/state/clipboard/session_paste/tests.rs
@@ -1,0 +1,256 @@
+use super::*;
+use crate::draw::Color;
+use crate::input::BOARD_ID_TRANSPARENT;
+use crate::input::state::{PasteAnchor, test_support::make_test_input_state};
+use crate::session::{CompressionMode, SnapshotPayloadEstimate, SnapshotSaveEstimate};
+use crate::util::Rect;
+use std::path::PathBuf;
+
+#[test]
+fn paste_preflight_synthesizes_empty_persisted_target_board() {
+    let input = make_test_input_state();
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.persist_transparent = true;
+    options.restore_tool_state = false;
+
+    assert!(
+        session::snapshot_from_input(&input, &options).is_none(),
+        "empty boards are omitted from ordinary snapshots"
+    );
+
+    let snapshot = snapshot_after_external_image_paste_from_input(
+        &input,
+        &request_for_active_board(&input),
+        &test_image(128),
+        &options,
+    )
+    .expect("preflight snapshot");
+
+    assert_eq!(snapshot.boards.len(), 1);
+    assert_eq!(snapshot.boards[0].id, BOARD_ID_TRANSPARENT);
+    assert_eq!(snapshot.boards[0].pages.pages.len(), 1);
+    assert_eq!(snapshot.boards[0].pages.pages[0].shapes.len(), 1);
+    assert_eq!(snapshot.boards[0].pages.pages[0].undo_stack_len(), 1);
+}
+
+#[test]
+fn paste_preflight_does_not_synthesize_non_persisted_target_board() {
+    let input = make_test_input_state();
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.persist_transparent = false;
+    options.restore_tool_state = true;
+
+    let snapshot = snapshot_after_external_image_paste_from_input(
+        &input,
+        &request_for_active_board(&input),
+        &test_image(128),
+        &options,
+    );
+
+    assert!(snapshot.is_none());
+}
+
+#[test]
+fn paste_preflight_skips_stale_target_page_generation() {
+    let mut input = make_test_input_state();
+    input.boards.active_frame_mut().add_shape(Shape::Rect {
+        x: 1,
+        y: 2,
+        w: 3,
+        h: 4,
+        fill: false,
+        color: Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 1.0,
+    });
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.persist_transparent = true;
+    options.restore_tool_state = false;
+
+    assert!(
+        session::snapshot_from_input(&input, &options).is_some(),
+        "non-empty board would otherwise be eligible for preflight"
+    );
+    let mut request = request_for_active_board(&input);
+    request.target_page_generation = request.target_page_generation.wrapping_add(1);
+
+    let snapshot = snapshot_after_external_image_paste_from_input(
+        &input,
+        &request,
+        &test_image(128),
+        &options,
+    );
+
+    assert!(
+        snapshot.is_none(),
+        "stale target generation should bypass size preflight so paste reports target changed"
+    );
+}
+
+#[test]
+fn paste_decision_blocks_when_visible_data_exceeds_limit() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.max_file_size_bytes = 10 * 1024 * 1024;
+    let estimate = estimate(13 * 1024 * 1024, 13 * 1024 * 1024, &options);
+
+    match paste_persistence_decision(&estimate, &options) {
+        PastePersistenceDecision::Block { warning } => {
+            assert!(warning.toast.contains("Image blocked"));
+            assert!(warning.toast.contains("20 MiB"));
+        }
+        other => panic!("expected block decision, got {other:?}"),
+    }
+}
+
+#[test]
+fn paste_decision_blocks_expanded_visible_data_with_restore_safety_message() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.max_file_size_bytes = 10 * 1024 * 1024;
+    let estimate = SnapshotSaveEstimate {
+        full: expanded_payload_estimate(&options),
+        visible_without_history: expanded_payload_estimate(&options),
+    };
+
+    match paste_persistence_decision(&estimate, &options) {
+        PastePersistenceDecision::Block { warning } => {
+            assert!(warning.toast.contains("restore safety"));
+            let body = warning
+                .notification
+                .as_ref()
+                .map(|(_, body)| body.as_str())
+                .unwrap_or_default();
+            assert!(body.contains("restore safety limit"));
+            assert!(body.contains("max_file_size_mb will not help"));
+        }
+        other => panic!("expected expanded-size block decision, got {other:?}"),
+    }
+}
+
+#[test]
+fn paste_decision_allows_with_warning_when_only_history_exceeds_limit() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.max_file_size_bytes = 10 * 1024 * 1024;
+    let estimate = estimate(12 * 1024 * 1024, 8 * 1024 * 1024, &options);
+
+    match paste_persistence_decision(&estimate, &options) {
+        PastePersistenceDecision::Allow {
+            warning: Some(warning),
+        } => {
+            assert!(warning.toast.contains("Undo history may be dropped"));
+            assert!(warning.toast.contains("18 MiB"));
+        }
+        other => panic!("expected warning decision, got {other:?}"),
+    }
+}
+
+#[test]
+fn paste_decision_warns_for_expanded_history_without_file_size_advice() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.max_file_size_bytes = 10 * 1024 * 1024;
+    let estimate = SnapshotSaveEstimate {
+        full: expanded_payload_estimate(&options),
+        visible_without_history: payload_estimate(8 * 1024 * 1024, &options),
+    };
+
+    match paste_persistence_decision(&estimate, &options) {
+        PastePersistenceDecision::Allow {
+            warning: Some(warning),
+        } => {
+            assert!(warning.toast.contains("restore safety"));
+            let body = warning
+                .notification
+                .as_ref()
+                .map(|(_, body)| body.as_str())
+                .unwrap_or_default();
+            assert!(body.contains("restore safety limit"));
+            assert!(!body.contains("Max file size"));
+        }
+        other => panic!("expected expanded history warning decision, got {other:?}"),
+    }
+}
+
+#[test]
+fn paste_decision_warns_when_full_payload_is_near_limit() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display");
+    options.max_file_size_bytes = 10 * 1024 * 1024;
+    let estimate = estimate(9 * 1024 * 1024, 9 * 1024 * 1024, &options);
+
+    match paste_persistence_decision(&estimate, &options) {
+        PastePersistenceDecision::Allow {
+            warning: Some(warning),
+        } => {
+            assert!(warning.toast.contains("Session near limit"));
+            assert!(warning.toast.contains("15 MiB"));
+        }
+        other => panic!("expected near-limit warning, got {other:?}"),
+    }
+}
+
+fn request_for_active_board(input: &InputState) -> ClipboardPasteRequest {
+    ClipboardPasteRequest {
+        id: 1,
+        target_board_id: input.board_id().to_string(),
+        target_page_index: input.boards.active_page_index(),
+        target_page_generation: input.boards.active_page_generation(),
+        anchor: PasteAnchor::VisibleCenter { x: 10, y: 10 },
+        visible_canvas_rect: Rect::new(0, 0, 100, 100).expect("rect"),
+        screen_size: (100, 100),
+        selection_clipboard_generation_at_request: 0,
+        local_selection_fallback_generation: None,
+    }
+}
+
+fn test_image(bytes: usize) -> EmbeddedImage {
+    EmbeddedImage {
+        mime_type: "image/png".to_string(),
+        width: 16,
+        height: 16,
+        bytes: vec![7; bytes],
+    }
+}
+
+fn estimate(
+    full_written: u64,
+    visible_written: u64,
+    options: &session::SessionOptions,
+) -> SnapshotSaveEstimate {
+    SnapshotSaveEstimate {
+        full: payload_estimate(full_written, options),
+        visible_without_history: payload_estimate(visible_written, options),
+    }
+}
+
+fn payload_estimate(
+    written_size: u64,
+    options: &session::SessionOptions,
+) -> SnapshotPayloadEstimate {
+    SnapshotPayloadEstimate {
+        raw_size: written_size as usize,
+        written_size: written_size as usize,
+        max_file_size_bytes: options.max_file_size_bytes,
+        compressed: matches!(options.compression, CompressionMode::On),
+        limit_exceeded: (written_size > options.max_file_size_bytes).then_some(
+            session::SaveLimitExceeded::WrittenSize {
+                written_size,
+                max_file_size: options.max_file_size_bytes,
+            },
+        ),
+    }
+}
+
+fn expanded_payload_estimate(options: &session::SessionOptions) -> SnapshotPayloadEstimate {
+    SnapshotPayloadEstimate {
+        raw_size: 129 * 1024 * 1024,
+        written_size: 2 * 1024 * 1024,
+        max_file_size_bytes: options.max_file_size_bytes,
+        compressed: true,
+        limit_exceeded: Some(session::SaveLimitExceeded::ExpandedSize {
+            raw_size: 129 * 1024 * 1024,
+            max_expanded_size: 128 * 1024 * 1024,
+        }),
+    }
+}

--- a/src/backend/wayland/state/core/output.rs
+++ b/src/backend/wayland/state/core/output.rs
@@ -1,10 +1,11 @@
-use log::{info, warn};
+use log::{debug, info, warn};
 use smithay_client_toolkit::shell::{WaylandSurface, wlr_layer::Anchor};
 use std::time::Instant;
 
 use super::super::*;
 use crate::{
     input::state::{OutputFocusAction, UiToastKind},
+    notification,
     session::{self, SessionSnapshot},
 };
 
@@ -124,6 +125,10 @@ impl WaylandState {
         };
         save_options.set_output_identity(output_identity.as_deref());
 
+        if self.should_skip_protected_session_save(&save_options) {
+            return;
+        }
+
         let save_result = if let Some(snapshot) =
             session::snapshot_from_input(&self.input_state, &save_options)
         {
@@ -162,6 +167,73 @@ impl WaylandState {
                 err
             ),
         }
+    }
+
+    pub(in crate::backend::wayland) fn handle_session_load_outcome(
+        &mut self,
+        outcome: session::LoadSnapshotOutcome,
+        context: &str,
+    ) {
+        match outcome {
+            session::LoadSnapshotOutcome::Loaded(snapshot) => {
+                if let Some(options) = self.session_options().cloned() {
+                    debug!(
+                        "Restoring session {} from {}",
+                        context,
+                        options.session_file_path().display()
+                    );
+                    session::apply_snapshot(&mut self.input_state, *snapshot, &options);
+                }
+            }
+            session::LoadSnapshotOutcome::Empty => {
+                if let Some(options) = self.session_options() {
+                    debug!(
+                        "No session data found for {} ({})",
+                        options.session_file_path().display(),
+                        context
+                    );
+                }
+            }
+            session::LoadSnapshotOutcome::ExpandedTooLarge {
+                path,
+                max_expanded_size,
+            } => {
+                self.session.protect_session_path(path.clone());
+                if self.session.mark_expanded_load_notified(&path) {
+                    notification::send_notification_async(
+                        &self.tokio_handle,
+                        "Session Too Large to Restore".to_string(),
+                        format!(
+                            "The saved session was left unchanged because it expands beyond the {} MiB safety cap. Clear the session or move {} if it is no longer needed.",
+                            max_expanded_size / 1024 / 1024,
+                            path.display()
+                        ),
+                        Some("dialog-warning".to_string()),
+                    );
+                }
+            }
+        }
+        self.mark_clean_after_session_load();
+    }
+
+    fn mark_clean_after_session_load(&mut self) {
+        self.input_state.clear_session_dirty();
+        self.session.mark_clean_after_load();
+    }
+
+    fn should_skip_protected_session_save(&self, options: &session::SessionOptions) -> bool {
+        let session_path = options.session_file_path();
+        let skip = self.session.should_skip_save_for_protected_path(
+            &session_path,
+            self.input_state.is_session_dirty(),
+        );
+        if skip {
+            info!(
+                "Skipping session save to {} because a previous oversized compressed session was left protected and no session changes have been made",
+                session_path.display()
+            );
+        }
+        skip
     }
 
     fn session_persistence_enabled(options: &session::SessionOptions) -> bool {

--- a/src/config/types/session.rs
+++ b/src/config/types/session.rs
@@ -156,7 +156,7 @@ fn default_max_shapes_per_frame() -> usize {
 }
 
 fn default_max_file_size_mb() -> u64 {
-    10
+    50
 }
 
 fn default_session_compression() -> SessionCompression {

--- a/src/daemon/overlay/process.rs
+++ b/src/daemon/overlay/process.rs
@@ -10,7 +10,13 @@ use super::super::types::OverlayState;
 impl Daemon {
     pub(super) fn terminate_overlay_process(&mut self) -> Result<()> {
         if let Some(mut child) = self.overlay_child.take() {
-            info!("Stopping overlay process (pid {})", child.id());
+            let stop_started = Instant::now();
+            let timeout = Duration::from_secs(2);
+            info!(
+                "Stopping overlay process (pid {}, graceful_timeout={:?})",
+                child.id(),
+                timeout
+            );
             #[cfg(unix)]
             {
                 if unsafe { libc::kill(child.id() as i32, libc::SIGTERM) } != 0 {
@@ -27,18 +33,36 @@ impl Daemon {
                 }
             }
 
-            let deadline = Instant::now() + Duration::from_secs(2);
+            let deadline = Instant::now() + timeout;
             loop {
                 match child.try_wait() {
                     Ok(Some(status)) => {
-                        info!("Overlay process exited with status {:?}", status);
+                        info!(
+                            "Overlay process exited with status {:?} after {:?}",
+                            status,
+                            stop_started.elapsed()
+                        );
                         break;
                     }
                     Ok(None) => {
                         if Instant::now() >= deadline {
-                            warn!("Overlay process did not exit, sending SIGKILL");
+                            warn!(
+                                "Overlay process did not exit after {:?}, sending SIGKILL",
+                                stop_started.elapsed()
+                            );
                             let _ = child.kill();
-                            let _ = child.wait();
+                            match child.wait() {
+                                Ok(status) => warn!(
+                                    "Overlay process killed with status {:?} after {:?}",
+                                    status,
+                                    stop_started.elapsed()
+                                ),
+                                Err(err) => warn!(
+                                    "Failed to wait for killed overlay process after {:?}: {}",
+                                    stop_started.elapsed(),
+                                    err
+                                ),
+                            }
                             break;
                         }
                         thread::sleep(Duration::from_millis(50));

--- a/src/daemon/tray/helpers.rs
+++ b/src/daemon/tray/helpers.rs
@@ -43,11 +43,12 @@ impl WayscriberTray {
             }
             Err(err) => {
                 let not_found = err.kind() == ErrorKind::NotFound;
-                if not_found {
+                let opened_config = if not_found {
                     error!(
                         "Configurator not found (looked for '{}'). Install 'wayscriber-configurator' (Arch: yay -S wayscriber-configurator; deb/rpm users: grab the wayscriber-configurator package from the release page) or set WAYSCRIBER_CONFIGURATOR to its path.",
                         self.configurator_binary
                     );
+                    self.open_config_file()
                 } else {
                     error!(
                         "Failed to launch wayscriber-configurator using '{}': {}",
@@ -56,11 +57,14 @@ impl WayscriberTray {
                     error!(
                         "Set WAYSCRIBER_CONFIGURATOR to override the executable path if needed."
                     );
-                }
+                    false
+                };
                 #[cfg(feature = "dbus")]
                 {
-                    let body = if not_found {
-                        "Install wayscriber-configurator or set WAYSCRIBER_CONFIGURATOR to its path."
+                    let body = if opened_config {
+                        "Configurator not found; opened config.toml with the default application."
+                    } else if not_found {
+                        "Configurator not found, and config.toml could not be opened."
                     } else {
                         "Failed to launch configurator; see logs for details."
                     };
@@ -196,12 +200,12 @@ impl WayscriberTray {
         }
     }
 
-    pub(super) fn open_config_file(&self) {
+    pub(super) fn open_config_file(&self) -> bool {
         let path = match Config::get_config_path() {
             Ok(p) => p,
             Err(err) => {
                 warn!("Unable to resolve config path: {}", err);
-                return;
+                return false;
             }
         };
 
@@ -221,12 +225,18 @@ impl WayscriberTray {
         }
 
         match cmd.spawn() {
-            Ok(child) => info!(
-                "Opened config file at {} (pid {})",
-                path.display(),
-                child.id()
-            ),
-            Err(err) => warn!("Failed to open config file at {}: {}", path.display(), err),
+            Ok(child) => {
+                info!(
+                    "Opened config file at {} (pid {})",
+                    path.display(),
+                    child.id()
+                );
+                true
+            }
+            Err(err) => {
+                warn!("Failed to open config file at {}: {}", path.display(), err);
+                false
+            }
         }
     }
 

--- a/src/input/state/core/selection_actions/clipboard.rs
+++ b/src/input/state/core/selection_actions/clipboard.rs
@@ -488,9 +488,18 @@ impl InputState {
         image: EmbeddedImage,
     ) -> bool {
         if self.active_clipboard_paste_request_id != Some(request.id) {
+            log::info!(
+                "Ignoring external image paste request {} because active request is {:?}",
+                request.id,
+                self.active_clipboard_paste_request_id
+            );
             return false;
         }
 
+        let image_mime_type = image.mime_type.clone();
+        let image_width = image.width;
+        let image_height = image.height;
+        let image_bytes = image.bytes.len();
         let target_active = self.clipboard_request_targets_active_page(request);
         let max_shapes = self.max_shapes_per_frame;
         let undo_limit = self.undo_stack_limit;
@@ -501,6 +510,13 @@ impl InputState {
             .and_then(|board| board.pages.frame_mut(request.target_page_index));
 
         let Some(frame) = target else {
+            log::warn!(
+                "External image paste request {} cancelled because target board '{}' page {} generation {} is no longer available",
+                request.id,
+                request.target_board_id,
+                request.target_page_index,
+                request.target_page_generation
+            );
             self.set_ui_toast(
                 UiToastKind::Warning,
                 "Paste target changed; image paste was cancelled.",
@@ -518,6 +534,14 @@ impl InputState {
             data: image,
         };
         let Some(new_id) = frame.try_add_shape_with_id(shape, max_shapes) else {
+            log::warn!(
+                "External image paste request {} rejected by shape limit on board '{}' page {} (max_shapes={}, image_bytes={})",
+                request.id,
+                request.target_board_id,
+                request.target_page_index,
+                max_shapes,
+                image_bytes
+            );
             self.set_ui_toast(
                 UiToastKind::Warning,
                 "Shape limit reached; image not pasted.",
@@ -539,6 +563,7 @@ impl InputState {
             },
             undo_limit,
         );
+        let undo_entries = frame.undo_stack_len();
         self.mark_session_dirty();
         if target_active {
             self.mark_selection_dirty_region(bounds);
@@ -546,6 +571,23 @@ impl InputState {
             self.set_selection(vec![new_id]);
             self.needs_redraw = true;
         }
+        log::info!(
+            "Pasted external image shape {} from request {} into board '{}' page {}: target_active={}, mime={}, image={}x{}, bytes={}, display_bounds=({}, {}, {}, {}), undo_entries={}",
+            new_id,
+            request.id,
+            request.target_board_id,
+            request.target_page_index,
+            target_active,
+            image_mime_type,
+            image_width,
+            image_height,
+            image_bytes,
+            x,
+            y,
+            w,
+            h,
+            undo_entries
+        );
         true
     }
 

--- a/src/input/state/core/session.rs
+++ b/src/input/state/core/session.rs
@@ -16,4 +16,16 @@ impl InputState {
             false
         }
     }
+
+    /// Clears session dirtiness after loading persisted state into memory.
+    #[allow(dead_code)]
+    pub(crate) fn clear_session_dirty(&mut self) {
+        self.session_dirty = false;
+    }
+
+    /// Returns whether session data is dirty without clearing the dirty flag.
+    #[allow(dead_code)]
+    pub(crate) fn is_session_dirty(&self) -> bool {
+        self.session_dirty
+    }
 }

--- a/src/input/state/core/utility/launcher.rs
+++ b/src/input/state/core/utility/launcher.rs
@@ -26,10 +26,16 @@ impl InputState {
                     log::error!(
                         "Configurator not found (looked for '{binary}'). Install 'wayscriber-configurator' (Arch: yay -S wayscriber-configurator; deb/rpm users: grab the wayscriber-configurator package from the release page) or set WAYSCRIBER_CONFIGURATOR to its path."
                     );
-                    self.set_ui_toast(
-                        UiToastKind::Warning,
-                        format!("Configurator not found: {binary}"),
-                    );
+                    if self.open_config_file_default() {
+                        log::info!(
+                            "Opened config file with default application because wayscriber-configurator was unavailable"
+                        );
+                    } else {
+                        self.set_ui_toast(
+                            UiToastKind::Warning,
+                            format!("Configurator not found: {binary}"),
+                        );
+                    }
                 } else {
                     log::error!("Failed to launch wayscriber-configurator using '{binary}': {err}");
                     log::error!(
@@ -96,12 +102,13 @@ impl InputState {
     }
 
     /// Opens the primary config file using the desktop default application.
-    pub(crate) fn open_config_file_default(&mut self) {
+    pub(crate) fn open_config_file_default(&mut self) -> bool {
         let path = match Config::get_config_path() {
             Ok(p) => p,
             Err(err) => {
                 log::error!("Unable to resolve config path: {}", err);
-                return;
+                self.set_ui_toast(UiToastKind::Error, "Unable to resolve config path.");
+                return false;
             }
         };
 
@@ -128,9 +135,12 @@ impl InputState {
                     child.id()
                 );
                 self.should_exit = true;
+                true
             }
             Err(err) => {
                 log::error!("Failed to open config file at {}: {}", path.display(), err);
+                self.set_ui_toast(UiToastKind::Error, "Failed to open config file.");
+                false
             }
         }
     }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -46,6 +46,15 @@ mod real {
         body: &str,
         icon: Option<&str>,
     ) -> Result<(), String> {
+        send_notification_with_timeout(summary, body, icon, 3000).await
+    }
+
+    pub async fn send_notification_with_timeout(
+        summary: &str,
+        body: &str,
+        icon: Option<&str>,
+        expire_timeout_ms: i32,
+    ) -> Result<(), String> {
         let connection = Connection::session()
             .await
             .map_err(|e| format!("Failed to connect to session bus: {}", e))?;
@@ -66,7 +75,7 @@ mod real {
                 body,
                 vec![],
                 hints,
-                3000, // 3 second timeout
+                expire_timeout_ms,
             )
             .await
             .map_err(|e| format!("Failed to send notification: {}", e))?;
@@ -87,6 +96,23 @@ mod real {
             }
         });
     }
+
+    pub fn send_notification_with_timeout_async(
+        runtime_handle: &tokio::runtime::Handle,
+        summary: String,
+        body: String,
+        icon: Option<String>,
+        expire_timeout_ms: i32,
+    ) {
+        runtime_handle.spawn(async move {
+            let icon_ref = icon.as_deref();
+            if let Err(e) =
+                send_notification_with_timeout(&summary, &body, icon_ref, expire_timeout_ms).await
+            {
+                log::warn!("Failed to send notification: {}", e);
+            }
+        });
+    }
 }
 
 #[cfg(not(feature = "dbus"))]
@@ -101,6 +127,16 @@ mod real {
     }
 
     #[cfg_attr(not(feature = "dbus"), allow(dead_code))]
+    pub async fn send_notification_with_timeout(
+        _summary: &str,
+        _body: &str,
+        _icon: Option<&str>,
+        _expire_timeout_ms: i32,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "dbus"), allow(dead_code))]
     pub fn send_notification_async(
         _runtime_handle: &tokio::runtime::Handle,
         _summary: String,
@@ -109,7 +145,21 @@ mod real {
     ) {
         // no-op without D-Bus
     }
+
+    #[cfg_attr(not(feature = "dbus"), allow(dead_code))]
+    pub fn send_notification_with_timeout_async(
+        _runtime_handle: &tokio::runtime::Handle,
+        _summary: String,
+        _body: String,
+        _icon: Option<String>,
+        _expire_timeout_ms: i32,
+    ) {
+        // no-op without D-Bus
+    }
 }
 
 #[allow(unused_imports)]
-pub use real::{send_notification, send_notification_async};
+pub use real::{
+    send_notification, send_notification_async, send_notification_with_timeout,
+    send_notification_with_timeout_async,
+};

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -22,7 +22,11 @@ pub use snapshot::{
 #[allow(unused_imports)]
 pub(crate) use snapshot::{LoadSnapshotOutcome, load_snapshot_with_outcome};
 #[allow(unused_imports)]
-pub(crate) use snapshot::{SaveSnapshotOutcome, SaveSnapshotReport, save_snapshot_with_report};
+pub(crate) use snapshot::{
+    SaveLimitExceeded, SaveSnapshotOutcome, SaveSnapshotReport, SnapshotPayloadEstimate,
+    SnapshotSaveEstimate, estimate_snapshot_payload, estimate_snapshot_save,
+    estimate_snapshot_without_history_payload, save_snapshot_with_report,
+};
 #[allow(unused_imports)]
 pub use storage::{ClearOutcome, FrameCounts, SessionInspection, clear_session, inspect_session};
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -20,6 +20,10 @@ pub use snapshot::{
     load_snapshot, save_snapshot, snapshot_from_input,
 };
 #[allow(unused_imports)]
+pub(crate) use snapshot::{LoadSnapshotOutcome, load_snapshot_with_outcome};
+#[allow(unused_imports)]
+pub(crate) use snapshot::{SaveSnapshotOutcome, SaveSnapshotReport, save_snapshot_with_report};
+#[allow(unused_imports)]
 pub use storage::{ClearOutcome, FrameCounts, SessionInspection, clear_session, inspect_session};
 
 #[cfg(test)]

--- a/src/session/options/types.rs
+++ b/src/session/options/types.rs
@@ -62,7 +62,7 @@ impl SessionOptions {
             autosave_failure_backoff: Duration::from_millis(DEFAULT_AUTOSAVE_FAILURE_BACKOFF_MS),
             max_shapes_per_frame: 10_000,
             max_persisted_undo_depth: None,
-            max_file_size_bytes: 10 * 1024 * 1024,
+            max_file_size_bytes: 50 * 1024 * 1024,
             compression: CompressionMode::Auto,
             auto_compress_threshold_bytes: DEFAULT_AUTO_COMPRESS_THRESHOLD_BYTES,
             display_id,

--- a/src/session/snapshot/compression.rs
+++ b/src/session/snapshot/compression.rs
@@ -1,7 +1,28 @@
 use anyhow::{Context, Result};
 use flate2::{Compression, bufread::GzDecoder, write::GzEncoder};
+use std::fmt;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+pub(super) const DEFAULT_MAX_EXPANDED_SESSION_BYTES: u64 = 128 * 1024 * 1024;
+
+#[derive(Debug)]
+pub(super) struct ExpandedSessionTooLarge {
+    pub expanded_size: u64,
+    pub max_expanded_size: u64,
+}
+
+impl fmt::Display for ExpandedSessionTooLarge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "session expands to at least {} bytes which exceeds the safety limit of {} bytes",
+            self.expanded_size, self.max_expanded_size
+        )
+    }
+}
+
+impl std::error::Error for ExpandedSessionTooLarge {}
 
 pub(super) fn compress_bytes(data: &[u8]) -> Result<Vec<u8>> {
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
@@ -13,7 +34,10 @@ pub(super) fn compress_bytes(data: &[u8]) -> Result<Vec<u8>> {
         .context("failed to finalise compressed session payload")
 }
 
-pub(super) fn maybe_decompress(bytes: Vec<u8>) -> Result<(Vec<u8>, bool)> {
+pub(super) fn maybe_decompress_with_limit(
+    bytes: Vec<u8>,
+    max_expanded_size: u64,
+) -> Result<(Vec<u8>, bool)> {
     if !is_gzip(&bytes) {
         return Ok((bytes, false));
     }
@@ -21,8 +45,17 @@ pub(super) fn maybe_decompress(bytes: Vec<u8>) -> Result<(Vec<u8>, bool)> {
     let mut decoder = GzDecoder::new(&bytes[..]);
     let mut out = Vec::new();
     decoder
+        .by_ref()
+        .take(max_expanded_size.saturating_add(1))
         .read_to_end(&mut out)
         .context("failed to decompress session file")?;
+    if out.len() as u64 > max_expanded_size {
+        return Err(ExpandedSessionTooLarge {
+            expanded_size: out.len() as u64,
+            max_expanded_size,
+        }
+        .into());
+    }
     Ok((out, true))
 }
 

--- a/src/session/snapshot/load.rs
+++ b/src/session/snapshot/load.rs
@@ -1,4 +1,6 @@
-use super::compression::maybe_decompress;
+use super::compression::{
+    DEFAULT_MAX_EXPANDED_SESSION_BYTES, ExpandedSessionTooLarge, maybe_decompress_with_limit,
+};
 use super::history::{
     apply_history_policies, enforce_shape_limits, max_history_depth, strip_history_fields,
 };
@@ -14,7 +16,7 @@ use log::{debug, info, warn};
 use serde_json::Value;
 use std::fs::{self, File, OpenOptions};
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct LoadedSnapshot {
     pub snapshot: SessionSnapshot,
@@ -22,15 +24,43 @@ pub struct LoadedSnapshot {
     pub version: u32,
 }
 
+/// High-level load result used by runtime callers that need to distinguish a
+/// missing session from a protected session that was intentionally left intact.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum LoadSnapshotOutcome {
+    Loaded(Box<SessionSnapshot>),
+    Empty,
+    ExpandedTooLarge {
+        path: PathBuf,
+        max_expanded_size: u64,
+    },
+}
+
 /// Attempt to load a previously saved session.
+#[allow(dead_code)]
 pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>> {
+    match load_snapshot_with_outcome(options)? {
+        LoadSnapshotOutcome::Loaded(snapshot) => Ok(Some(*snapshot)),
+        LoadSnapshotOutcome::Empty | LoadSnapshotOutcome::ExpandedTooLarge { .. } => Ok(None),
+    }
+}
+
+pub(crate) fn load_snapshot_with_outcome(options: &SessionOptions) -> Result<LoadSnapshotOutcome> {
+    load_snapshot_with_expanded_limit(options, DEFAULT_MAX_EXPANDED_SESSION_BYTES)
+}
+
+pub(super) fn load_snapshot_with_expanded_limit(
+    options: &SessionOptions,
+    max_expanded_size: u64,
+) -> Result<LoadSnapshotOutcome> {
     if !options.any_enabled() && !options.restore_tool_state {
         info!(
             "Session load skipped: persistence disabled (base_dir={}, file={})",
             options.base_dir.display(),
             options.session_file_path().display()
         );
-        return Ok(None);
+        return Ok(LoadSnapshotOutcome::Empty);
     }
 
     let session_path = options.session_file_path();
@@ -39,7 +69,7 @@ pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>
             "Session file not found at {}; skipping load",
             session_path.display()
         );
-        return Ok(None);
+        return Ok(LoadSnapshotOutcome::Empty);
     }
 
     let metadata = fs::metadata(&session_path)
@@ -58,7 +88,7 @@ pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>
             metadata.len(),
             options.max_file_size_bytes
         );
-        return Ok(None);
+        return Ok(LoadSnapshotOutcome::Empty);
     }
 
     let lock_path = options.lock_file_path();
@@ -72,7 +102,7 @@ pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>
     lock_shared(&lock_file)
         .with_context(|| format!("failed to acquire shared lock {}", lock_path.display()))?;
 
-    let result = load_snapshot_inner(&session_path, options);
+    let result = load_snapshot_inner_with_expanded_limit(&session_path, options, max_expanded_size);
 
     if let Err(err) = unlock(&lock_file) {
         warn!(
@@ -94,14 +124,26 @@ pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>
                 loaded.snapshot.active_board_id,
                 tool_state
             );
-            Ok(Some(loaded.snapshot))
+            Ok(LoadSnapshotOutcome::Loaded(Box::new(loaded.snapshot)))
         }
         Ok(None) => {
             info!(
                 "Session file {} contained no usable data; continuing with defaults",
                 session_path.display()
             );
-            Ok(None)
+            Ok(LoadSnapshotOutcome::Empty)
+        }
+        Err(err) if err.downcast_ref::<ExpandedSessionTooLarge>().is_some() => {
+            warn!(
+                "Refusing to load session {}; expanded payload exceeds safety limit ({} bytes). The session file is left unchanged; clear the session or move the file if it is no longer needed: {}",
+                session_path.display(),
+                max_expanded_size,
+                err
+            );
+            Ok(LoadSnapshotOutcome::ExpandedTooLarge {
+                path: session_path,
+                max_expanded_size,
+            })
         }
         Err(err) => {
             warn!(
@@ -116,7 +158,7 @@ pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>
                     backup_err
                 );
             }
-            Ok(None)
+            Ok(LoadSnapshotOutcome::Empty)
         }
     }
 }
@@ -124,6 +166,18 @@ pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>
 pub(crate) fn load_snapshot_inner(
     session_path: &Path,
     options: &SessionOptions,
+) -> Result<Option<LoadedSnapshot>> {
+    load_snapshot_inner_with_expanded_limit(
+        session_path,
+        options,
+        DEFAULT_MAX_EXPANDED_SESSION_BYTES,
+    )
+}
+
+pub(super) fn load_snapshot_inner_with_expanded_limit(
+    session_path: &Path,
+    options: &SessionOptions,
+    max_expanded_size: u64,
 ) -> Result<Option<LoadedSnapshot>> {
     let mut file_bytes = Vec::new();
     {
@@ -133,7 +187,7 @@ pub(crate) fn load_snapshot_inner(
             .context("failed to read session file")?;
     }
 
-    let (decompressed, compressed) = maybe_decompress(file_bytes)?;
+    let (decompressed, compressed) = maybe_decompress_with_limit(file_bytes, max_expanded_size)?;
 
     let original_value: Value =
         serde_json::from_slice(&decompressed).context("failed to parse session json")?;

--- a/src/session/snapshot/mod.rs
+++ b/src/session/snapshot/mod.rs
@@ -14,7 +14,11 @@ pub use capture::snapshot_from_input;
 pub use load::load_snapshot;
 pub(crate) use load::{LoadSnapshotOutcome, load_snapshot_inner, load_snapshot_with_outcome};
 pub use save::save_snapshot;
-pub(crate) use save::{SaveSnapshotOutcome, SaveSnapshotReport, save_snapshot_with_report};
+pub(crate) use save::{
+    SaveLimitExceeded, SaveSnapshotOutcome, SaveSnapshotReport, SnapshotPayloadEstimate,
+    SnapshotSaveEstimate, estimate_snapshot_payload, estimate_snapshot_save,
+    estimate_snapshot_without_history_payload, save_snapshot_with_report,
+};
 #[allow(unused_imports)]
 pub use types::BoardSnapshot;
 pub use types::{BoardPagesSnapshot, SessionSnapshot, ToolStateSnapshot};

--- a/src/session/snapshot/mod.rs
+++ b/src/session/snapshot/mod.rs
@@ -12,8 +12,9 @@ mod tests;
 pub use apply::apply_snapshot;
 pub use capture::snapshot_from_input;
 pub use load::load_snapshot;
-pub(crate) use load::load_snapshot_inner;
+pub(crate) use load::{LoadSnapshotOutcome, load_snapshot_inner, load_snapshot_with_outcome};
 pub use save::save_snapshot;
+pub(crate) use save::{SaveSnapshotOutcome, SaveSnapshotReport, save_snapshot_with_report};
 #[allow(unused_imports)]
 pub use types::BoardSnapshot;
 pub use types::{BoardPagesSnapshot, SessionSnapshot, ToolStateSnapshot};

--- a/src/session/snapshot/save.rs
+++ b/src/session/snapshot/save.rs
@@ -10,6 +10,7 @@ use log::{debug, info, warn};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 const NEAR_LIMIT_PERCENT: u64 = 90;
 
@@ -35,12 +36,65 @@ pub struct SaveSnapshotReport {
 
 impl SaveSnapshotReport {
     pub fn is_near_limit(&self) -> bool {
-        if self.written_size == 0 {
-            return false;
+        is_near_limit(self.written_size as u64, self.max_file_size_bytes)
+    }
+}
+
+/// Estimated session payload size using the same serialisation, compression, and limits as saves.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotPayloadEstimate {
+    pub raw_size: usize,
+    pub written_size: usize,
+    pub max_file_size_bytes: u64,
+    pub compressed: bool,
+    pub limit_exceeded: Option<SaveLimitExceeded>,
+}
+
+#[allow(dead_code)]
+impl SnapshotPayloadEstimate {
+    pub fn is_near_limit(&self) -> bool {
+        is_near_limit(self.written_size as u64, self.max_file_size_bytes)
+    }
+}
+
+/// Estimated full and visible-only payloads for a snapshot.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotSaveEstimate {
+    pub full: SnapshotPayloadEstimate,
+    pub visible_without_history: SnapshotPayloadEstimate,
+}
+
+/// The save or restore safety limit exceeded by a prepared payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveLimitExceeded {
+    WrittenSize {
+        written_size: u64,
+        max_file_size: u64,
+    },
+    ExpandedSize {
+        raw_size: u64,
+        max_expanded_size: u64,
+    },
+}
+
+impl SaveLimitExceeded {
+    fn description(self) -> String {
+        match self {
+            Self::WrittenSize {
+                written_size,
+                max_file_size,
+            } => format!(
+                "writes as {written_size} bytes and exceeds the configured limit of {max_file_size} bytes"
+            ),
+            Self::ExpandedSize {
+                raw_size,
+                max_expanded_size,
+            } => format!(
+                "would expand to {raw_size} raw bytes, exceeding the load safety limit of {max_expanded_size} bytes"
+            ),
         }
-        let threshold =
-            ((self.max_file_size_bytes as u128) * (NEAR_LIMIT_PERCENT as u128)).div_ceil(100);
-        (self.written_size as u128) >= threshold
     }
 }
 
@@ -55,6 +109,75 @@ pub(crate) fn save_snapshot_with_report(
     options: &SessionOptions,
 ) -> Result<Option<SaveSnapshotReport>> {
     save_snapshot_with_expanded_limit(snapshot, options, DEFAULT_MAX_EXPANDED_SESSION_BYTES)
+}
+
+#[allow(dead_code)]
+pub(crate) fn estimate_snapshot_save(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+) -> Result<SnapshotSaveEstimate> {
+    estimate_snapshot_save_with_expanded_limit(
+        snapshot,
+        options,
+        DEFAULT_MAX_EXPANDED_SESSION_BYTES,
+    )
+}
+
+#[allow(dead_code)]
+pub(super) fn estimate_snapshot_save_with_expanded_limit(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    max_expanded_size: u64,
+) -> Result<SnapshotSaveEstimate> {
+    let last_modified = now_rfc3339();
+    let full = payload_candidate(snapshot, options, &last_modified)?;
+    let visible_only = snapshot_without_history(snapshot);
+    let visible_without_history = payload_candidate(&visible_only, options, &last_modified)?;
+
+    Ok(SnapshotSaveEstimate {
+        full: estimate_from_candidate(&full, options, max_expanded_size),
+        visible_without_history: estimate_from_candidate(
+            &visible_without_history,
+            options,
+            max_expanded_size,
+        ),
+    })
+}
+
+#[allow(dead_code)]
+pub(crate) fn estimate_snapshot_payload(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+) -> Result<SnapshotPayloadEstimate> {
+    estimate_snapshot_payload_with_expanded_limit(
+        snapshot,
+        options,
+        DEFAULT_MAX_EXPANDED_SESSION_BYTES,
+    )
+}
+
+#[allow(dead_code)]
+pub(crate) fn estimate_snapshot_without_history_payload(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+) -> Result<SnapshotPayloadEstimate> {
+    let visible_only = snapshot_without_history(snapshot);
+    estimate_snapshot_payload(&visible_only, options)
+}
+
+#[allow(dead_code)]
+pub(super) fn estimate_snapshot_payload_with_expanded_limit(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    max_expanded_size: u64,
+) -> Result<SnapshotPayloadEstimate> {
+    let last_modified = now_rfc3339();
+    let candidate = payload_candidate(snapshot, options, &last_modified)?;
+    Ok(estimate_from_candidate(
+        &candidate,
+        options,
+        max_expanded_size,
+    ))
 }
 
 pub(super) fn save_snapshot_with_expanded_limit(
@@ -82,10 +205,38 @@ pub(super) fn save_snapshot_with_expanded_limit(
         .truncate(true)
         .open(&lock_path)
         .with_context(|| format!("failed to open session lock file {}", lock_path.display()))?;
+    let lock_started = Instant::now();
     lock_exclusive(&lock_file)
         .with_context(|| format!("failed to lock session file {}", lock_path.display()))?;
+    info!(
+        "Acquired session save lock {} in {:?}",
+        lock_path.display(),
+        lock_started.elapsed()
+    );
 
+    let save_started = Instant::now();
     let result = save_snapshot_inner(snapshot, options, max_expanded_size);
+    match &result {
+        Ok(Some(report)) => info!(
+            "Session save pipeline finished for {} in {:?}: outcome={:?}, written={} bytes, raw={} bytes, compression={}",
+            report.path.display(),
+            save_started.elapsed(),
+            report.outcome,
+            report.written_size,
+            report.raw_size,
+            report.compressed
+        ),
+        Ok(None) => info!(
+            "Session save pipeline finished in {:?}: no file write needed",
+            save_started.elapsed()
+        ),
+        Err(err) => warn!(
+            "Session save pipeline failed for {} after {:?}: {}",
+            options.session_file_path().display(),
+            save_started.elapsed(),
+            err
+        ),
+    }
 
     if let Err(err) = unlock(&lock_file) {
         warn!(
@@ -107,6 +258,7 @@ fn save_snapshot_inner(
     let backup_path = options.backup_file_path();
     let last_modified = now_rfc3339();
 
+    let prepare_started = Instant::now();
     let prepared = match payload_within_limit(snapshot, options, &last_modified, max_expanded_size)
     {
         Ok(prepared) => prepared,
@@ -120,6 +272,19 @@ fn save_snapshot_inner(
             return Err(err);
         }
     };
+    let prepared_written_size = prepared
+        .payload
+        .as_ref()
+        .map_or(0, PayloadCandidate::final_size);
+    info!(
+        "Prepared session payload for {} in {:?}: outcome={:?}, written={} bytes, raw={} bytes, compression={}",
+        session_path.display(),
+        prepare_started.elapsed(),
+        prepared.outcome,
+        prepared_written_size,
+        prepared.raw_size,
+        prepared.compressed
+    );
 
     let Some(payload) = prepared.payload else {
         let report = SaveSnapshotReport {
@@ -144,6 +309,7 @@ fn save_snapshot_inner(
     let final_size = payload_bytes.len();
 
     let tmp_path = temp_path(&session_path)?;
+    let write_started = Instant::now();
     {
         let mut tmp_file = OpenOptions::new()
             .write(true)
@@ -162,7 +328,9 @@ fn save_snapshot_inner(
             .sync_all()
             .context("failed to sync temporary session file")?;
     }
+    let write_elapsed = write_started.elapsed();
 
+    let replace_started = Instant::now();
     if session_path.exists() {
         if options.backup_retention > 0 {
             if backup_path.exists() {
@@ -187,6 +355,14 @@ fn save_snapshot_inner(
             session_path.display()
         )
     })?;
+    let replace_elapsed = replace_started.elapsed();
+    info!(
+        "Session file replace completed for {}: write_and_sync={:?}, rotate_and_rename={:?}, final_size={} bytes",
+        session_path.display(),
+        write_elapsed,
+        replace_elapsed,
+        final_size
+    );
 
     info!(
         "Session saved to {} ({} bytes written, raw={} bytes, compression={}, outcome={:?})",
@@ -233,15 +409,15 @@ impl PayloadCandidate {
         &self,
         options: &SessionOptions,
         max_expanded_size: u64,
-    ) -> Option<PayloadLimitExceeded> {
+    ) -> Option<SaveLimitExceeded> {
         if self.final_size() as u64 > options.max_file_size_bytes {
-            return Some(PayloadLimitExceeded::WrittenSize {
+            return Some(SaveLimitExceeded::WrittenSize {
                 written_size: self.final_size() as u64,
                 max_file_size: options.max_file_size_bytes,
             });
         }
         if self.compressed && self.raw_size as u64 > max_expanded_size {
-            return Some(PayloadLimitExceeded::ExpandedSize {
+            return Some(SaveLimitExceeded::ExpandedSize {
                 raw_size: self.raw_size as u64,
                 max_expanded_size,
             });
@@ -251,37 +427,6 @@ impl PayloadCandidate {
 
     fn fits_limit(&self, options: &SessionOptions, max_expanded_size: u64) -> bool {
         self.limit_exceeded(options, max_expanded_size).is_none()
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum PayloadLimitExceeded {
-    WrittenSize {
-        written_size: u64,
-        max_file_size: u64,
-    },
-    ExpandedSize {
-        raw_size: u64,
-        max_expanded_size: u64,
-    },
-}
-
-impl PayloadLimitExceeded {
-    fn description(self) -> String {
-        match self {
-            Self::WrittenSize {
-                written_size,
-                max_file_size,
-            } => format!(
-                "writes as {written_size} bytes and exceeds the configured limit of {max_file_size} bytes"
-            ),
-            Self::ExpandedSize {
-                raw_size,
-                max_expanded_size,
-            } => format!(
-                "would expand to {raw_size} raw bytes, exceeding the load safety limit of {max_expanded_size} bytes"
-            ),
-        }
     }
 }
 
@@ -322,7 +467,9 @@ fn payload_within_limit(
         return Ok(PreparedPayload::clear(0, false));
     }
 
+    let full_started = Instant::now();
     let full_payload = payload_candidate(snapshot, options, last_modified)?;
+    log_payload_candidate("full", &full_payload, full_started.elapsed());
     if full_payload.fits_limit(options, max_expanded_size) {
         return Ok(PreparedPayload::write(
             full_payload,
@@ -335,33 +482,6 @@ fn payload_within_limit(
     let full_limit = full_payload
         .limit_exceeded(options, max_expanded_size)
         .expect("full payload should exceed a save/load limit");
-    let history_depth = max_history_depth(snapshot);
-    if history_depth > 0
-        && let Some((depth, payload)) = largest_fitting_history_payload(
-            snapshot,
-            history_depth,
-            options,
-            last_modified,
-            max_expanded_size,
-        )?
-    {
-        warn!(
-            "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); saving recent {} undo/redo history entries per stack ({} bytes written from {} raw bytes, compression={})",
-            full_limit.description(),
-            full_final_size,
-            full_raw_size,
-            full_payload.compressed,
-            depth,
-            payload.final_size(),
-            payload.raw_size,
-            payload.compressed
-        );
-        return Ok(PreparedPayload::write(
-            payload,
-            SaveSnapshotOutcome::TrimmedHistory { depth },
-        ));
-    }
-
     let visible_only = snapshot_without_history(snapshot);
     if visible_only.is_empty() && visible_only.tool_state.is_none() {
         warn!(
@@ -377,52 +497,164 @@ fn payload_within_limit(
         ));
     }
 
+    let visible_started = Instant::now();
     let visible_payload = payload_candidate(&visible_only, options, last_modified)?;
-    if visible_payload.fits_limit(options, max_expanded_size) {
-        warn!(
-            "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); saving visible data without undo/redo history ({} bytes written from {} raw bytes, compression={})",
-            full_limit.description(),
-            full_final_size,
-            full_raw_size,
-            full_payload.compressed,
+    log_payload_candidate("visible-only", &visible_payload, visible_started.elapsed());
+    if !visible_payload.fits_limit(options, max_expanded_size) {
+        let visible_limit = visible_payload
+            .limit_exceeded(options, max_expanded_size)
+            .expect("visible payload should exceed a save/load limit");
+        return Err(anyhow!(
+            "Session data cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); skipping save",
+            visible_limit.description(),
             visible_payload.final_size(),
             visible_payload.raw_size,
             visible_payload.compressed
-        );
-        return Ok(PreparedPayload::write(
-            visible_payload,
-            SaveSnapshotOutcome::VisibleOnly,
         ));
     }
 
-    let visible_limit = visible_payload
-        .limit_exceeded(options, max_expanded_size)
-        .expect("visible payload should exceed a save/load limit");
-    Err(anyhow!(
-        "Session data cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); skipping save",
-        visible_limit.description(),
+    let history_depth = max_history_depth(snapshot);
+    if history_depth > 0 {
+        let visible_near_limit = is_near_limit(
+            visible_payload.final_size() as u64,
+            options.max_file_size_bytes,
+        );
+        let depth_one_started = Instant::now();
+        let depth_one_candidate = snapshot_with_history_depth(snapshot, 1);
+        let depth_one_payload = payload_candidate(&depth_one_candidate, options, last_modified)?;
+        log_payload_candidate(
+            "history-depth 1",
+            &depth_one_payload,
+            depth_one_started.elapsed(),
+        );
+
+        if depth_one_payload.fits_limit(options, max_expanded_size) {
+            let fitting_history = if history_depth == 1 || visible_near_limit {
+                if visible_near_limit && history_depth > 1 {
+                    warn!(
+                        "Visible-only session payload is already near the configured limit ({} of {} bytes); keeping one history entry and skipping deeper history-depth scan",
+                        visible_payload.final_size(),
+                        options.max_file_size_bytes
+                    );
+                }
+                Some((1, depth_one_payload))
+            } else {
+                largest_fitting_history_payload(
+                    snapshot,
+                    2,
+                    history_depth,
+                    options,
+                    last_modified,
+                    max_expanded_size,
+                )?
+                .or(Some((1, depth_one_payload)))
+            };
+
+            if let Some((depth, payload)) = fitting_history {
+                warn!(
+                    "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); saving recent {} undo/redo history entries per stack ({} bytes written from {} raw bytes, compression={})",
+                    full_limit.description(),
+                    full_final_size,
+                    full_raw_size,
+                    full_payload.compressed,
+                    depth,
+                    payload.final_size(),
+                    payload.raw_size,
+                    payload.compressed
+                );
+                return Ok(PreparedPayload::write(
+                    payload,
+                    SaveSnapshotOutcome::TrimmedHistory { depth },
+                ));
+            }
+        } else {
+            let depth_one_limit = depth_one_payload
+                .limit_exceeded(options, max_expanded_size)
+                .expect("depth-one payload should exceed a save/load limit");
+            warn!(
+                "Even one persisted history entry cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); skipping history-depth scan and saving visible data only",
+                depth_one_limit.description(),
+                depth_one_payload.final_size(),
+                depth_one_payload.raw_size,
+                depth_one_payload.compressed
+            );
+        }
+    }
+
+    warn!(
+        "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); saving visible data without undo/redo history ({} bytes written from {} raw bytes, compression={})",
+        full_limit.description(),
+        full_final_size,
+        full_raw_size,
+        full_payload.compressed,
         visible_payload.final_size(),
         visible_payload.raw_size,
         visible_payload.compressed
+    );
+    Ok(PreparedPayload::write(
+        visible_payload,
+        SaveSnapshotOutcome::VisibleOnly,
     ))
 }
 
 fn largest_fitting_history_payload(
     snapshot: &SessionSnapshot,
+    min_depth: usize,
     max_depth: usize,
     options: &SessionOptions,
     last_modified: &str,
     max_expanded_size: u64,
 ) -> Result<Option<(usize, PayloadCandidate)>> {
-    for depth in (1..=max_depth).rev() {
+    if min_depth > max_depth {
+        return Ok(None);
+    }
+
+    let scan_started = Instant::now();
+    let mut attempts = 0usize;
+    for depth in (min_depth..=max_depth).rev() {
+        attempts += 1;
+        let candidate_started = Instant::now();
         let candidate = snapshot_with_history_depth(snapshot, depth);
         let payload = payload_candidate(&candidate, options, last_modified)?;
+        debug!(
+            "Prepared history-depth session payload candidate depth={} in {:?}: written={} bytes, raw={} bytes, compression={}",
+            depth,
+            candidate_started.elapsed(),
+            payload.final_size(),
+            payload.raw_size,
+            payload.compressed
+        );
         if payload.fits_limit(options, max_expanded_size) {
+            info!(
+                "History trim scan found fitting session payload at depth {} after {} candidate(s) in {:?}: written={} bytes, raw={} bytes, compression={}",
+                depth,
+                attempts,
+                scan_started.elapsed(),
+                payload.final_size(),
+                payload.raw_size,
+                payload.compressed
+            );
             return Ok(Some((depth, payload)));
         }
     }
 
+    warn!(
+        "History trim scan found no fitting session payload after {} candidate(s) in {:?}",
+        attempts,
+        scan_started.elapsed()
+    );
     Ok(None)
+}
+
+fn log_payload_candidate(label: &str, payload: &PayloadCandidate, elapsed: Duration) {
+    info!(
+        "Prepared {} session payload candidate in {:?}: written={} bytes, raw={} bytes, compression={}",
+        label,
+        elapsed,
+        payload.final_size(),
+        payload.raw_size,
+        payload.compressed
+    );
 }
 
 fn payload_candidate(
@@ -482,6 +714,29 @@ fn serialize_payload(snapshot: &SessionSnapshot, last_modified: &str) -> Result<
     };
 
     serde_json::to_vec_pretty(&file_payload).context("failed to serialise session payload")
+}
+
+#[allow(dead_code)]
+fn estimate_from_candidate(
+    candidate: &PayloadCandidate,
+    options: &SessionOptions,
+    max_expanded_size: u64,
+) -> SnapshotPayloadEstimate {
+    SnapshotPayloadEstimate {
+        raw_size: candidate.raw_size,
+        written_size: candidate.final_size(),
+        max_file_size_bytes: options.max_file_size_bytes,
+        compressed: candidate.compressed,
+        limit_exceeded: candidate.limit_exceeded(options, max_expanded_size),
+    }
+}
+
+fn is_near_limit(written_size: u64, max_file_size_bytes: u64) -> bool {
+    if written_size == 0 {
+        return false;
+    }
+    let threshold = ((max_file_size_bytes as u128) * (NEAR_LIMIT_PERCENT as u128)).div_ceil(100);
+    (written_size as u128) >= threshold
 }
 
 fn max_history_depth(snapshot: &SessionSnapshot) -> usize {

--- a/src/session/snapshot/save.rs
+++ b/src/session/snapshot/save.rs
@@ -1,4 +1,4 @@
-use super::compression::{compress_bytes, temp_path};
+use super::compression::{DEFAULT_MAX_EXPANDED_SESSION_BYTES, compress_bytes, temp_path};
 use super::types::{
     BoardFile, BoardPagesSnapshot, BoardSnapshot, CURRENT_VERSION, SessionFile, SessionSnapshot,
 };
@@ -9,13 +9,62 @@ use anyhow::{Context, Result, anyhow};
 use log::{debug, info, warn};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+const NEAR_LIMIT_PERCENT: u64 = 90;
+
+/// Outcome of a session save after applying configured size fallbacks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveSnapshotOutcome {
+    Full,
+    TrimmedHistory { depth: usize },
+    VisibleOnly,
+    ClearedEmpty,
+}
+
+/// Details about a completed session save.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SaveSnapshotReport {
+    pub path: PathBuf,
+    pub outcome: SaveSnapshotOutcome,
+    pub raw_size: usize,
+    pub written_size: usize,
+    pub max_file_size_bytes: u64,
+    pub compressed: bool,
+}
+
+impl SaveSnapshotReport {
+    pub fn is_near_limit(&self) -> bool {
+        if self.written_size == 0 {
+            return false;
+        }
+        let threshold =
+            ((self.max_file_size_bytes as u128) * (NEAR_LIMIT_PERCENT as u128)).div_ceil(100);
+        (self.written_size as u128) >= threshold
+    }
+}
 
 /// Persist the provided snapshot to disk according to the configured options.
 pub fn save_snapshot(snapshot: &SessionSnapshot, options: &SessionOptions) -> Result<()> {
+    save_snapshot_with_report(snapshot, options).map(|_| ())
+}
+
+/// Persist the provided snapshot and report what was written.
+pub(crate) fn save_snapshot_with_report(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+) -> Result<Option<SaveSnapshotReport>> {
+    save_snapshot_with_expanded_limit(snapshot, options, DEFAULT_MAX_EXPANDED_SESSION_BYTES)
+}
+
+pub(super) fn save_snapshot_with_expanded_limit(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    max_expanded_size: u64,
+) -> Result<Option<SaveSnapshotReport>> {
     if !options.any_enabled() && !options.persist_history && snapshot.tool_state.is_none() {
         debug!("Session persistence disabled for all boards; skipping save");
-        return Ok(());
+        return Ok(None);
     }
 
     fs::create_dir_all(&options.base_dir).with_context(|| {
@@ -36,7 +85,7 @@ pub fn save_snapshot(snapshot: &SessionSnapshot, options: &SessionOptions) -> Re
     lock_exclusive(&lock_file)
         .with_context(|| format!("failed to lock session file {}", lock_path.display()))?;
 
-    let result = save_snapshot_inner(snapshot, options);
+    let result = save_snapshot_inner(snapshot, options, max_expanded_size);
 
     if let Err(err) = unlock(&lock_file) {
         warn!(
@@ -49,17 +98,18 @@ pub fn save_snapshot(snapshot: &SessionSnapshot, options: &SessionOptions) -> Re
     result
 }
 
-fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> Result<()> {
+fn save_snapshot_inner(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    max_expanded_size: u64,
+) -> Result<Option<SaveSnapshotReport>> {
     let session_path = options.session_file_path();
     let backup_path = options.backup_file_path();
     let last_modified = now_rfc3339();
 
-    let payload = match payload_within_limit(snapshot, options, &last_modified) {
-        Ok(Some(payload)) => payload,
-        Ok(None) => {
-            remove_session_file(&session_path)?;
-            return Ok(());
-        }
+    let prepared = match payload_within_limit(snapshot, options, &last_modified, max_expanded_size)
+    {
+        Ok(prepared) => prepared,
         Err(err) => {
             if session_path.exists() {
                 warn!(
@@ -69,6 +119,22 @@ fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> 
             }
             return Err(err);
         }
+    };
+
+    let Some(payload) = prepared.payload else {
+        let report = SaveSnapshotReport {
+            path: session_path.clone(),
+            outcome: prepared.outcome,
+            raw_size: prepared.raw_size,
+            written_size: 0,
+            max_file_size_bytes: options.max_file_size_bytes,
+            compressed: prepared.compressed,
+        };
+        if matches!(prepared.outcome, SaveSnapshotOutcome::ClearedEmpty) {
+            remove_session_file(&session_path)?;
+        }
+        log_near_limit(&report);
+        return Ok(Some(report));
     };
     let PayloadCandidate {
         bytes: payload_bytes,
@@ -123,14 +189,33 @@ fn save_snapshot_inner(snapshot: &SessionSnapshot, options: &SessionOptions) -> 
     })?;
 
     info!(
-        "Session saved to {} ({} bytes written, raw={} bytes, compression={})",
+        "Session saved to {} ({} bytes written, raw={} bytes, compression={}, outcome={:?})",
         session_path.display(),
         final_size,
         raw_size,
-        compressed
+        compressed,
+        prepared.outcome
     );
 
-    Ok(())
+    let report = SaveSnapshotReport {
+        path: session_path,
+        outcome: prepared.outcome,
+        raw_size,
+        written_size: final_size,
+        max_file_size_bytes: options.max_file_size_bytes,
+        compressed,
+    };
+    log_near_limit(&report);
+    Ok(Some(report))
+}
+
+fn log_near_limit(report: &SaveSnapshotReport) {
+    if report.is_near_limit() {
+        debug!(
+            "Session save size is near the configured limit ({} of {} bytes, threshold={}%)",
+            report.written_size, report.max_file_size_bytes, NEAR_LIMIT_PERCENT
+        );
+    }
 }
 
 struct PayloadCandidate {
@@ -144,8 +229,86 @@ impl PayloadCandidate {
         self.bytes.len()
     }
 
-    fn fits_limit(&self, options: &SessionOptions) -> bool {
-        self.final_size() as u64 <= options.max_file_size_bytes
+    fn limit_exceeded(
+        &self,
+        options: &SessionOptions,
+        max_expanded_size: u64,
+    ) -> Option<PayloadLimitExceeded> {
+        if self.final_size() as u64 > options.max_file_size_bytes {
+            return Some(PayloadLimitExceeded::WrittenSize {
+                written_size: self.final_size() as u64,
+                max_file_size: options.max_file_size_bytes,
+            });
+        }
+        if self.compressed && self.raw_size as u64 > max_expanded_size {
+            return Some(PayloadLimitExceeded::ExpandedSize {
+                raw_size: self.raw_size as u64,
+                max_expanded_size,
+            });
+        }
+        None
+    }
+
+    fn fits_limit(&self, options: &SessionOptions, max_expanded_size: u64) -> bool {
+        self.limit_exceeded(options, max_expanded_size).is_none()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PayloadLimitExceeded {
+    WrittenSize {
+        written_size: u64,
+        max_file_size: u64,
+    },
+    ExpandedSize {
+        raw_size: u64,
+        max_expanded_size: u64,
+    },
+}
+
+impl PayloadLimitExceeded {
+    fn description(self) -> String {
+        match self {
+            Self::WrittenSize {
+                written_size,
+                max_file_size,
+            } => format!(
+                "writes as {written_size} bytes and exceeds the configured limit of {max_file_size} bytes"
+            ),
+            Self::ExpandedSize {
+                raw_size,
+                max_expanded_size,
+            } => format!(
+                "would expand to {raw_size} raw bytes, exceeding the load safety limit of {max_expanded_size} bytes"
+            ),
+        }
+    }
+}
+
+struct PreparedPayload {
+    payload: Option<PayloadCandidate>,
+    outcome: SaveSnapshotOutcome,
+    raw_size: usize,
+    compressed: bool,
+}
+
+impl PreparedPayload {
+    fn write(payload: PayloadCandidate, outcome: SaveSnapshotOutcome) -> Self {
+        Self {
+            raw_size: payload.raw_size,
+            compressed: payload.compressed,
+            payload: Some(payload),
+            outcome,
+        }
+    }
+
+    fn clear(raw_size: usize, compressed: bool) -> Self {
+        Self {
+            payload: None,
+            outcome: SaveSnapshotOutcome::ClearedEmpty,
+            raw_size,
+            compressed,
+        }
     }
 }
 
@@ -153,65 +316,94 @@ fn payload_within_limit(
     snapshot: &SessionSnapshot,
     options: &SessionOptions,
     last_modified: &str,
-) -> Result<Option<PayloadCandidate>> {
+    max_expanded_size: u64,
+) -> Result<PreparedPayload> {
     if snapshot.is_empty() && snapshot.tool_state.is_none() {
-        return Ok(None);
+        return Ok(PreparedPayload::clear(0, false));
     }
 
     let full_payload = payload_candidate(snapshot, options, last_modified)?;
-    if full_payload.fits_limit(options) {
-        return Ok(Some(full_payload));
+    if full_payload.fits_limit(options, max_expanded_size) {
+        return Ok(PreparedPayload::write(
+            full_payload,
+            SaveSnapshotOutcome::Full,
+        ));
     }
 
     let full_raw_size = full_payload.raw_size;
     let full_final_size = full_payload.final_size();
+    let full_limit = full_payload
+        .limit_exceeded(options, max_expanded_size)
+        .expect("full payload should exceed a save/load limit");
     let history_depth = max_history_depth(snapshot);
     if history_depth > 0
-        && let Some((depth, payload)) =
-            largest_fitting_history_payload(snapshot, history_depth, options, last_modified)?
+        && let Some((depth, payload)) = largest_fitting_history_payload(
+            snapshot,
+            history_depth,
+            options,
+            last_modified,
+            max_expanded_size,
+        )?
     {
         warn!(
-            "Full session payload writes as {} bytes from {} raw bytes, exceeding the configured limit of {} bytes; saving recent {} undo/redo history entries per stack ({} bytes written from {} raw bytes, compression={})",
+            "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); saving recent {} undo/redo history entries per stack ({} bytes written from {} raw bytes, compression={})",
+            full_limit.description(),
             full_final_size,
             full_raw_size,
-            options.max_file_size_bytes,
+            full_payload.compressed,
             depth,
             payload.final_size(),
             payload.raw_size,
             payload.compressed
         );
-        return Ok(Some(payload));
+        return Ok(PreparedPayload::write(
+            payload,
+            SaveSnapshotOutcome::TrimmedHistory { depth },
+        ));
     }
 
     let visible_only = snapshot_without_history(snapshot);
     if visible_only.is_empty() && visible_only.tool_state.is_none() {
         warn!(
-            "Full session payload writes as {} bytes from {} raw bytes, exceeding the configured limit of {} bytes; dropping undo/redo history leaves no visible session data, clearing saved session",
-            full_final_size, full_raw_size, options.max_file_size_bytes
+            "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); dropping undo/redo history leaves no visible session data, clearing saved session",
+            full_limit.description(),
+            full_final_size,
+            full_raw_size,
+            full_payload.compressed
         );
-        return Ok(None);
+        return Ok(PreparedPayload::clear(
+            full_raw_size,
+            full_payload.compressed,
+        ));
     }
 
     let visible_payload = payload_candidate(&visible_only, options, last_modified)?;
-    if visible_payload.fits_limit(options) {
+    if visible_payload.fits_limit(options, max_expanded_size) {
         warn!(
-            "Full session payload writes as {} bytes from {} raw bytes, exceeding the configured limit of {} bytes; saving visible data without undo/redo history ({} bytes written from {} raw bytes, compression={})",
+            "Full session payload cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); saving visible data without undo/redo history ({} bytes written from {} raw bytes, compression={})",
+            full_limit.description(),
             full_final_size,
             full_raw_size,
-            options.max_file_size_bytes,
+            full_payload.compressed,
             visible_payload.final_size(),
             visible_payload.raw_size,
             visible_payload.compressed
         );
-        return Ok(Some(visible_payload));
+        return Ok(PreparedPayload::write(
+            visible_payload,
+            SaveSnapshotOutcome::VisibleOnly,
+        ));
     }
 
+    let visible_limit = visible_payload
+        .limit_exceeded(options, max_expanded_size)
+        .expect("visible payload should exceed a save/load limit");
     Err(anyhow!(
-        "Session data writes as {} bytes from {} raw bytes with compression={} which exceeds the configured limit of {} bytes; skipping save",
+        "Session data cannot be saved safely ({}; {} bytes written from {} raw bytes, compression={}); skipping save",
+        visible_limit.description(),
         visible_payload.final_size(),
         visible_payload.raw_size,
-        visible_payload.compressed,
-        options.max_file_size_bytes
+        visible_payload.compressed
     ))
 }
 
@@ -220,11 +412,12 @@ fn largest_fitting_history_payload(
     max_depth: usize,
     options: &SessionOptions,
     last_modified: &str,
+    max_expanded_size: u64,
 ) -> Result<Option<(usize, PayloadCandidate)>> {
     for depth in (1..=max_depth).rev() {
         let candidate = snapshot_with_history_depth(snapshot, depth);
         let payload = payload_candidate(&candidate, options, last_modified)?;
-        if payload.fits_limit(options) {
+        if payload.fits_limit(options, max_expanded_size) {
             return Ok(Some((depth, payload)));
         }
     }

--- a/src/session/snapshot/tests.rs
+++ b/src/session/snapshot/tests.rs
@@ -1,5 +1,9 @@
 use super::compression::is_gzip;
-use super::load::load_snapshot_inner;
+use super::load::{
+    LoadSnapshotOutcome, load_snapshot_inner, load_snapshot_inner_with_expanded_limit,
+    load_snapshot_with_expanded_limit,
+};
+use super::save::save_snapshot_with_expanded_limit;
 use super::types::{
     BoardFile, BoardPagesSnapshot, BoardSnapshot, CURRENT_VERSION, SessionFile, SessionSnapshot,
 };
@@ -87,6 +91,107 @@ fn load_snapshot_inner_reports_compression_and_version() {
             .boards
             .iter()
             .any(|board| board.id == "transparent")
+    );
+}
+
+#[test]
+fn load_snapshot_inner_refuses_compressed_payload_over_expanded_limit() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "expanded-inner");
+    options.persist_transparent = true;
+    options.compression = CompressionMode::On;
+    save_snapshot(&snapshot, &options).expect("save_snapshot should succeed");
+
+    let Err(err) =
+        load_snapshot_inner_with_expanded_limit(&options.session_file_path(), &options, 16)
+    else {
+        panic!("expanded payload should exceed the test cap");
+    };
+    assert!(
+        err.to_string().contains("exceeds the safety limit"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn load_snapshot_expansion_limit_leaves_primary_file_unchanged() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "expanded-outer");
+    options.persist_transparent = true;
+    options.compression = CompressionMode::On;
+    save_snapshot(&snapshot, &options).expect("save_snapshot should succeed");
+
+    let session_path = options.session_file_path();
+    let original_bytes = std::fs::read(&session_path).expect("session bytes");
+    let outcome = load_snapshot_with_expanded_limit(&options, 16)
+        .expect("expanded-cap refusal should not be a load error");
+
+    assert!(matches!(
+        outcome,
+        LoadSnapshotOutcome::ExpandedTooLarge {
+            max_expanded_size: 16,
+            ..
+        }
+    ));
+    assert_eq!(
+        std::fs::read(&session_path).expect("session should remain in place"),
+        original_bytes
+    );
+    assert!(
+        !options.backup_file_path().exists(),
+        "expanded-cap refusal should not rotate the primary session into backup"
+    );
+}
+
+#[test]
+fn save_snapshot_refuses_compressed_payload_over_expanded_limit() {
+    let temp = tempdir().unwrap();
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "expanded-save");
+    options.persist_transparent = true;
+    options.compression = CompressionMode::On;
+    options.max_file_size_bytes = u64::MAX;
+
+    let mut frame = Frame::new();
+    frame.add_shape(Shape::Text {
+        x: 1,
+        y: 2,
+        text: "x".repeat(4096),
+        color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        size: 24.0,
+        font_descriptor: Default::default(),
+        background_enabled: false,
+        wrap_width: None,
+    });
+    let snapshot = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: vec![BoardSnapshot {
+            id: "transparent".to_string(),
+            pages: BoardPagesSnapshot {
+                pages: vec![frame],
+                active: 0,
+            },
+        }],
+        tool_state: None,
+    };
+
+    let err = save_snapshot_with_expanded_limit(&snapshot, &options, 512)
+        .expect_err("compressed raw payload over expanded cap should not be written");
+    assert!(
+        err.to_string().contains("load safety limit"),
+        "unexpected error: {err:#}"
+    );
+    assert!(
+        !options.session_file_path().exists(),
+        "unloadable compressed session should not be created"
     );
 }
 

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -410,6 +410,116 @@ fn save_snapshot_keeps_largest_recent_history_depth_that_fits() {
 }
 
 #[test]
+fn save_snapshot_keeps_depth_one_when_visible_payload_is_near_limit() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut input = dummy_input_state();
+    {
+        let frame = input.boards.active_frame_mut();
+        frame.add_shape(Shape::Image {
+            x: 12,
+            y: 16,
+            w: 640,
+            h: 360,
+            data: EmbeddedImage {
+                mime_type: "image/png".to_string(),
+                width: 640,
+                height: 360,
+                bytes: vec![0x35; 96 * 1024],
+            },
+        });
+        let id = frame.add_shape(large_freehand(40, 0));
+        for offset in 1..=2 {
+            let current = frame.shape(id).expect("shape should exist");
+            let before = ShapeSnapshot {
+                shape: current.shape.clone(),
+                locked: current.locked,
+            };
+            let after_shape = large_freehand(40, offset);
+            frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+            frame.push_undo_action(
+                UndoAction::Modify {
+                    shape_id: id,
+                    before,
+                    after: ShapeSnapshot {
+                        shape: after_shape,
+                        locked: false,
+                    },
+                },
+                input.undo_stack_limit,
+            );
+        }
+    }
+
+    let mut visible_options = limit_test_options(temp.path(), "display-near-visible", false);
+    visible_options.max_file_size_bytes = u64::MAX;
+    let visible_snapshot =
+        snapshot_from_input(&input, &visible_options).expect("visible snapshot present");
+    save_snapshot(&visible_snapshot, &visible_options).expect("visible save should fit");
+    let visible_size = fs::metadata(visible_options.session_file_path())
+        .expect("visible metadata")
+        .len();
+
+    let mut depth_one_options = limit_test_options(temp.path(), "display-near-depth-one", true);
+    depth_one_options.max_file_size_bytes = u64::MAX;
+    depth_one_options.max_persisted_undo_depth = Some(1);
+    let depth_one_snapshot =
+        snapshot_from_input(&input, &depth_one_options).expect("depth one snapshot present");
+    save_snapshot(&depth_one_snapshot, &depth_one_options).expect("depth one save should fit");
+    let depth_one_size = fs::metadata(depth_one_options.session_file_path())
+        .expect("depth one metadata")
+        .len();
+
+    let mut depth_two_options = limit_test_options(temp.path(), "display-near-depth-two", true);
+    depth_two_options.max_file_size_bytes = u64::MAX;
+    depth_two_options.max_persisted_undo_depth = Some(2);
+    let depth_two_snapshot =
+        snapshot_from_input(&input, &depth_two_options).expect("depth two snapshot present");
+    save_snapshot(&depth_two_snapshot, &depth_two_options).expect("depth two save should fit");
+    let depth_two_size = fs::metadata(depth_two_options.session_file_path())
+        .expect("depth two metadata")
+        .len();
+
+    assert!(
+        (visible_size as u128) * 100 >= (depth_one_size as u128) * 90,
+        "visible-only payload should be near the depth-one cap for this regression"
+    );
+    assert!(
+        depth_two_size > depth_one_size,
+        "second history entry should exceed the depth-one size"
+    );
+
+    let mut options = limit_test_options(temp.path(), "display-near-fallback", true);
+    options.max_file_size_bytes = depth_one_size;
+    options.max_persisted_undo_depth = Some(2);
+    let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
+
+    let report = save_snapshot_with_report(&snapshot, &options)
+        .expect("save should keep depth-one history")
+        .expect("session should be written");
+    assert_eq!(
+        report.outcome,
+        SaveSnapshotOutcome::TrimmedHistory { depth: 1 }
+    );
+
+    let loaded = load_snapshot(&options)
+        .expect("load_snapshot should succeed")
+        .expect("snapshot should be present");
+    let transparent = loaded
+        .boards
+        .iter()
+        .find(|board| board.id == "transparent")
+        .expect("transparent board should be present");
+    let frame = &transparent.pages.pages[0];
+
+    assert_eq!(frame.shapes.len(), 2, "visible shapes should be saved");
+    assert_eq!(
+        frame.undo_stack_len(),
+        1,
+        "near-limit visible data should still keep a fitting depth-one history entry"
+    );
+}
+
+#[test]
 fn save_snapshot_report_marks_near_limit_at_ninety_percent() {
     let report = SaveSnapshotReport {
         path: Path::new("/tmp/session.json").to_path_buf(),

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -160,7 +160,19 @@ fn save_snapshot_allows_compressed_payload_that_fits_limit() {
     assert!(input.switch_to_page(ACTIVE_PAGE));
 
     let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
-    save_snapshot(&snapshot, &options).expect("compressed payload should fit and save");
+    let report = save_snapshot_with_report(&snapshot, &options)
+        .expect("compressed payload should fit and save")
+        .expect("session should be written");
+    assert_eq!(report.outcome, SaveSnapshotOutcome::Full);
+    assert!(report.compressed);
+    assert!(
+        report.raw_size as u64 > options.max_file_size_bytes,
+        "raw session should exceed the configured limit"
+    );
+    assert!(
+        report.written_size as u64 <= options.max_file_size_bytes,
+        "compressed session should fit configured limit"
+    );
 
     let saved_size = fs::metadata(options.session_file_path())
         .expect("session metadata")
@@ -266,7 +278,10 @@ fn save_snapshot_drops_history_when_modified_stroke_exceeds_limit() {
     options.max_file_size_bytes = visible_size + (full_size - visible_size) / 2;
     let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
 
-    save_snapshot(&snapshot, &options).expect("save should drop oversized history");
+    let report = save_snapshot_with_report(&snapshot, &options)
+        .expect("save should drop oversized history")
+        .expect("session should be written");
+    assert_eq!(report.outcome, SaveSnapshotOutcome::VisibleOnly);
 
     let saved_size = fs::metadata(options.session_file_path())
         .expect("fallback session metadata")
@@ -367,7 +382,13 @@ fn save_snapshot_keeps_largest_recent_history_depth_that_fits() {
     options.max_file_size_bytes = depth_two_size + (depth_three_size - depth_two_size) / 2;
     let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
 
-    save_snapshot(&snapshot, &options).expect("save should trim history to the fitting depth");
+    let report = save_snapshot_with_report(&snapshot, &options)
+        .expect("save should trim history to the fitting depth")
+        .expect("session should be written");
+    assert_eq!(
+        report.outcome,
+        SaveSnapshotOutcome::TrimmedHistory { depth: 2 }
+    );
 
     let loaded = load_snapshot(&options)
         .expect("load_snapshot should succeed")
@@ -386,6 +407,25 @@ fn save_snapshot_keeps_largest_recent_history_depth_that_fits() {
         "save should keep the largest recent undo depth that fits"
     );
     assert_eq!(frame.redo_stack_len(), 0);
+}
+
+#[test]
+fn save_snapshot_report_marks_near_limit_at_ninety_percent() {
+    let report = SaveSnapshotReport {
+        path: Path::new("/tmp/session.json").to_path_buf(),
+        outcome: SaveSnapshotOutcome::Full,
+        raw_size: 90,
+        written_size: 90,
+        max_file_size_bytes: 100,
+        compressed: false,
+    };
+    assert!(report.is_near_limit());
+
+    let report = SaveSnapshotReport {
+        written_size: 89,
+        ..report
+    };
+    assert!(!report.is_near_limit());
 }
 
 fn add_image_and_annotations(frame: &mut crate::draw::Frame, page_index: usize, bytes: usize) {


### PR DESCRIPTION
## Summary
- check session size limits against the final bytes written after compression
- add image paste preflight so oversized pasted images are blocked before making unsavable session state
- preserve fitting undo history when possible, including depth 1 near the limit
- add near-limit, history-trimmed, visible-only, and save-failure user warnings
- harden load/save behavior around expanded compressed payload size
- improve session save, clipboard image, and shutdown diagnostics

## Notes
Existing users with an explicit `session.max_file_size_mb = 10` keep that value. New configs or missing values use the new 50 MiB default.