### PR TITLE
 fix: remove tablet pressure stroke startup blot

### DIFF
--- a/src/backend/wayland/handlers/tablet/frame.rs
+++ b/src/backend/wayland/handlers/tablet/frame.rs
@@ -75,12 +75,18 @@ impl WaylandState {
             return;
         }
 
+        let first_pressure_sample =
+            self.stylus_tip_down && self.stylus_pressure_thickness.is_none();
         let p01 = (pressure as f64) / 65535.0;
         crate::input::tablet::apply_pressure_to_state(
             p01,
             &mut self.input_state,
             self.tablet_settings,
         );
+        if first_pressure_sample {
+            self.input_state
+                .replace_active_drawing_pressure_samples(self.input_state.current_thickness);
+        }
         self.stylus_pressure_thickness = Some(self.input_state.current_thickness);
         self.record_stylus_peak(self.input_state.current_thickness);
     }
@@ -95,8 +101,7 @@ impl WaylandState {
         let next_hover_cursor_pos = self.stylus_hover_cursor_position();
         self.mark_stylus_hover_cursor_dirty(previous_hover_cursor_pos, next_hover_cursor_pos);
         if self.stylus_tip_down {
-            self.stylus_pressure_thickness = Some(self.input_state.current_thickness);
-            self.record_stylus_peak(self.input_state.current_thickness);
+            self.record_stylus_motion_thickness();
         }
     }
 
@@ -127,8 +132,7 @@ impl WaylandState {
             .on_mouse_press_with_canvas(MouseButton::Left, screen_x, screen_y, wx, wy);
         let base_thickness = self.input_state.current_thickness;
         self.stylus_base_thickness = Some(base_thickness);
-        self.stylus_pressure_thickness = Some(base_thickness);
-        self.record_stylus_peak(base_thickness);
+        self.record_stylus_motion_thickness();
         self.input_state.needs_redraw = true;
     }
 
@@ -173,5 +177,17 @@ impl WaylandState {
 
     fn current_stylus_position(&self) -> (f64, f64) {
         self.current_or_pending_stylus_position()
+    }
+
+    fn record_stylus_motion_thickness(&mut self) {
+        if self.tablet_settings.enabled
+            && self.tablet_settings.pressure_enabled
+            && self.stylus_pressure_thickness.is_none()
+        {
+            return;
+        }
+
+        self.stylus_pressure_thickness = Some(self.input_state.current_thickness);
+        self.record_stylus_peak(self.input_state.current_thickness);
     }
 }

--- a/src/input/state/core/tool_controls/settings.rs
+++ b/src/input/state/core/tool_controls/settings.rs
@@ -89,8 +89,41 @@ impl InputState {
             self.tool_settings.get_mut(tool).thickness = clamped;
         }
         self.current_thickness = clamped;
+        self.update_initial_pressure_sample(clamped);
         self.needs_redraw = true;
         clamped
+    }
+
+    #[allow(dead_code)] // Used by the binary Wayland backend; the lib target has no backend modules.
+    pub(crate) fn replace_active_drawing_pressure_samples(&mut self, thickness: f64) -> bool {
+        let clamped = thickness.clamp(MIN_STROKE_THICKNESS, MAX_STROKE_THICKNESS) as f32;
+        let DrawingState::Drawing {
+            point_thicknesses, ..
+        } = &mut self.state
+        else {
+            return false;
+        };
+        if point_thicknesses.is_empty() {
+            return false;
+        }
+
+        point_thicknesses.fill(clamped);
+        self.needs_redraw = true;
+        true
+    }
+
+    fn update_initial_pressure_sample(&mut self, thickness: f64) {
+        let DrawingState::Drawing {
+            points,
+            point_thicknesses,
+            ..
+        } = &mut self.state
+        else {
+            return;
+        };
+        if points.len() == 1 && point_thicknesses.len() == 1 {
+            point_thicknesses[0] = thickness as f32;
+        }
     }
 
     /// Sets or clears an explicit tool override. Returns true if the tool changed.

--- a/src/input/tablet/mod.rs
+++ b/src/input/tablet/mod.rs
@@ -57,7 +57,7 @@ mod tests {
     use super::*;
     use crate::config::{BoardsConfig, KeybindingsConfig, PresenterModeConfig};
     use crate::draw::{Color, FontDescriptor, Shape};
-    use crate::input::{ClickHighlightSettings, EraserMode, MouseButton, Tool};
+    use crate::input::{ClickHighlightSettings, DrawingState, EraserMode, MouseButton, Tool};
 
     fn make_state() -> InputState {
         let keybindings = KeybindingsConfig::default();
@@ -191,6 +191,27 @@ mod tests {
             panic!("expected pressure-sensitive stroke");
         };
         let widths: Vec<f32> = points.iter().map(|(_, _, width)| *width).collect();
-        assert_eq!(widths, vec![4.0, 2.0, 6.0]);
+        assert_eq!(widths, vec![2.0, 2.0, 6.0]);
+    }
+
+    #[test]
+    fn first_pressure_sample_replaces_unpressured_stroke_samples() {
+        let mut state = make_state();
+
+        state.set_tool_override(Some(Tool::Pen));
+        assert!(state.set_thickness(32.0));
+        state.on_mouse_press(MouseButton::Left, 0, 0);
+        state.on_mouse_motion(10, 0);
+        state.on_mouse_motion(20, 0);
+
+        assert!(state.replace_active_drawing_pressure_samples(2.0));
+
+        let DrawingState::Drawing {
+            point_thicknesses, ..
+        } = &state.state
+        else {
+            panic!("expected active drawing");
+        };
+        assert_eq!(point_thicknesses.as_slice(), &[2.0, 2.0, 2.0]);
     }
 }


### PR DESCRIPTION
Fixes #233

## Summary
- Reseed in-progress tablet strokes with the first real pressure sample.
- Avoid treating the pre-pressure base pen width as the stroke’s pressure peak.
- Add regression coverage for pressure strokes that start before pressure data arrives.

## Why
Tablet frames can deliver tip-down/motion before the first non-zero pressure sample. If the configured pen thickness is much larger than the tablet pressure range, the first stroke sample renders as a visible blot at the contact point.