### PR TITLE
fix: prevent stale session artifacts from restoring cleared drawings

### DIFF
--- a/src/backend/wayland/backend/event_loop/session_save.rs
+++ b/src/backend/wayland/backend/event_loop/session_save.rs
@@ -1,6 +1,6 @@
 use super::super::super::state::WaylandState;
 use crate::{
-    backend::wayland::session::SessionState,
+    backend::wayland::session::{self as runtime_session, SessionState},
     config::{Action, Config},
     input::state::UiToastKind,
     notification, session,
@@ -35,10 +35,13 @@ pub(super) fn persist_session(state: &WaylandState) -> Result<(), anyhow::Error>
         snapshot.as_ref(),
         snapshot_started.elapsed(),
     );
-    let report = save_snapshot_or_clear(state, options, snapshot, SessionSaveReason::Shutdown)?;
+    if should_skip_unloaded_contentless_save(state, options, snapshot.as_ref()) {
+        return Ok(());
+    }
+    let save = save_snapshot_or_clear(state, options, snapshot, SessionSaveReason::Shutdown)?;
     log_session_save_result(
         SessionSaveReason::Shutdown,
-        report.as_ref(),
+        save.report.as_ref(),
         started.elapsed(),
     );
     Ok(())
@@ -78,14 +81,19 @@ pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<
     );
 
     match save_snapshot_or_clear(state, &options, snapshot, SessionSaveReason::Autosave) {
-        Ok(report) => {
+        Ok(save) => {
             log_session_save_result(
                 SessionSaveReason::Autosave,
-                report.as_ref(),
+                save.report.as_ref(),
                 started.elapsed(),
             );
-            notify_session_save_report(state, report.as_ref());
-            record_autosave_success(&mut state.session, now, report.is_some());
+            notify_session_save_report(state, save.report.as_ref());
+            record_autosave_success(
+                &mut state.session,
+                now,
+                save.report.is_some(),
+                save.saved_board_data,
+            );
         }
         Err(err) => {
             if record_autosave_failure(&mut state.session, now, &options) {
@@ -103,17 +111,31 @@ fn save_snapshot_or_clear(
     options: &session::SessionOptions,
     snapshot: Option<session::SessionSnapshot>,
     reason: SessionSaveReason,
-) -> Result<Option<SaveSnapshotReport>, anyhow::Error> {
+) -> Result<SessionSaveAttempt, anyhow::Error> {
     if should_skip_protected_session_save(state, options) {
-        return Ok(None);
+        return Ok(SessionSaveAttempt::skipped());
+    }
+
+    if should_skip_unloaded_contentless_save(state, options, snapshot.as_ref()) {
+        return Ok(SessionSaveAttempt::skipped());
     }
 
     if let Some(snapshot) = snapshot {
-        return save_snapshot_with_reason(&snapshot, options, reason);
+        let saved_board_data = snapshot.has_board_data();
+        let report = save_snapshot_with_reason(
+            &snapshot,
+            options,
+            reason,
+            state.session.has_loaded_board_data(),
+        )?;
+        return Ok(SessionSaveAttempt {
+            saved_board_data: report.is_some() && saved_board_data,
+            report,
+        });
     }
 
     if !persistence_enabled(options) {
-        return Ok(None);
+        return Ok(SessionSaveAttempt::skipped());
     }
 
     let empty_snapshot = session::SessionSnapshot {
@@ -121,19 +143,52 @@ fn save_snapshot_or_clear(
         boards: Vec::new(),
         tool_state: None,
     };
-    save_snapshot_with_reason(&empty_snapshot, options, reason)
+    let report = save_snapshot_with_reason(
+        &empty_snapshot,
+        options,
+        reason,
+        state.session.has_loaded_board_data(),
+    )?;
+    Ok(SessionSaveAttempt {
+        report,
+        saved_board_data: false,
+    })
+}
+
+#[derive(Debug)]
+struct SessionSaveAttempt {
+    report: Option<SaveSnapshotReport>,
+    saved_board_data: bool,
+}
+
+impl SessionSaveAttempt {
+    fn skipped() -> Self {
+        Self {
+            report: None,
+            saved_board_data: false,
+        }
+    }
 }
 
 fn save_snapshot_with_reason(
     snapshot: &session::SessionSnapshot,
     options: &session::SessionOptions,
     reason: SessionSaveReason,
+    contentless_clear_boundary: bool,
 ) -> Result<Option<SaveSnapshotReport>, anyhow::Error> {
     match reason {
         SessionSaveReason::Autosave => {
-            session::save_snapshot_autosave_with_report(snapshot, options)
+            session::save_snapshot_autosave_with_report_and_clear_boundary(
+                snapshot,
+                options,
+                contentless_clear_boundary,
+            )
         }
-        SessionSaveReason::Shutdown => session::save_snapshot_with_report(snapshot, options),
+        SessionSaveReason::Shutdown => session::save_snapshot_with_report_and_clear_boundary(
+            snapshot,
+            options,
+            contentless_clear_boundary,
+        ),
     }
 }
 
@@ -312,6 +367,27 @@ fn should_skip_protected_session_save(
     skip
 }
 
+fn should_skip_unloaded_contentless_save(
+    state: &WaylandState,
+    options: &session::SessionOptions,
+    snapshot: Option<&session::SessionSnapshot>,
+) -> bool {
+    let skip = runtime_session::should_skip_unloaded_contentless_save(
+        state.session.has_loaded_board_data(),
+        state.session.is_dirty(),
+        state.input_state.is_session_dirty(),
+        snapshot.is_some_and(session::SessionSnapshot::has_board_data),
+        runtime_session::has_session_artifact(options),
+    );
+    if skip {
+        log::warn!(
+            "Skipping session save to {} because no session was loaded, no session changes were recorded, and the current snapshot has no board data",
+            options.session_file_path().display()
+        );
+    }
+    skip
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SessionSaveNotification {
     NearLimit,
@@ -430,9 +506,14 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-fn record_autosave_success(session_state: &mut SessionState, now: Instant, saved: bool) {
+fn record_autosave_success(
+    session_state: &mut SessionState,
+    now: Instant,
+    saved: bool,
+    saved_board_data: bool,
+) {
     if saved {
-        session_state.mark_saved(now);
+        session_state.mark_saved(now, saved_board_data);
     }
 }
 
@@ -540,7 +621,7 @@ mod tests {
         assert!(!record_autosave_failure(&mut state, now, &options));
         assert!(!state.autosave_due(now, &options));
 
-        record_autosave_success(&mut state, now, true);
+        record_autosave_success(&mut state, now, true, false);
         state.record_input_dirty(now, true);
         assert!(record_autosave_failure(&mut state, now, &options));
     }
@@ -558,8 +639,25 @@ mod tests {
         state.record_input_dirty(now, true);
         assert!(state.autosave_due(now + Duration::from_millis(2), &options));
 
-        record_autosave_success(&mut state, now + Duration::from_millis(2), true);
+        record_autosave_success(&mut state, now + Duration::from_millis(2), true, false);
         assert!(!state.autosave_due(now + Duration::from_millis(2), &options));
+    }
+
+    #[test]
+    fn record_autosave_success_tracks_saved_board_data_for_future_clear_boundaries() {
+        let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display-1");
+        options.persist_transparent = true;
+        options.autosave_enabled = true;
+
+        let mut state = SessionState::new(Some(options));
+        assert!(!state.has_loaded_board_data());
+
+        record_autosave_success(&mut state, Instant::now(), true, true);
+
+        assert!(
+            state.has_loaded_board_data(),
+            "board data saved during this run must count when the next contentless save decides whether it is a clear"
+        );
     }
 
     #[test]
@@ -576,7 +674,7 @@ mod tests {
         let due_at = now + Duration::from_millis(2);
         assert!(state.autosave_due(due_at, &options));
 
-        record_autosave_success(&mut state, due_at, false);
+        record_autosave_success(&mut state, due_at, false, false);
 
         assert!(state.autosave_due(due_at, &options));
     }

--- a/src/backend/wayland/handlers/compositor.rs
+++ b/src/backend/wayland/handlers/compositor.rs
@@ -209,15 +209,19 @@ impl CompositorHandler for WaylandState {
         }
 
         if let Some(result) = load_result {
+            let mut loaded_board_data = false;
             match result {
-                Ok(outcome) => self.handle_session_load_outcome(outcome, "output load"),
+                Ok(outcome) => {
+                    loaded_board_data = outcome.has_board_data();
+                    self.handle_session_load_outcome(outcome, "output load");
+                }
                 Err(err) => {
                     warn!("Failed to load session state: {}", err);
                 }
             }
 
             if load_requested {
-                self.session.mark_loaded();
+                self.session.mark_loaded(loaded_board_data);
                 self.input_state.needs_redraw = true;
             }
         }

--- a/src/backend/wayland/handlers/layer.rs
+++ b/src/backend/wayland/handlers/layer.rs
@@ -117,9 +117,11 @@ impl LayerShellHandler for WaylandState {
         {
             let load_result = session::load_snapshot_with_outcome(options);
             let mut load_succeeded = false;
+            let mut loaded_board_data = false;
             match load_result {
                 Ok(outcome) => {
                     load_succeeded = true;
+                    loaded_board_data = outcome.has_board_data();
                     self.handle_session_load_outcome(outcome, "fallback load");
                 }
                 Err(err) => {
@@ -130,7 +132,7 @@ impl LayerShellHandler for WaylandState {
             // enter still reloads when a concrete output identity arrives because that changes
             // the identity and triggers a fresh load.
             if load_succeeded {
-                self.session.mark_loaded();
+                self.session.mark_loaded(loaded_board_data);
             }
             self.input_state.needs_redraw = true;
         }

--- a/src/backend/wayland/handlers/xdg.rs
+++ b/src/backend/wayland/handlers/xdg.rs
@@ -143,9 +143,11 @@ impl WindowHandler for WaylandState {
         {
             let load_result = session::load_snapshot_with_outcome(options);
             let mut load_succeeded = false;
+            let mut loaded_board_data = false;
             match load_result {
                 Ok(outcome) => {
                     load_succeeded = true;
+                    loaded_board_data = outcome.has_board_data();
                     self.handle_session_load_outcome(outcome, "fallback load");
                 }
                 Err(err) => {
@@ -155,7 +157,7 @@ impl WindowHandler for WaylandState {
             // Mark loaded to avoid repeated loads when load succeeded; compositor enter still
             // reloads when it sets a new output identity.
             if load_succeeded {
-                self.session.mark_loaded();
+                self.session.mark_loaded(loaded_board_data);
             }
             self.input_state.needs_redraw = true;
         }

--- a/src/backend/wayland/session.rs
+++ b/src/backend/wayland/session.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 pub struct SessionState {
     options: Option<SessionOptions>,
     loaded: bool,
+    loaded_board_data: bool,
     dirty: bool,
     dirty_since: Option<Instant>,
     last_dirty_at: Option<Instant>,
@@ -32,6 +33,7 @@ impl SessionState {
         Self {
             options,
             loaded: false,
+            loaded_board_data: false,
             dirty: false,
             dirty_since: None,
             last_dirty_at: None,
@@ -62,9 +64,18 @@ impl SessionState {
         self.loaded
     }
 
-    /// Marks the session as loaded and records the identity used.
-    pub fn mark_loaded(&mut self) {
+    /// Marks the session as loaded and records whether board data is now on disk.
+    pub fn mark_loaded(&mut self, loaded_board_data: bool) {
         self.loaded = true;
+        self.loaded_board_data = loaded_board_data;
+    }
+
+    pub fn has_loaded_board_data(&self) -> bool {
+        self.loaded_board_data
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
     }
 
     pub fn record_input_dirty(&mut self, now: Instant, input_dirty: bool) {
@@ -78,7 +89,7 @@ impl SessionState {
         self.last_dirty_at = Some(now);
     }
 
-    pub fn mark_saved(&mut self, now: Instant) {
+    pub fn mark_saved(&mut self, now: Instant, saved_board_data: bool) {
         self.dirty = false;
         self.dirty_since = None;
         self.last_dirty_at = None;
@@ -86,6 +97,7 @@ impl SessionState {
         self.autosave_retry_at = None;
         self.autosave_deferred_until = None;
         self.notified_failure = false;
+        self.loaded_board_data = saved_board_data;
     }
 
     pub fn mark_clean_after_load(&mut self) {
@@ -208,6 +220,54 @@ fn autosave_active(options: &SessionOptions) -> bool {
         && (options.any_enabled() || options.restore_tool_state || options.persist_history)
 }
 
+pub(super) fn has_session_artifact(options: &SessionOptions) -> bool {
+    options.session_file_path().exists()
+        || options.backup_file_path().exists()
+        || options.backup_recovery_marker_file_path().exists()
+        || options.clear_marker_file_path().exists()
+        || options.recovery_recoverable_marker_file_path().exists()
+        || has_recovery_artifact(options)
+}
+
+fn has_recovery_artifact(options: &SessionOptions) -> bool {
+    let recovery_path = options.recovery_file_path();
+    if recovery_path.exists() {
+        return true;
+    }
+    let Some(parent) = recovery_path.parent() else {
+        return false;
+    };
+    let Some(recovery_name) = recovery_path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let preserved_prefix = format!("{recovery_name}.");
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+        path.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(&preserved_prefix))
+    })
+}
+
+pub(super) fn should_skip_unloaded_contentless_save(
+    loaded_board_data: bool,
+    session_dirty: bool,
+    input_dirty: bool,
+    has_board_data: bool,
+    session_artifact_exists: bool,
+) -> bool {
+    !has_board_data
+        && !loaded_board_data
+        && !session_dirty
+        && !input_dirty
+        && session_artifact_exists
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,7 +338,7 @@ mod tests {
         let now = Instant::now();
         state.record_input_dirty(now, true);
         state.defer_autosave(now, Duration::from_secs(60));
-        state.mark_saved(now);
+        state.mark_saved(now, false);
 
         assert_eq!(state.autosave_deferred_until, None);
     }
@@ -314,5 +374,89 @@ mod tests {
 
         state.mark_clean_after_load();
         assert!(state.should_skip_save_for_protected_path(&path, false));
+    }
+
+    #[test]
+    fn contentless_save_guard_blocks_clean_unloaded_save_when_primary_exists() {
+        assert!(should_skip_unloaded_contentless_save(
+            false, false, false, false, true,
+        ));
+    }
+
+    #[test]
+    fn contentless_save_guard_blocks_clean_unloaded_save_when_only_backup_exists() {
+        let temp = crate::test_temp::tempdir().expect("tempdir");
+        let options = SessionOptions::new(temp.path().to_path_buf(), "backup-only");
+        std::fs::write(options.backup_file_path(), b"backup").expect("backup write");
+
+        assert!(has_session_artifact(&options));
+        assert!(should_skip_unloaded_contentless_save(
+            false,
+            false,
+            false,
+            false,
+            has_session_artifact(&options),
+        ));
+    }
+
+    #[test]
+    fn contentless_save_guard_blocks_clean_unloaded_save_when_only_recovery_exists() {
+        let temp = crate::test_temp::tempdir().expect("tempdir");
+        let options = SessionOptions::new(temp.path().to_path_buf(), "recovery-only");
+        std::fs::write(options.recovery_file_path(), b"recovery").expect("recovery write");
+
+        assert!(has_session_artifact(&options));
+        assert!(should_skip_unloaded_contentless_save(
+            false,
+            false,
+            false,
+            false,
+            has_session_artifact(&options),
+        ));
+    }
+
+    #[test]
+    fn contentless_save_guard_blocks_clean_loaded_empty_save_when_only_preserved_recovery_exists() {
+        let temp = crate::test_temp::tempdir().expect("tempdir");
+        let options = SessionOptions::new(temp.path().to_path_buf(), "preserved-recovery");
+        std::fs::write(
+            options
+                .recovery_file_path()
+                .with_extension("recovery.empty"),
+            b"recovery",
+        )
+        .expect("preserved recovery write");
+
+        assert!(has_session_artifact(&options));
+        assert!(should_skip_unloaded_contentless_save(
+            false,
+            false,
+            false,
+            false,
+            has_session_artifact(&options),
+        ));
+    }
+
+    #[test]
+    fn contentless_save_guard_allows_real_board_data_or_dirty_state() {
+        assert!(!should_skip_unloaded_contentless_save(
+            false, false, false, true, true,
+        ));
+        assert!(!should_skip_unloaded_contentless_save(
+            false, true, false, false, true,
+        ));
+        assert!(!should_skip_unloaded_contentless_save(
+            false, false, true, false, true,
+        ));
+        assert!(!should_skip_unloaded_contentless_save(
+            true, false, false, false, true,
+        ));
+    }
+
+    #[test]
+    fn contentless_save_guard_allows_noop_when_no_session_artifact_exists() {
+        assert!(!should_skip_unloaded_contentless_save(
+            false, false, false, false, false,
+        ));
     }
 }

--- a/src/backend/wayland/state/core/output.rs
+++ b/src/backend/wayland/state/core/output.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use super::super::*;
 use crate::{
+    backend::wayland::session as runtime_session,
     input::state::{OutputFocusAction, UiToastKind},
     notification,
     session::{self, SessionSnapshot},
@@ -129,17 +130,34 @@ impl WaylandState {
             return;
         }
 
-        let save_result = if let Some(snapshot) =
-            session::snapshot_from_input(&self.input_state, &save_options)
-        {
-            session::save_snapshot(&snapshot, &save_options).map(|_| true)
+        let snapshot = session::snapshot_from_input(&self.input_state, &save_options);
+        if self.should_skip_unloaded_contentless_session_save(&save_options, snapshot.as_ref()) {
+            return;
+        }
+
+        let contentless_clear_boundary = self.session.has_loaded_board_data();
+        let saved_board_data = snapshot
+            .as_ref()
+            .is_some_and(session::SessionSnapshot::has_board_data);
+        let save_result = if let Some(snapshot) = snapshot {
+            session::save_snapshot_with_report_and_clear_boundary(
+                &snapshot,
+                &save_options,
+                contentless_clear_boundary,
+            )
+            .map(|report| report.is_some())
         } else if Self::session_persistence_enabled(&save_options) {
             let empty_snapshot = SessionSnapshot {
                 active_board_id: self.input_state.board_id().to_string(),
                 boards: Vec::new(),
                 tool_state: None,
             };
-            session::save_snapshot(&empty_snapshot, &save_options).map(|_| true)
+            session::save_snapshot_with_report_and_clear_boundary(
+                &empty_snapshot,
+                &save_options,
+                contentless_clear_boundary,
+            )
+            .map(|report| report.is_some())
         } else {
             Ok(false)
         };
@@ -153,7 +171,7 @@ impl WaylandState {
                     runtime_options.set_output_identity(output_identity.as_deref());
                 }
                 let _ = self.input_state.take_session_dirty();
-                self.session.mark_saved(Instant::now());
+                self.session.mark_saved(Instant::now(), saved_board_data);
                 info!(
                     "Persisted session before {} (output_identity={:?})",
                     reason,
@@ -183,6 +201,20 @@ impl WaylandState {
                         options.session_file_path().display()
                     );
                     session::apply_snapshot(&mut self.input_state, *snapshot, &options);
+                }
+            }
+            session::LoadSnapshotOutcome::LoadedFromBackup(snapshot) => {
+                if let Some(options) = self.session_options().cloned() {
+                    warn!(
+                        "Restoring session {} from backup {} because the primary session had no board data",
+                        context,
+                        options.backup_file_path().display()
+                    );
+                    session::apply_snapshot(&mut self.input_state, *snapshot, &options);
+                    self.input_state.set_ui_toast(
+                        UiToastKind::Warning,
+                        "Restored drawings from the session backup; the primary session had no board data.",
+                    );
                 }
             }
             session::LoadSnapshotOutcome::LoadedFromRecovery(snapshot) => {
@@ -245,6 +277,27 @@ impl WaylandState {
             info!(
                 "Skipping session save to {} because a previous oversized compressed session was left protected and no session changes have been made",
                 session_path.display()
+            );
+        }
+        skip
+    }
+
+    fn should_skip_unloaded_contentless_session_save(
+        &self,
+        options: &session::SessionOptions,
+        snapshot: Option<&SessionSnapshot>,
+    ) -> bool {
+        let skip = runtime_session::should_skip_unloaded_contentless_save(
+            self.session.has_loaded_board_data(),
+            self.session.is_dirty(),
+            self.input_state.is_session_dirty(),
+            snapshot.is_some_and(SessionSnapshot::has_board_data),
+            runtime_session::has_session_artifact(options),
+        );
+        if skip {
+            info!(
+                "Skipping session save to {} because no session was loaded, no session changes were recorded, and the current snapshot has no board data",
+                options.session_file_path().display()
             );
         }
         skip

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -24,7 +24,8 @@ pub(crate) use snapshot::{
     DEFAULT_MAX_EXPANDED_SESSION_BYTES, SaveLimitExceeded, SaveSnapshotOutcome, SaveSnapshotReport,
     SnapshotPayloadEstimate, SnapshotSaveEstimate, estimate_snapshot_payload,
     estimate_snapshot_save, estimate_snapshot_without_history_payload,
-    save_snapshot_autosave_with_report, save_snapshot_with_report,
+    save_snapshot_autosave_with_report, save_snapshot_autosave_with_report_and_clear_boundary,
+    save_snapshot_with_report, save_snapshot_with_report_and_clear_boundary,
 };
 #[allow(unused_imports)]
 pub(crate) use snapshot::{LoadSnapshotOutcome, load_snapshot_with_outcome};

--- a/src/session/options/types.rs
+++ b/src/session/options/types.rs
@@ -96,9 +96,26 @@ impl SessionOptions {
             .join(format!("{}.json.bak", self.session_file_stem()))
     }
 
+    pub fn backup_recovery_marker_file_path(&self) -> PathBuf {
+        self.base_dir
+            .join(format!("{}.json.bak.recoverable", self.session_file_stem()))
+    }
+
     pub fn recovery_file_path(&self) -> PathBuf {
         self.base_dir
             .join(format!("{}.json.recovery", self.session_file_stem()))
+    }
+
+    pub fn recovery_recoverable_marker_file_path(&self) -> PathBuf {
+        self.base_dir.join(format!(
+            "{}.json.recovery.recoverable",
+            self.session_file_stem()
+        ))
+    }
+
+    pub fn clear_marker_file_path(&self) -> PathBuf {
+        self.base_dir
+            .join(format!("{}.json.cleared", self.session_file_stem()))
     }
 
     pub fn lock_file_path(&self) -> PathBuf {

--- a/src/session/snapshot/load.rs
+++ b/src/session/snapshot/load.rs
@@ -30,6 +30,7 @@ pub struct LoadedSnapshot {
 #[derive(Debug)]
 pub(crate) enum LoadSnapshotOutcome {
     Loaded(Box<SessionSnapshot>),
+    LoadedFromBackup(Box<SessionSnapshot>),
     LoadedFromRecovery(Box<SessionSnapshot>),
     Empty,
     ExpandedTooLarge {
@@ -38,11 +39,24 @@ pub(crate) enum LoadSnapshotOutcome {
     },
 }
 
+impl LoadSnapshotOutcome {
+    #[allow(dead_code)]
+    pub(crate) fn has_board_data(&self) -> bool {
+        match self {
+            Self::Loaded(snapshot)
+            | Self::LoadedFromBackup(snapshot)
+            | Self::LoadedFromRecovery(snapshot) => snapshot.has_board_data(),
+            Self::Empty | Self::ExpandedTooLarge { .. } => false,
+        }
+    }
+}
+
 /// Attempt to load a previously saved session.
 #[allow(dead_code)]
 pub fn load_snapshot(options: &SessionOptions) -> Result<Option<SessionSnapshot>> {
     match load_snapshot_with_outcome(options)? {
         LoadSnapshotOutcome::Loaded(snapshot)
+        | LoadSnapshotOutcome::LoadedFromBackup(snapshot)
         | LoadSnapshotOutcome::LoadedFromRecovery(snapshot) => Ok(Some(*snapshot)),
         LoadSnapshotOutcome::Empty | LoadSnapshotOutcome::ExpandedTooLarge { .. } => Ok(None),
     }
@@ -69,10 +83,31 @@ pub(super) fn load_snapshot_with_expanded_limit(
     let recovery_path = options.recovery_file_path();
     let session_metadata = fs::metadata(&session_path).ok();
     let recovery_metadata = fs::metadata(&recovery_path).ok();
+    let clear_marker_metadata = fs::metadata(options.clear_marker_file_path()).ok();
+    let backup_recovery_marker_metadata =
+        recoverable_backup_marker_metadata(options, clear_marker_metadata.as_ref());
+    let recovery_recoverable_marker_metadata =
+        recoverable_recovery_marker_metadata(options, clear_marker_metadata.as_ref());
 
     if let Some(recovery_metadata) = recovery_metadata.as_ref()
         && should_prefer_recovery(recovery_metadata, session_metadata.as_ref())
     {
+        if clear_marker_suppresses_artifact(
+            "session recovery",
+            &recovery_path,
+            recovery_metadata,
+            clear_marker_metadata.as_ref(),
+        ) {
+            return load_normal_session_or_empty(
+                options,
+                &session_path,
+                session_metadata,
+                max_expanded_size,
+                clear_marker_metadata.as_ref(),
+                backup_recovery_marker_metadata.as_ref(),
+                recovery_recoverable_marker_metadata.as_ref(),
+            );
+        }
         info!(
             "Loading session recovery artifact {} before normal session {}",
             recovery_path.display(),
@@ -84,11 +119,13 @@ pub(super) fn load_snapshot_with_expanded_limit(
             max_expanded_size,
             false,
             "session recovery",
+            CorruptLoadAction::Backup,
         )?;
         match recovery_outcome {
             LoadSnapshotOutcome::Loaded(snapshot) => {
                 return Ok(LoadSnapshotOutcome::LoadedFromRecovery(snapshot));
             }
+            loaded @ LoadSnapshotOutcome::LoadedFromBackup(_) => return Ok(loaded),
             loaded @ LoadSnapshotOutcome::LoadedFromRecovery(_) => return Ok(loaded),
             LoadSnapshotOutcome::Empty => {
                 warn!(
@@ -109,7 +146,15 @@ pub(super) fn load_snapshot_with_expanded_limit(
         }
     }
 
-    load_normal_session_or_empty(options, &session_path, session_metadata, max_expanded_size)
+    load_normal_session_or_empty(
+        options,
+        &session_path,
+        session_metadata,
+        max_expanded_size,
+        clear_marker_metadata.as_ref(),
+        backup_recovery_marker_metadata.as_ref(),
+        recovery_recoverable_marker_metadata.as_ref(),
+    )
 }
 
 fn load_snapshot_path_with_outcome(
@@ -118,6 +163,7 @@ fn load_snapshot_path_with_outcome(
     max_expanded_size: u64,
     enforce_configured_file_size: bool,
     label: &str,
+    corrupt_load_action: CorruptLoadAction,
 ) -> Result<LoadSnapshotOutcome> {
     let metadata = fs::metadata(session_path)
         .with_context(|| format!("failed to stat session file {}", session_path.display()))?;
@@ -218,21 +264,38 @@ fn load_snapshot_path_with_outcome(
         }
         Err(err) => {
             warn!(
-                "Failed to load {} {}; backing up and continuing with defaults: {}",
+                "Failed to load {} {}; continuing with defaults: {}",
                 label,
                 session_path.display(),
                 err
             );
-            if let Err(backup_err) = backup_corrupt_session(session_path, options) {
-                warn!(
-                    "Failed to back up corrupt session {}: {}",
-                    session_path.display(),
-                    backup_err
-                );
+            match corrupt_load_action {
+                CorruptLoadAction::Backup => {
+                    if let Err(backup_err) = backup_corrupt_session(session_path, options) {
+                        warn!(
+                            "Failed to back up corrupt session {}: {}",
+                            session_path.display(),
+                            backup_err
+                        );
+                    }
+                }
+                CorruptLoadAction::Preserve => {
+                    debug!(
+                        "Leaving unloadable {} {} in place because it is suppressed by the session clear marker",
+                        label,
+                        session_path.display()
+                    );
+                }
             }
             Ok(LoadSnapshotOutcome::Empty)
         }
     }
+}
+
+#[derive(Clone, Copy)]
+enum CorruptLoadAction {
+    Backup,
+    Preserve,
 }
 
 fn load_normal_session_or_empty(
@@ -240,15 +303,302 @@ fn load_normal_session_or_empty(
     session_path: &Path,
     session_metadata: Option<fs::Metadata>,
     max_expanded_size: u64,
+    clear_marker_metadata: Option<&fs::Metadata>,
+    backup_recovery_marker_metadata: Option<&fs::Metadata>,
+    recovery_recoverable_marker_metadata: Option<&fs::Metadata>,
 ) -> Result<LoadSnapshotOutcome> {
-    if session_metadata.is_none() {
+    let Some(primary_metadata) = session_metadata.as_ref() else {
+        if let Some(backup) = load_contentful_backup(
+            options,
+            max_expanded_size,
+            None,
+            clear_marker_metadata,
+            backup_recovery_marker_metadata,
+            recovery_recoverable_marker_metadata,
+        )? {
+            return Ok(LoadSnapshotOutcome::LoadedFromBackup(backup));
+        }
         info!(
             "Session file not found at {}; skipping load",
             session_path.display()
         );
         return Ok(LoadSnapshotOutcome::Empty);
+    };
+
+    if clear_marker_suppresses_artifact(
+        "primary session",
+        session_path,
+        primary_metadata,
+        clear_marker_metadata,
+    ) {
+        match load_snapshot_path_with_outcome(
+            session_path,
+            options,
+            max_expanded_size,
+            true,
+            "session",
+            CorruptLoadAction::Preserve,
+        )? {
+            LoadSnapshotOutcome::Loaded(snapshot) if !snapshot.has_board_data() => {
+                return Ok(LoadSnapshotOutcome::Loaded(snapshot));
+            }
+            LoadSnapshotOutcome::Loaded(_) => {}
+            LoadSnapshotOutcome::Empty | LoadSnapshotOutcome::ExpandedTooLarge { .. } => {}
+            LoadSnapshotOutcome::LoadedFromBackup(_)
+            | LoadSnapshotOutcome::LoadedFromRecovery(_) => {}
+        }
+
+        if let Some(backup) = load_contentful_backup(
+            options,
+            max_expanded_size,
+            None,
+            clear_marker_metadata,
+            backup_recovery_marker_metadata,
+            recovery_recoverable_marker_metadata,
+        )? {
+            return Ok(LoadSnapshotOutcome::LoadedFromBackup(backup));
+        }
+        return Ok(LoadSnapshotOutcome::Empty);
     }
-    load_snapshot_path_with_outcome(session_path, options, max_expanded_size, true, "session")
+
+    let outcome = load_snapshot_path_with_outcome(
+        session_path,
+        options,
+        max_expanded_size,
+        true,
+        "session",
+        CorruptLoadAction::Backup,
+    )?;
+    let LoadSnapshotOutcome::Loaded(snapshot) = outcome else {
+        return Ok(outcome);
+    };
+
+    if snapshot.has_board_data() {
+        return Ok(LoadSnapshotOutcome::Loaded(snapshot));
+    }
+
+    if let Some(backup) = load_contentful_backup(
+        options,
+        max_expanded_size,
+        Some(primary_metadata),
+        clear_marker_metadata,
+        backup_recovery_marker_metadata,
+        recovery_recoverable_marker_metadata,
+    )? {
+        return Ok(LoadSnapshotOutcome::LoadedFromBackup(backup));
+    }
+
+    if let Some(recovery) = load_contentful_recovery(
+        options,
+        max_expanded_size,
+        clear_marker_metadata,
+        recovery_recoverable_marker_metadata,
+    )? {
+        return Ok(LoadSnapshotOutcome::LoadedFromRecovery(recovery));
+    }
+
+    Ok(LoadSnapshotOutcome::Loaded(snapshot))
+}
+
+fn load_contentful_backup(
+    options: &SessionOptions,
+    max_expanded_size: u64,
+    primary_metadata: Option<&fs::Metadata>,
+    clear_marker_metadata: Option<&fs::Metadata>,
+    backup_recovery_marker_metadata: Option<&fs::Metadata>,
+    recovery_recoverable_marker_metadata: Option<&fs::Metadata>,
+) -> Result<Option<Box<SessionSnapshot>>> {
+    let backup_path = options.backup_file_path();
+    let Some(backup_metadata) = fs::metadata(&backup_path).ok() else {
+        return Ok(None);
+    };
+
+    if clear_marker_suppresses_artifact(
+        "session backup",
+        &backup_path,
+        &backup_metadata,
+        clear_marker_metadata,
+    ) {
+        return Ok(None);
+    }
+
+    if let Some(primary_metadata) = primary_metadata
+        && backup_recovery_marker_metadata.is_none()
+        && !backup_is_newer_than_primary(&backup_metadata, primary_metadata)
+    {
+        info!(
+            "Primary session {} contains no board data, but backup {} is not newer; keeping primary session",
+            options.session_file_path().display(),
+            backup_path.display()
+        );
+        return Ok(None);
+    }
+
+    if primary_metadata.is_some() {
+        warn!(
+            "Primary session {} contains no board data; checking newer backup {} before accepting the blank session",
+            options.session_file_path().display(),
+            backup_path.display()
+        );
+    } else {
+        warn!(
+            "Primary session {} is missing; checking backup {} for recoverable board data",
+            options.session_file_path().display(),
+            backup_path.display()
+        );
+    }
+
+    match load_snapshot_path_with_outcome(
+        &backup_path,
+        options,
+        max_expanded_size,
+        true,
+        "session backup",
+        CorruptLoadAction::Backup,
+    )? {
+        LoadSnapshotOutcome::Loaded(snapshot) if snapshot.has_board_data() => {
+            warn!(
+                "Restoring board data from backup {} because primary session {} contained no board data",
+                backup_path.display(),
+                options.session_file_path().display()
+            );
+            Ok(Some(snapshot))
+        }
+        LoadSnapshotOutcome::Loaded(_) => {
+            info!(
+                "Session backup {} also contains no board data; keeping primary session",
+                backup_path.display()
+            );
+            Ok(None)
+        }
+        LoadSnapshotOutcome::Empty => Ok(None),
+        LoadSnapshotOutcome::ExpandedTooLarge { path, .. } => {
+            warn!(
+                "Session backup {} is too large to restore; keeping primary session",
+                path.display()
+            );
+            Ok(None)
+        }
+        LoadSnapshotOutcome::LoadedFromBackup(_) | LoadSnapshotOutcome::LoadedFromRecovery(_) => {
+            load_contentful_recovery(
+                options,
+                max_expanded_size,
+                clear_marker_metadata,
+                recovery_recoverable_marker_metadata,
+            )
+        }
+    }
+}
+
+fn load_contentful_recovery(
+    options: &SessionOptions,
+    max_expanded_size: u64,
+    clear_marker_metadata: Option<&fs::Metadata>,
+    recovery_recoverable_marker_metadata: Option<&fs::Metadata>,
+) -> Result<Option<Box<SessionSnapshot>>> {
+    if recovery_recoverable_marker_metadata.is_none() {
+        return Ok(None);
+    }
+
+    let recovery_path = options.recovery_file_path();
+    let Some(recovery_metadata) = fs::metadata(&recovery_path).ok() else {
+        return Ok(None);
+    };
+    if clear_marker_suppresses_artifact(
+        "session recovery",
+        &recovery_path,
+        &recovery_metadata,
+        clear_marker_metadata,
+    ) {
+        return Ok(None);
+    }
+
+    match load_snapshot_path_with_outcome(
+        &recovery_path,
+        options,
+        max_expanded_size,
+        false,
+        "session recovery",
+        CorruptLoadAction::Backup,
+    )? {
+        LoadSnapshotOutcome::Loaded(snapshot) if snapshot.has_board_data() => Ok(Some(snapshot)),
+        LoadSnapshotOutcome::Loaded(_) | LoadSnapshotOutcome::Empty => Ok(None),
+        LoadSnapshotOutcome::ExpandedTooLarge { path, .. } => {
+            preserve_unloadable_recovery(&path, "too-large");
+            Ok(None)
+        }
+        LoadSnapshotOutcome::LoadedFromBackup(_) | LoadSnapshotOutcome::LoadedFromRecovery(_) => {
+            Ok(None)
+        }
+    }
+}
+
+fn backup_is_newer_than_primary(backup: &fs::Metadata, primary: &fs::Metadata) -> bool {
+    match (backup.modified(), primary.modified()) {
+        (Ok(backup_modified), Ok(primary_modified)) => backup_modified > primary_modified,
+        _ => false,
+    }
+}
+
+fn recoverable_backup_marker_metadata(
+    options: &SessionOptions,
+    clear_marker_metadata: Option<&fs::Metadata>,
+) -> Option<fs::Metadata> {
+    let marker_path = options.backup_recovery_marker_file_path();
+    let marker_metadata = fs::metadata(&marker_path).ok()?;
+    if clear_marker_suppresses_artifact(
+        "backup recovery marker",
+        &marker_path,
+        &marker_metadata,
+        clear_marker_metadata,
+    ) {
+        return None;
+    }
+    Some(marker_metadata)
+}
+
+fn recoverable_recovery_marker_metadata(
+    options: &SessionOptions,
+    clear_marker_metadata: Option<&fs::Metadata>,
+) -> Option<fs::Metadata> {
+    let marker_path = options.recovery_recoverable_marker_file_path();
+    let marker_metadata = fs::metadata(&marker_path).ok()?;
+    if clear_marker_suppresses_artifact(
+        "recovery recoverable marker",
+        &marker_path,
+        &marker_metadata,
+        clear_marker_metadata,
+    ) {
+        return None;
+    }
+    Some(marker_metadata)
+}
+
+fn clear_marker_suppresses_artifact(
+    label: &str,
+    path: &Path,
+    artifact_metadata: &fs::Metadata,
+    clear_marker_metadata: Option<&fs::Metadata>,
+) -> bool {
+    let Some(clear_marker_metadata) = clear_marker_metadata else {
+        return false;
+    };
+    let artifact_newer_than_marker = match (
+        artifact_metadata.modified(),
+        clear_marker_metadata.modified(),
+    ) {
+        (Ok(artifact_modified), Ok(marker_modified)) => artifact_modified > marker_modified,
+        _ => false,
+    };
+    if artifact_newer_than_marker {
+        return false;
+    }
+    info!(
+        "Ignoring {} {} because it is not newer than the session clear marker",
+        label,
+        path.display()
+    );
+    true
 }
 
 fn preserve_unloadable_recovery(path: &Path, reason: &str) {

--- a/src/session/snapshot/mod.rs
+++ b/src/session/snapshot/mod.rs
@@ -19,7 +19,8 @@ pub(crate) use save::{
     SaveLimitExceeded, SaveSnapshotOutcome, SaveSnapshotReport, SnapshotPayloadEstimate,
     SnapshotSaveEstimate, estimate_snapshot_payload, estimate_snapshot_save,
     estimate_snapshot_without_history_payload, save_snapshot_autosave_with_report,
-    save_snapshot_with_report,
+    save_snapshot_autosave_with_report_and_clear_boundary, save_snapshot_with_report,
+    save_snapshot_with_report_and_clear_boundary,
 };
 #[allow(unused_imports)]
 pub use types::BoardSnapshot;

--- a/src/session/snapshot/save.rs
+++ b/src/session/snapshot/save.rs
@@ -132,22 +132,46 @@ impl fmt::Display for SavePayloadTooLarge {
 impl std::error::Error for SavePayloadTooLarge {}
 
 /// Persist the provided snapshot to disk according to the configured options.
+#[allow(dead_code)]
 pub fn save_snapshot(snapshot: &SessionSnapshot, options: &SessionOptions) -> Result<()> {
     save_snapshot_with_report(snapshot, options).map(|_| ())
 }
 
 /// Persist the provided snapshot and report what was written.
+#[allow(dead_code)]
 pub(crate) fn save_snapshot_with_report(
     snapshot: &SessionSnapshot,
     options: &SessionOptions,
 ) -> Result<Option<SaveSnapshotReport>> {
-    save_snapshot_with_expanded_limit(snapshot, options, DEFAULT_MAX_EXPANDED_SESSION_BYTES)
+    save_snapshot_with_report_and_clear_boundary(snapshot, options, false)
+}
+
+pub(crate) fn save_snapshot_with_report_and_clear_boundary(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    contentless_clear_boundary: bool,
+) -> Result<Option<SaveSnapshotReport>> {
+    save_snapshot_with_expanded_limit_and_strategy(
+        snapshot,
+        options,
+        DEFAULT_MAX_EXPANDED_SESSION_BYTES,
+        HistoryFallbackStrategy::LargestFitting,
+        contentless_clear_boundary,
+    )
 }
 
 #[allow(dead_code)]
 pub(crate) fn save_snapshot_autosave_with_report(
     snapshot: &SessionSnapshot,
     options: &SessionOptions,
+) -> Result<Option<SaveSnapshotReport>> {
+    save_snapshot_autosave_with_report_and_clear_boundary(snapshot, options, false)
+}
+
+pub(crate) fn save_snapshot_autosave_with_report_and_clear_boundary(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    contentless_clear_boundary: bool,
 ) -> Result<Option<SaveSnapshotReport>> {
     save_snapshot_with_expanded_limit_and_strategy(
         snapshot,
@@ -156,6 +180,7 @@ pub(crate) fn save_snapshot_autosave_with_report(
         HistoryFallbackStrategy::Bounded {
             max_depth: AUTOSAVE_HISTORY_FALLBACK_DEPTH,
         },
+        contentless_clear_boundary,
     )
 }
 
@@ -228,6 +253,7 @@ pub(super) fn estimate_snapshot_payload_with_expanded_limit(
     ))
 }
 
+#[allow(dead_code)]
 pub(super) fn save_snapshot_with_expanded_limit(
     snapshot: &SessionSnapshot,
     options: &SessionOptions,
@@ -238,6 +264,7 @@ pub(super) fn save_snapshot_with_expanded_limit(
         options,
         max_expanded_size,
         HistoryFallbackStrategy::LargestFitting,
+        false,
     )
 }
 
@@ -246,6 +273,7 @@ fn save_snapshot_with_expanded_limit_and_strategy(
     options: &SessionOptions,
     max_expanded_size: u64,
     history_fallback: HistoryFallbackStrategy,
+    contentless_clear_boundary: bool,
 ) -> Result<Option<SaveSnapshotReport>> {
     if !options.any_enabled() && !options.persist_history && snapshot.tool_state.is_none() {
         debug!("Session persistence disabled for all boards; skipping save");
@@ -277,7 +305,13 @@ fn save_snapshot_with_expanded_limit_and_strategy(
     );
 
     let save_started = Instant::now();
-    let result = save_snapshot_inner(snapshot, options, max_expanded_size, history_fallback);
+    let result = save_snapshot_inner(
+        snapshot,
+        options,
+        max_expanded_size,
+        history_fallback,
+        contentless_clear_boundary,
+    );
     match &result {
         Ok(Some(report)) => info!(
             "Session save pipeline finished for {} in {:?}: outcome={:?}, written={} bytes, raw={} bytes, compression={}",
@@ -316,9 +350,16 @@ fn save_snapshot_inner(
     options: &SessionOptions,
     max_expanded_size: u64,
     history_fallback: HistoryFallbackStrategy,
+    contentless_clear_boundary: bool,
 ) -> Result<Option<SaveSnapshotReport>> {
     let session_path = options.session_file_path();
     let backup_path = options.backup_file_path();
+    let backup_recovery_marker_path = options.backup_recovery_marker_file_path();
+    let recovery_path = options.recovery_file_path();
+    let recovery_recoverable_marker_path = options.recovery_recoverable_marker_file_path();
+    let had_session_file = session_path.exists();
+    let snapshot_has_board_data = snapshot.has_board_data();
+    let contentless_clear_boundary = !snapshot_has_board_data && contentless_clear_boundary;
     let last_modified = now_rfc3339();
 
     let prepare_started = Instant::now();
@@ -384,8 +425,12 @@ fn save_snapshot_inner(
             compressed: prepared.compressed,
         };
         if matches!(prepared.outcome, SaveSnapshotOutcome::ClearedEmpty) {
+            write_clear_marker(options)?;
             remove_session_file(&session_path)?;
-            remove_recovery_file(options);
+            remove_backup_file(options);
+            remove_backup_recovery_marker_file(options);
+            remove_recovery_files(options);
+            remove_recovery_recoverable_marker_file(options);
         }
         log_near_limit(&report);
         return Ok(Some(report));
@@ -419,9 +464,33 @@ fn save_snapshot_inner(
     }
     let write_elapsed = write_started.elapsed();
 
+    if contentless_clear_boundary {
+        write_clear_marker(options)?;
+    }
+
     let replace_started = Instant::now();
+    let preserves_recoverable_backup =
+        !snapshot_has_board_data && !contentless_clear_boundary && backup_path.exists();
+    let preserves_recoverable_recovery = !snapshot_has_board_data
+        && !contentless_clear_boundary
+        && recovery_path.exists()
+        && (!had_session_file || recovery_recoverable_marker_path.exists());
+    let preserve_existing_backup = preserves_recoverable_backup
+        && backup_recovery_marker_path.exists()
+        && session_path.exists();
+    let mut should_mark_backup_recoverable = false;
+    let should_mark_recovery_recoverable = preserves_recoverable_recovery;
     if session_path.exists() {
-        if options.backup_retention > 0 {
+        if preserve_existing_backup {
+            fs::remove_file(&session_path).with_context(|| {
+                format!(
+                    "failed to remove previous contentless session file {} while preserving backup {}",
+                    session_path.display(),
+                    backup_path.display()
+                )
+            })?;
+            should_mark_backup_recoverable = true;
+        } else if options.backup_retention > 0 {
             if backup_path.exists() {
                 fs::remove_file(&backup_path).ok();
             }
@@ -432,9 +501,21 @@ fn save_snapshot_inner(
                     backup_path.display()
                 )
             })?;
+            if !snapshot_has_board_data && !contentless_clear_boundary {
+                should_mark_backup_recoverable = true;
+            }
         } else {
             fs::remove_file(&session_path).ok();
         }
+    } else if preserves_recoverable_backup {
+        should_mark_backup_recoverable = true;
+    }
+
+    if should_mark_backup_recoverable {
+        write_backup_recovery_marker(options)?;
+    }
+    if should_mark_recovery_recoverable {
+        write_recovery_recoverable_marker(options)?;
     }
 
     fs::rename(&tmp_path, &session_path).with_context(|| {
@@ -471,7 +552,27 @@ fn save_snapshot_inner(
         compressed,
     };
     log_near_limit(&report);
-    remove_recovery_file(options);
+    if snapshot_has_board_data {
+        if remove_recoverable_artifacts_suppressed_by_clear_marker(options) {
+            remove_clear_marker_file(options);
+        } else {
+            warn!(
+                "Keeping session clear marker {} because a stale recoverable artifact could not be removed",
+                options.clear_marker_file_path().display()
+            );
+        }
+        remove_backup_recovery_marker_file(options);
+        remove_recovery_recoverable_marker_file(options);
+        remove_recovery_file(options);
+    } else if contentless_clear_boundary {
+        remove_backup_file(options);
+        remove_backup_recovery_marker_file(options);
+        remove_recovery_files(options);
+        remove_recovery_recoverable_marker_file(options);
+    } else if had_session_file && !preserves_recoverable_recovery {
+        remove_recovery_file(options);
+        remove_recovery_recoverable_marker_file(options);
+    }
     Ok(Some(report))
 }
 
@@ -1061,6 +1162,305 @@ fn remove_session_file(session_path: &Path) -> Result<()> {
         })?;
     }
     Ok(())
+}
+
+fn remove_recoverable_artifacts_suppressed_by_clear_marker(options: &SessionOptions) -> bool {
+    let marker_path = options.clear_marker_file_path();
+    let Ok(marker_metadata) = fs::metadata(&marker_path) else {
+        return true;
+    };
+
+    let backup_removed = remove_recoverable_artifact_suppressed_by_clear_marker(
+        &options.backup_file_path(),
+        "session backup",
+        &marker_metadata,
+    );
+    let recovery_removed = remove_recoverable_artifact_suppressed_by_clear_marker(
+        &options.recovery_file_path(),
+        "session recovery",
+        &marker_metadata,
+    );
+    backup_removed && recovery_removed
+}
+
+fn remove_recoverable_artifact_suppressed_by_clear_marker(
+    path: &Path,
+    label: &str,
+    marker_metadata: &fs::Metadata,
+) -> bool {
+    let Ok(artifact_metadata) = fs::metadata(path) else {
+        return true;
+    };
+    if artifact_is_newer_than_marker(&artifact_metadata, marker_metadata) {
+        return true;
+    }
+
+    match fs::remove_file(path) {
+        Ok(()) => {
+            info!(
+                "Removed stale {} {} before removing session clear marker",
+                label,
+                path.display()
+            );
+            true
+        }
+        Err(err) => {
+            warn!(
+                "Failed to remove stale {} {} before removing session clear marker: {}",
+                label,
+                path.display(),
+                err
+            );
+            false
+        }
+    }
+}
+
+fn artifact_is_newer_than_marker(
+    artifact_metadata: &fs::Metadata,
+    marker_metadata: &fs::Metadata,
+) -> bool {
+    match (artifact_metadata.modified(), marker_metadata.modified()) {
+        (Ok(artifact_modified), Ok(marker_modified)) => artifact_modified > marker_modified,
+        _ => false,
+    }
+}
+
+fn write_backup_recovery_marker(options: &SessionOptions) -> Result<()> {
+    let marker_path = options.backup_recovery_marker_file_path();
+    let tmp_path = temp_path(&marker_path)?;
+    {
+        let mut tmp_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .with_context(|| {
+                format!(
+                    "failed to open temporary backup recovery marker {}",
+                    tmp_path.display()
+                )
+            })?;
+        tmp_file
+            .write_all(now_rfc3339().as_bytes())
+            .context("failed to write backup recovery marker")?;
+        tmp_file
+            .sync_all()
+            .context("failed to sync backup recovery marker")?;
+    }
+    fs::rename(&tmp_path, &marker_path).with_context(|| {
+        format!(
+            "failed to move temporary backup recovery marker {} -> {}",
+            tmp_path.display(),
+            marker_path.display()
+        )
+    })?;
+    info!(
+        "Wrote backup recovery marker {} for contentless non-clear session save",
+        marker_path.display()
+    );
+    Ok(())
+}
+
+fn write_recovery_recoverable_marker(options: &SessionOptions) -> Result<()> {
+    let marker_path = options.recovery_recoverable_marker_file_path();
+    let tmp_path = temp_path(&marker_path)?;
+    {
+        let mut tmp_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .with_context(|| {
+                format!(
+                    "failed to open temporary recovery recoverable marker {}",
+                    tmp_path.display()
+                )
+            })?;
+        tmp_file
+            .write_all(now_rfc3339().as_bytes())
+            .context("failed to write recovery recoverable marker")?;
+        tmp_file
+            .sync_all()
+            .context("failed to sync recovery recoverable marker")?;
+    }
+    fs::rename(&tmp_path, &marker_path).with_context(|| {
+        format!(
+            "failed to move temporary recovery recoverable marker {} -> {}",
+            tmp_path.display(),
+            marker_path.display()
+        )
+    })?;
+    info!(
+        "Wrote recovery recoverable marker {} for contentless non-clear session save",
+        marker_path.display()
+    );
+    Ok(())
+}
+
+fn write_clear_marker(options: &SessionOptions) -> Result<()> {
+    let marker_path = options.clear_marker_file_path();
+    let tmp_path = temp_path(&marker_path)?;
+    {
+        let mut tmp_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .with_context(|| {
+                format!(
+                    "failed to open temporary session clear marker {}",
+                    tmp_path.display()
+                )
+            })?;
+        tmp_file
+            .write_all(now_rfc3339().as_bytes())
+            .context("failed to write session clear marker")?;
+        tmp_file
+            .sync_all()
+            .context("failed to sync session clear marker")?;
+    }
+    fs::rename(&tmp_path, &marker_path).with_context(|| {
+        format!(
+            "failed to move temporary session clear marker {} -> {}",
+            tmp_path.display(),
+            marker_path.display()
+        )
+    })?;
+    info!(
+        "Wrote session clear marker {} for empty saved session",
+        marker_path.display()
+    );
+    Ok(())
+}
+
+fn remove_clear_marker_file(options: &SessionOptions) {
+    let marker_path = options.clear_marker_file_path();
+    if !marker_path.exists() {
+        return;
+    }
+    match fs::remove_file(&marker_path) {
+        Ok(()) => info!(
+            "Removed session clear marker after successful contentful save: {}",
+            marker_path.display()
+        ),
+        Err(err) => warn!(
+            "Failed to remove session clear marker {} after successful contentful save: {}",
+            marker_path.display(),
+            err
+        ),
+    }
+}
+
+fn remove_backup_file(options: &SessionOptions) {
+    let backup_path = options.backup_file_path();
+    if !backup_path.exists() {
+        return;
+    }
+    match fs::remove_file(&backup_path) {
+        Ok(()) => info!(
+            "Removed session backup after intentional empty clear: {}",
+            backup_path.display()
+        ),
+        Err(err) => warn!(
+            "Failed to remove session backup {} after intentional empty clear: {}",
+            backup_path.display(),
+            err
+        ),
+    }
+}
+
+fn remove_backup_recovery_marker_file(options: &SessionOptions) {
+    let marker_path = options.backup_recovery_marker_file_path();
+    if !marker_path.exists() {
+        return;
+    }
+    match fs::remove_file(&marker_path) {
+        Ok(()) => info!("Removed backup recovery marker: {}", marker_path.display()),
+        Err(err) => warn!(
+            "Failed to remove backup recovery marker {}: {}",
+            marker_path.display(),
+            err
+        ),
+    }
+}
+
+fn remove_recovery_recoverable_marker_file(options: &SessionOptions) {
+    let marker_path = options.recovery_recoverable_marker_file_path();
+    if !marker_path.exists() {
+        return;
+    }
+    match fs::remove_file(&marker_path) {
+        Ok(()) => info!(
+            "Removed recovery recoverable marker: {}",
+            marker_path.display()
+        ),
+        Err(err) => warn!(
+            "Failed to remove recovery recoverable marker {}: {}",
+            marker_path.display(),
+            err
+        ),
+    }
+}
+
+fn remove_recovery_files(options: &SessionOptions) {
+    let recovery_path = options.recovery_file_path();
+    let Some(recovery_name) = recovery_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+    else {
+        remove_recovery_file(options);
+        return;
+    };
+    let Some(parent) = recovery_path.parent() else {
+        remove_recovery_file(options);
+        return;
+    };
+
+    let mut removed_any = false;
+    match fs::read_dir(parent) {
+        Ok(entries) => {
+            for entry in entries {
+                let Ok(entry) = entry else {
+                    continue;
+                };
+                let path = entry.path();
+                if !path.is_file() {
+                    continue;
+                }
+                let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                if name != recovery_name && !name.starts_with(&format!("{recovery_name}.")) {
+                    continue;
+                }
+                match fs::remove_file(&path) {
+                    Ok(()) => {
+                        removed_any = true;
+                        info!(
+                            "Removed session recovery artifact after intentional empty clear: {}",
+                            path.display()
+                        );
+                    }
+                    Err(err) => warn!(
+                        "Failed to remove session recovery artifact {} after intentional empty clear: {}",
+                        path.display(),
+                        err
+                    ),
+                }
+            }
+        }
+        Err(err) => warn!(
+            "Failed to scan session recovery artifacts under {} after intentional empty clear: {}",
+            parent.display(),
+            err
+        ),
+    }
+
+    if !removed_any {
+        debug!(
+            "No session recovery artifact present after intentional empty clear: {}",
+            recovery_path.display()
+        );
+    }
 }
 
 fn remove_recovery_file(options: &SessionOptions) {

--- a/src/session/snapshot/tests.rs
+++ b/src/session/snapshot/tests.rs
@@ -3,15 +3,21 @@ use super::load::{
     LoadSnapshotOutcome, load_snapshot_inner, load_snapshot_inner_with_expanded_limit,
     load_snapshot_with_expanded_limit,
 };
-use super::save::save_snapshot_with_expanded_limit;
+use super::save::{
+    save_snapshot_with_expanded_limit, save_snapshot_with_report_and_clear_boundary,
+};
 use super::types::{
     BoardFile, BoardPagesSnapshot, BoardSnapshot, CURRENT_VERSION, SessionFile, SessionSnapshot,
+    ToolStateSnapshot,
 };
 use super::{load_snapshot, save_snapshot};
-use crate::draw::{Color, Frame, Shape};
+use crate::draw::{Color, FontDescriptor, Frame, Shape};
+use crate::input::EraserMode;
 use crate::session::options::{CompressionMode, SessionOptions};
 use crate::test_temp::tempdir;
 use crate::time_utils::now_rfc3339;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
 
 fn sample_frame() -> Frame {
     let mut frame = Frame::new();
@@ -43,6 +49,71 @@ fn sample_snapshot() -> SessionSnapshot {
         }],
         tool_state: None,
     }
+}
+
+fn sample_tool_state() -> ToolStateSnapshot {
+    ToolStateSnapshot {
+        current_color: Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        current_thickness: 3.0,
+        eraser_size: 12.0,
+        eraser_kind: crate::draw::EraserKind::Circle,
+        eraser_mode: EraserMode::Brush,
+        marker_opacity: Some(0.32),
+        fill_enabled: Some(false),
+        tool_override: None,
+        current_font_size: 24.0,
+        font_descriptor: Some(FontDescriptor::default()),
+        text_background_enabled: false,
+        arrow_length: 20.0,
+        arrow_angle: 30.0,
+        arrow_head_at_end: Some(false),
+        arrow_label_enabled: Some(false),
+        board_previous_color: None,
+        show_status_bar: true,
+        tool_settings: None,
+    }
+}
+
+fn contentless_session_file() -> SessionFile {
+    SessionFile {
+        version: CURRENT_VERSION,
+        last_modified: now_rfc3339(),
+        active_board_id: Some("transparent".to_string()),
+        active_mode: None,
+        boards: Vec::new(),
+        transparent: None,
+        whiteboard: None,
+        blackboard: None,
+        transparent_pages: None,
+        whiteboard_pages: None,
+        blackboard_pages: None,
+        transparent_active_page: None,
+        whiteboard_active_page: None,
+        blackboard_active_page: None,
+        tool_state: Some(sample_tool_state()),
+    }
+}
+
+fn write_contentless_session(path: &Path) {
+    std::fs::write(
+        path,
+        serde_json::to_vec_pretty(&contentless_session_file()).expect("contentless session json"),
+    )
+    .expect("contentless session write");
+}
+
+fn set_modified(path: &Path, modified: SystemTime) {
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open file for timestamp update")
+        .set_modified(modified)
+        .expect("set file modified timestamp");
 }
 
 #[test]
@@ -294,6 +365,539 @@ fn load_snapshot_rejects_oversized_plain_recovery_before_falling_back() {
 }
 
 #[test]
+fn load_snapshot_restores_newer_contentful_backup_when_primary_has_no_board_data() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "blank-primary");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::copy(options.session_file_path(), options.backup_file_path())
+        .expect("backup should be seeded");
+
+    write_contentless_session(&options.session_file_path());
+    set_modified(&options.session_file_path(), older);
+    set_modified(&options.backup_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("backup fallback should load");
+    let LoadSnapshotOutcome::LoadedFromBackup(snapshot) = outcome else {
+        panic!("expected backup restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+}
+
+#[test]
+fn load_snapshot_ignores_older_contentful_backup_when_primary_has_no_board_data() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "stale-backup");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::copy(options.session_file_path(), options.backup_file_path())
+        .expect("backup should be seeded");
+    write_contentless_session(&options.session_file_path());
+    set_modified(&options.backup_file_path(), older);
+    set_modified(&options.session_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("blank primary should load without stale backup restore");
+    let LoadSnapshotOutcome::Loaded(snapshot) = outcome else {
+        panic!("expected primary blank session to remain authoritative, got {outcome:?}");
+    };
+    assert!(
+        !snapshot.has_board_data(),
+        "older backup must not resurrect drawings over a newer blank primary"
+    );
+    assert!(snapshot.tool_state.is_some());
+}
+
+#[test]
+fn load_snapshot_restores_contentful_backup_when_primary_is_missing() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "backup-only");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.backup_file_path())
+        .expect("primary should be moved to backup");
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("backup-only fallback should load");
+    let LoadSnapshotOutcome::LoadedFromBackup(snapshot) = outcome else {
+        panic!("expected backup-only restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+}
+
+#[test]
+fn save_contentless_snapshot_preserves_backup_when_primary_is_missing() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "backup-preserved");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.backup_file_path())
+        .expect("primary should be moved to backup");
+    let backup_before = std::fs::read(options.backup_file_path()).expect("backup bytes");
+
+    let contentless = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: Some(sample_tool_state()),
+    };
+    save_snapshot(&contentless, &options).expect("contentless session should save");
+
+    assert!(
+        options.session_file_path().exists(),
+        "contentless primary should be saved"
+    );
+    assert_eq!(
+        std::fs::read(options.backup_file_path()).expect("backup should remain"),
+        backup_before,
+        "contentless save must not delete the only backup when primary was missing"
+    );
+    assert!(
+        options.backup_recovery_marker_file_path().exists(),
+        "backup-only recovery must be marked so the newer blank primary cannot shadow it"
+    );
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("preserved backup should load over blank primary");
+    let LoadSnapshotOutcome::LoadedFromBackup(snapshot) = outcome else {
+        panic!("expected preserved backup restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+}
+
+#[test]
+fn save_contentless_snapshot_preserves_recovery_when_primary_is_missing() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "recovery-preserved");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.recovery_file_path())
+        .expect("primary should be moved to recovery");
+    let recovery_before = std::fs::read(options.recovery_file_path()).expect("recovery bytes");
+
+    let contentless = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: Some(sample_tool_state()),
+    };
+    save_snapshot(&contentless, &options).expect("contentless session should save");
+
+    assert!(
+        options.session_file_path().exists(),
+        "contentless primary should be saved"
+    );
+    assert_eq!(
+        std::fs::read(options.recovery_file_path()).expect("recovery should remain"),
+        recovery_before,
+        "contentless save must not delete the only recovery artifact when primary was missing"
+    );
+    assert!(
+        options.recovery_recoverable_marker_file_path().exists(),
+        "recovery-only board data must be marked so the newer blank primary cannot shadow it"
+    );
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("preserved recovery should load over blank primary");
+    let LoadSnapshotOutcome::LoadedFromRecovery(snapshot) = outcome else {
+        panic!("expected preserved recovery restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+
+    save_snapshot(&contentless, &options).expect("second contentless session should save");
+    assert_eq!(
+        std::fs::read(options.recovery_file_path())
+            .expect("recovery should remain after second save"),
+        recovery_before,
+        "a later non-clear contentless save must not remove the recoverable recovery artifact"
+    );
+}
+
+#[test]
+fn clear_empty_snapshot_removes_backup_when_primary_is_missing() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "clear-backup");
+    options.persist_transparent = true;
+    options.restore_tool_state = false;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.backup_file_path())
+        .expect("primary should be moved to backup");
+    std::fs::write(options.backup_recovery_marker_file_path(), b"recoverable")
+        .expect("backup recovery marker");
+
+    let cleared = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: None,
+    };
+    save_snapshot(&cleared, &options).expect("empty clear should save");
+
+    assert!(
+        !options.backup_file_path().exists(),
+        "intentional empty clear must remove stale backup-only board data"
+    );
+    assert!(
+        !options.backup_recovery_marker_file_path().exists(),
+        "intentional empty clear must remove stale backup recovery markers"
+    );
+    assert!(
+        options.clear_marker_file_path().exists(),
+        "intentional empty clear should leave a marker that suppresses stale artifacts"
+    );
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("cleared session should load as empty");
+    let LoadSnapshotOutcome::Empty = outcome else {
+        panic!("expected cleared session to stay empty, got {outcome:?}");
+    };
+}
+
+#[test]
+fn clear_empty_snapshot_removes_recovery_when_primary_is_missing() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "clear-recovery");
+    options.persist_transparent = true;
+    options.restore_tool_state = false;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.recovery_file_path())
+        .expect("primary should be moved to recovery");
+
+    let cleared = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: None,
+    };
+    save_snapshot(&cleared, &options).expect("empty clear should save");
+
+    assert!(
+        !options.recovery_file_path().exists(),
+        "intentional empty clear must remove stale recovery-only board data"
+    );
+    assert!(
+        options.clear_marker_file_path().exists(),
+        "intentional empty clear should leave a marker that suppresses stale artifacts"
+    );
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("cleared session should load as empty");
+    let LoadSnapshotOutcome::Empty = outcome else {
+        panic!("expected cleared session to stay empty, got {outcome:?}");
+    };
+}
+
+#[test]
+fn load_snapshot_ignores_backup_older_than_clear_marker() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "marker-backup");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.backup_file_path())
+        .expect("primary should be moved to backup");
+    std::fs::write(options.clear_marker_file_path(), b"cleared").expect("clear marker");
+    set_modified(&options.backup_file_path(), older);
+    set_modified(&options.clear_marker_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("stale backup should be suppressed");
+    let LoadSnapshotOutcome::Empty = outcome else {
+        panic!("expected clear marker to suppress stale backup, got {outcome:?}");
+    };
+}
+
+#[test]
+fn load_snapshot_ignores_primary_older_than_clear_marker() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "marker-primary");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::write(options.clear_marker_file_path(), b"cleared").expect("clear marker");
+    set_modified(&options.session_file_path(), older);
+    set_modified(&options.clear_marker_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("stale primary should be suppressed");
+    let LoadSnapshotOutcome::Empty = outcome else {
+        panic!("expected clear marker to suppress stale primary, got {outcome:?}");
+    };
+}
+
+#[test]
+fn load_snapshot_preserves_backup_when_suppressed_primary_is_corrupt() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let primary_time = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let marker_time = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+    let backup_time = SystemTime::UNIX_EPOCH + Duration::from_secs(30);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "marker-corrupt-primary");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+
+    let primary_path = options.session_file_path();
+    let backup_path = options.backup_file_path();
+    let clear_marker_path = options.clear_marker_file_path();
+    let backup_bytes = std::fs::read(&primary_path).expect("saved primary bytes");
+    std::fs::write(&backup_path, &backup_bytes).expect("backup write");
+    std::fs::write(&primary_path, b"{not valid json").expect("corrupt primary write");
+    std::fs::write(&clear_marker_path, b"cleared").expect("clear marker");
+    set_modified(&primary_path, primary_time);
+    set_modified(&clear_marker_path, marker_time);
+    set_modified(&backup_path, backup_time);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("valid backup should survive suppressed corrupt primary probe");
+    let LoadSnapshotOutcome::LoadedFromBackup(snapshot) = outcome else {
+        panic!("expected backup restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+    assert_eq!(
+        std::fs::read(&backup_path).expect("backup should remain readable"),
+        backup_bytes,
+        "suppressed corrupt primary probe must not overwrite the valid backup"
+    );
+    assert!(
+        primary_path.exists(),
+        "suppressed corrupt primary should be ignored without quarantine side effects"
+    );
+}
+
+#[test]
+fn load_snapshot_ignores_recovery_older_than_clear_marker() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "marker-recovery");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.recovery_file_path())
+        .expect("primary should be moved to recovery");
+    std::fs::write(options.clear_marker_file_path(), b"cleared").expect("clear marker");
+    set_modified(&options.recovery_file_path(), older);
+    set_modified(&options.clear_marker_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("stale recovery should be suppressed");
+    let LoadSnapshotOutcome::Empty = outcome else {
+        panic!("expected clear marker to suppress stale recovery, got {outcome:?}");
+    };
+}
+
+#[test]
+fn load_snapshot_restores_backup_newer_than_clear_marker() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "marker-newer-backup");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.backup_file_path())
+        .expect("primary should be moved to backup");
+    std::fs::write(options.clear_marker_file_path(), b"cleared").expect("clear marker");
+    set_modified(&options.clear_marker_file_path(), older);
+    set_modified(&options.backup_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("newer backup should still recover");
+    let LoadSnapshotOutcome::LoadedFromBackup(snapshot) = outcome else {
+        panic!("expected newer backup restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+}
+
+#[test]
+fn save_contentless_tool_state_snapshot_marks_clear_boundary_before_backup_rotation() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "tool-clear-marker");
+    options.persist_transparent = true;
+    options.restore_tool_state = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    let stale_backup_bytes = std::fs::read(options.session_file_path()).expect("primary bytes");
+
+    let contentless = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: Some(sample_tool_state()),
+    };
+    save_snapshot_with_report_and_clear_boundary(&contentless, &options, true)
+        .expect("contentless tool-state session should save");
+
+    assert!(
+        options.clear_marker_file_path().exists(),
+        "contentless tool-state save after board data must mark a clear boundary"
+    );
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("contentless clear primary should still load");
+    let LoadSnapshotOutcome::Loaded(snapshot) = outcome else {
+        panic!("expected contentless primary to load, got {outcome:?}");
+    };
+    assert!(
+        !snapshot.has_board_data(),
+        "contentless primary must remain authoritative after a clear"
+    );
+    assert!(
+        snapshot.tool_state.is_some(),
+        "clear marker must not suppress the freshly saved tool state"
+    );
+
+    std::fs::remove_file(options.session_file_path()).expect("remove primary to simulate crash");
+    std::fs::write(options.backup_file_path(), stale_backup_bytes).expect("stale backup write");
+    set_modified(&options.backup_file_path(), older);
+    set_modified(&options.clear_marker_file_path(), newer);
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("stale backup after contentless clear should be suppressed");
+    let LoadSnapshotOutcome::Empty = outcome else {
+        panic!("expected clear marker to suppress stale backup, got {outcome:?}");
+    };
+}
+
+#[test]
+fn contentful_save_after_clear_marker_removes_stale_backup_before_marker() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+    let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+    let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "contentful-after-clear");
+    options.persist_transparent = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    std::fs::rename(options.session_file_path(), options.backup_file_path())
+        .expect("primary should be moved to backup");
+    std::fs::write(options.clear_marker_file_path(), b"cleared").expect("clear marker");
+    set_modified(&options.backup_file_path(), older);
+    set_modified(&options.clear_marker_file_path(), newer);
+
+    save_snapshot(&snapshot, &options).expect("contentful save should succeed");
+
+    assert!(
+        options.session_file_path().exists(),
+        "contentful primary should be saved"
+    );
+    assert!(
+        !options.backup_file_path().exists(),
+        "contentful save must remove a stale backup before dropping the clear marker"
+    );
+    assert!(
+        !options.clear_marker_file_path().exists(),
+        "clear marker can be removed after stale backup cleanup"
+    );
+}
+
+#[test]
+fn contentless_save_without_loaded_board_data_preserves_rotated_backup() {
+    let temp = tempdir().unwrap();
+    let snapshot = sample_snapshot();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "tool-state-protected");
+    options.persist_transparent = true;
+    options.restore_tool_state = true;
+    save_snapshot(&snapshot, &options).expect("normal session should save");
+    let primary_before = std::fs::read(options.session_file_path()).expect("primary bytes");
+
+    let contentless = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: Some(sample_tool_state()),
+    };
+    save_snapshot_with_report_and_clear_boundary(&contentless, &options, false)
+        .expect("dirty tool-state-only session should save");
+
+    assert!(
+        options.session_file_path().exists(),
+        "contentless primary should be saved"
+    );
+    assert_eq!(
+        std::fs::read(options.backup_file_path()).expect("backup should remain"),
+        primary_before,
+        "contentless save without loaded board data must preserve the rotated recoverable primary"
+    );
+    assert!(
+        options.backup_recovery_marker_file_path().exists(),
+        "non-clear contentless save must mark the preserved backup as recoverable"
+    );
+    assert!(
+        !options.clear_marker_file_path().exists(),
+        "caller did not mark this contentless save as an intentional clear"
+    );
+
+    let outcome = load_snapshot_with_expanded_limit(&options, 64 * 1024)
+        .expect("recoverable backup should load over non-clear blank primary");
+    let LoadSnapshotOutcome::LoadedFromBackup(snapshot) = outcome else {
+        panic!("expected preserved backup restore, got {outcome:?}");
+    };
+    assert_sample_snapshot(&snapshot);
+
+    save_snapshot_with_report_and_clear_boundary(&contentless, &options, false)
+        .expect("second dirty tool-state-only session should save");
+    assert_eq!(
+        std::fs::read(options.backup_file_path()).expect("backup should remain after second save"),
+        primary_before,
+        "a later non-clear contentless save must not replace the recoverable backup with a blank primary"
+    );
+}
+
+#[test]
+fn contentless_save_twice_without_loaded_board_data_preserves_preserved_recovery() {
+    let temp = tempdir().unwrap();
+
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "preserved-recovery-twice");
+    options.persist_transparent = true;
+    options.restore_tool_state = true;
+    let preserved_recovery = options
+        .recovery_file_path()
+        .with_extension("recovery.empty");
+    std::fs::write(&preserved_recovery, b"unloadable recovery").expect("preserved recovery write");
+
+    let contentless = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: Vec::new(),
+        tool_state: Some(sample_tool_state()),
+    };
+    save_snapshot_with_report_and_clear_boundary(&contentless, &options, false)
+        .expect("first contentless save should succeed");
+    save_snapshot_with_report_and_clear_boundary(&contentless, &options, false)
+        .expect("second contentless save should succeed");
+
+    assert!(
+        preserved_recovery.exists(),
+        "contentless saves without loaded board data must not delete preserved recovery artifacts"
+    );
+    assert!(
+        !options.clear_marker_file_path().exists(),
+        "caller did not mark either contentless save as an intentional clear"
+    );
+}
+
+#[test]
 fn save_snapshot_refuses_compressed_payload_over_expanded_limit() {
     let temp = tempdir().unwrap();
     let mut options = SessionOptions::new(temp.path().to_path_buf(), "expanded-save");
@@ -345,6 +949,10 @@ fn assert_loaded_sample_snapshot(outcome: LoadSnapshotOutcome) {
     let LoadSnapshotOutcome::Loaded(snapshot) = outcome else {
         panic!("expected normal session to load, got {outcome:?}");
     };
+    assert_sample_snapshot(&snapshot);
+}
+
+fn assert_sample_snapshot(snapshot: &SessionSnapshot) {
     assert_eq!(snapshot.boards.len(), 1);
     assert_eq!(snapshot.boards[0].id, "transparent");
     assert_eq!(snapshot.boards[0].pages.pages.len(), 1);

--- a/src/session/snapshot/types.rs
+++ b/src/session/snapshot/types.rs
@@ -34,10 +34,14 @@ impl BoardPagesSnapshot {
 }
 
 impl SessionSnapshot {
-    pub(super) fn is_empty(&self) -> bool {
+    pub(crate) fn has_board_data(&self) -> bool {
         self.boards
             .iter()
-            .all(|board| !board.pages.has_persistable_data())
+            .any(|board| board.pages.has_persistable_data())
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        !self.has_board_data()
     }
 }
 

--- a/src/session/storage/clear.rs
+++ b/src/session/storage/clear.rs
@@ -9,11 +9,16 @@ use crate::session::options::SessionOptions;
 pub fn clear_session(options: &SessionOptions) -> Result<ClearOutcome> {
     let session_path = options.session_file_path();
     let backup_path = options.backup_file_path();
+    let backup_recovery_marker_path = options.backup_recovery_marker_file_path();
     let recovery_path = options.recovery_file_path();
+    let clear_marker_path = options.clear_marker_file_path();
     let lock_path = options.lock_file_path();
 
-    let mut removed_session = remove_file_if_exists(&session_path)?;
+    let removed_primary_session = remove_file_if_exists(&session_path)?;
+    let removed_clear_marker = remove_file_if_exists(&clear_marker_path)?;
+    let mut removed_session = removed_primary_session || removed_clear_marker;
     let mut removed_backup = remove_file_if_exists(&backup_path)?;
+    removed_backup = remove_file_if_exists(&backup_recovery_marker_path)? || removed_backup;
     let mut removed_recovery = remove_recovery_files(&recovery_path)?;
     let mut removed_lock = remove_file_if_exists(&lock_path)?;
 
@@ -21,20 +26,19 @@ pub fn clear_session(options: &SessionOptions) -> Result<ClearOutcome> {
         let prefix = options.file_prefix();
         let base_dir = &options.base_dir;
 
-        if !removed_session {
-            removed_session = remove_matching_files(base_dir, &prefix, ".json")? || removed_session;
-        }
+        let removed_matching_sessions = remove_matching_files(base_dir, &prefix, ".json")?;
+        let removed_matching_clear_markers =
+            remove_matching_files(base_dir, &prefix, ".json.cleared")?;
+        removed_session =
+            removed_matching_sessions || removed_matching_clear_markers || removed_session;
 
-        if !removed_backup {
-            removed_backup =
-                remove_matching_files(base_dir, &prefix, ".json.bak")? || removed_backup;
-        }
+        removed_backup = remove_matching_files(base_dir, &prefix, ".json.bak")? || removed_backup;
+        removed_backup =
+            remove_matching_files(base_dir, &prefix, ".json.bak.recoverable")? || removed_backup;
 
         removed_recovery = remove_matching_recovery_files(base_dir, &prefix)? || removed_recovery;
 
-        if !removed_lock {
-            removed_lock = remove_matching_files(base_dir, &prefix, ".lock")? || removed_lock;
-        }
+        removed_lock = remove_matching_files(base_dir, &prefix, ".lock")? || removed_lock;
     }
 
     Ok(ClearOutcome {
@@ -100,7 +104,7 @@ fn remove_matching_files(dir: &Path, prefix: &str, suffix: &str) -> Result<bool>
                 .file_name()
                 .and_then(|n| n.to_str())
                 .map(|s| s.to_string())
-                && name.starts_with(prefix)
+                && name_matches_session_prefix(&name, prefix)
                 && name.ends_with(suffix)
             {
                 fs::remove_file(&path)
@@ -122,7 +126,7 @@ fn remove_matching_recovery_files(dir: &Path, prefix: &str) -> Result<bool> {
                 continue;
             }
             if let Some(name) = path.file_name().and_then(|n| n.to_str())
-                && name.starts_with(prefix)
+                && name_matches_session_prefix(name, prefix)
                 && name.contains(".json.recovery")
             {
                 fs::remove_file(&path)
@@ -132,4 +136,9 @@ fn remove_matching_recovery_files(dir: &Path, prefix: &str) -> Result<bool> {
         }
     }
     Ok(removed)
+}
+
+fn name_matches_session_prefix(name: &str, prefix: &str) -> bool {
+    name.strip_prefix(prefix)
+        .is_some_and(|rest| rest.starts_with('.') || rest.starts_with('-'))
 }

--- a/src/session/storage/tests.rs
+++ b/src/session/storage/tests.rs
@@ -14,9 +14,26 @@ fn clear_session_removes_all_variants_for_prefix() {
     let base_dir = &options.base_dir;
     std::fs::write(base_dir.join("session-display_1.json"), b"{}").unwrap();
     std::fs::write(base_dir.join("session-display_1-DP_1.json"), b"{}").unwrap();
+    std::fs::write(base_dir.join("session-display_1.json.cleared"), b"{}").unwrap();
+    std::fs::write(base_dir.join("session-display_1-DP_1.json.cleared"), b"{}").unwrap();
     std::fs::write(base_dir.join("session-display_1.json.bak"), b"{}").unwrap();
     std::fs::write(base_dir.join("session-display_1-DP_1.json.bak"), b"{}").unwrap();
+    std::fs::write(
+        base_dir.join("session-display_1.json.bak.recoverable"),
+        b"{}",
+    )
+    .unwrap();
+    std::fs::write(
+        base_dir.join("session-display_1-DP_1.json.bak.recoverable"),
+        b"{}",
+    )
+    .unwrap();
     std::fs::write(base_dir.join("session-display_1.json.recovery"), b"{}").unwrap();
+    std::fs::write(
+        base_dir.join("session-display_1.json.recovery.recoverable"),
+        b"{}",
+    )
+    .unwrap();
     std::fs::write(
         base_dir.join("session-display_1.json.recovery.empty"),
         b"{}",
@@ -50,12 +67,34 @@ fn clear_session_removes_all_variants_for_prefix() {
         "primary session file should be removed"
     );
     assert!(
+        !base_dir.join("session-display_1.json.cleared").exists(),
+        "primary clear marker should be removed"
+    );
+    assert!(
+        !base_dir
+            .join("session-display_1-DP_1.json.cleared")
+            .exists(),
+        "per-output clear marker should be removed"
+    );
+    assert!(
         !base_dir.join("session-display_1.json.bak").exists(),
         "primary backup file should be removed"
     );
     assert!(
+        !base_dir
+            .join("session-display_1.json.bak.recoverable")
+            .exists(),
+        "primary backup recovery marker should be removed"
+    );
+    assert!(
         !base_dir.join("session-display_1.json.recovery").exists(),
         "primary recovery file should be removed"
+    );
+    assert!(
+        !base_dir
+            .join("session-display_1.json.recovery.recoverable")
+            .exists(),
+        "primary recovery recoverable marker should be removed"
     );
     assert!(
         !base_dir
@@ -76,6 +115,83 @@ fn clear_session_removes_all_variants_for_prefix() {
 
     // Per-output variants may or may not be removed depending on identity resolution,
     // so we only assert that the primary files are gone.
+}
+
+#[test]
+fn clear_session_keeps_neighbor_display_prefix_variants() {
+    let temp = crate::test_temp::tempdir().unwrap();
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "wayland-1");
+    options.per_output = true;
+
+    let base_dir = &options.base_dir;
+    for name in [
+        "session-wayland_1.json",
+        "session-wayland_1-DP_1.json",
+        "session-wayland_1.json.cleared",
+        "session-wayland_1-DP_1.json.cleared",
+        "session-wayland_1.json.bak",
+        "session-wayland_1-DP_1.json.bak",
+        "session-wayland_1.json.bak.recoverable",
+        "session-wayland_1-DP_1.json.bak.recoverable",
+        "session-wayland_1.json.recovery",
+        "session-wayland_1.json.recovery.recoverable",
+        "session-wayland_1.json.recovery.empty",
+        "session-wayland_1-DP_1.json.recovery.too-large",
+        "session-wayland_1.lock",
+        "session-wayland_1-DP_1.lock",
+        "session-wayland_10.json",
+        "session-wayland_10-DP_1.json",
+        "session-wayland_10.json.cleared",
+        "session-wayland_10.json.bak",
+        "session-wayland_10.json.bak.recoverable",
+        "session-wayland_10.json.recovery",
+        "session-wayland_10.json.recovery.recoverable",
+        "session-wayland_10.json.recovery.empty",
+        "session-wayland_10.lock",
+    ] {
+        std::fs::write(base_dir.join(name), b"{}").unwrap();
+    }
+
+    clear_session(&options).expect("clear_session should succeed");
+
+    for removed in [
+        "session-wayland_1.json",
+        "session-wayland_1-DP_1.json",
+        "session-wayland_1.json.cleared",
+        "session-wayland_1-DP_1.json.cleared",
+        "session-wayland_1.json.bak",
+        "session-wayland_1-DP_1.json.bak",
+        "session-wayland_1.json.bak.recoverable",
+        "session-wayland_1-DP_1.json.bak.recoverable",
+        "session-wayland_1.json.recovery",
+        "session-wayland_1.json.recovery.recoverable",
+        "session-wayland_1.json.recovery.empty",
+        "session-wayland_1-DP_1.json.recovery.too-large",
+        "session-wayland_1.lock",
+        "session-wayland_1-DP_1.lock",
+    ] {
+        assert!(
+            !base_dir.join(removed).exists(),
+            "{removed} should be removed"
+        );
+    }
+
+    for preserved in [
+        "session-wayland_10.json",
+        "session-wayland_10-DP_1.json",
+        "session-wayland_10.json.cleared",
+        "session-wayland_10.json.bak",
+        "session-wayland_10.json.bak.recoverable",
+        "session-wayland_10.json.recovery",
+        "session-wayland_10.json.recovery.recoverable",
+        "session-wayland_10.json.recovery.empty",
+        "session-wayland_10.lock",
+    ] {
+        assert!(
+            base_dir.join(preserved).exists(),
+            "{preserved} should not be removed"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Resolves #232

## Summary

Fixes session persistence recovery paths that could restore stale drawings after an intentional clear, or delete/shadow the only recoverable backup/recovery artifact during contentless saves.

Changes include:
- Add clear markers to suppress stale primary, backup, and recovery artifacts.
- Preserve backup-only and recovery-only board data unless the user explicitly cleared loaded board data.
- Track whether board data was loaded/saved in runtime session state before treating contentless saves as clear boundaries.
- Add recoverable sidecar markers for protected backup/recovery artifacts.
- Expand session clear cleanup to remove all related marker/recovery variants.
- Avoid overwriting a valid backup when probing a corrupt primary suppressed by a clear marker.