### PR TITLE
fix(session): preserve multi-selection changes in persisted sessions

### DIFF
--- a/src/draw/frame/history/frame/apply.rs
+++ b/src/draw/frame/history/frame/apply.rs
@@ -34,7 +34,7 @@ impl Frame {
             } => {
                 self.move_shape_to(*shape_id, *to);
             }
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 for action in actions {
                     self.apply_action(action);
                 }
@@ -71,7 +71,7 @@ impl Frame {
             UndoAction::Reorder { shape_id, from, .. } => {
                 self.move_shape_to(*shape_id, *from);
             }
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 for action in actions.iter().rev() {
                     self.apply_inverse(action);
                 }

--- a/src/draw/frame/history/frame/primary.rs
+++ b/src/draw/frame/history/frame/primary.rs
@@ -14,7 +14,7 @@ impl Frame {
             UndoAction::Modify { before, .. } => Some(before.shape.clone()),
             UndoAction::ModifyImageBounds { .. } => None,
             UndoAction::Reorder { .. } => None,
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 actions.iter().rev().find_map(Self::primary_shape_for_undo)
             }
         }
@@ -28,7 +28,9 @@ impl Frame {
             UndoAction::Modify { after, .. } => Some(after.shape.clone()),
             UndoAction::ModifyImageBounds { .. } => None,
             UndoAction::Reorder { .. } => None,
-            UndoAction::Compound(actions) => actions.iter().find_map(Self::primary_shape_for_redo),
+            UndoAction::Compound { actions } => {
+                actions.iter().find_map(Self::primary_shape_for_redo)
+            }
         }
     }
 

--- a/src/draw/frame/history/undo_action.rs
+++ b/src/draw/frame/history/undo_action.rs
@@ -5,7 +5,7 @@ use super::super::types::{ShapeId, UndoAction};
 impl UndoAction {
     pub(super) fn depth(&self) -> usize {
         match self {
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 1 + actions
                     .iter()
                     .map(|action| action.depth())
@@ -24,7 +24,7 @@ impl UndoAction {
             UndoAction::Modify { shape_id, .. }
             | UndoAction::ModifyImageBounds { shape_id, .. } => Some(*shape_id),
             UndoAction::Reorder { shape_id, .. } => Some(*shape_id),
-            UndoAction::Compound(actions) => actions
+            UndoAction::Compound { actions } => actions
                 .iter()
                 .filter_map(|action| action.max_shape_id())
                 .max(),
@@ -40,7 +40,7 @@ impl UndoAction {
             UndoAction::Modify { shape_id, .. }
             | UndoAction::ModifyImageBounds { shape_id, .. }
             | UndoAction::Reorder { shape_id, .. } => !removed.contains(shape_id),
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 actions.retain_mut(|action| action.prune_removed_shapes(removed));
                 !actions.is_empty()
             }
@@ -53,7 +53,7 @@ impl UndoAction {
             UndoAction::Modify { shape_id, .. }
             | UndoAction::ModifyImageBounds { shape_id, .. }
             | UndoAction::Reorder { shape_id, .. } => ids.contains(shape_id),
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 actions.retain_mut(|action| action.validate_against_shapes(ids));
                 !actions.is_empty()
             }
@@ -72,7 +72,7 @@ impl UndoAction {
             | UndoAction::Reorder { shape_id, .. } => {
                 ids.insert(*shape_id);
             }
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 for action in actions {
                     action.collect_ids(ids);
                 }

--- a/src/draw/frame/tests/history/validate.rs
+++ b/src/draw/frame/tests/history/validate.rs
@@ -25,14 +25,20 @@ fn validate_history_drops_actions_exceeding_compound_depth() {
         locked: false,
     };
 
-    let shallow = UndoAction::Compound(vec![UndoAction::Create {
-        shapes: vec![(0, shallow_drawn)],
-    }]);
+    let shallow = UndoAction::Compound {
+        actions: vec![UndoAction::Create {
+            shapes: vec![(0, shallow_drawn)],
+        }],
+    };
 
     // Nested compound to create depth 3.
-    let deep = UndoAction::Compound(vec![UndoAction::Compound(vec![UndoAction::Create {
-        shapes: vec![(0, deep_drawn)],
-    }])]);
+    let deep = UndoAction::Compound {
+        actions: vec![UndoAction::Compound {
+            actions: vec![UndoAction::Create {
+                shapes: vec![(0, deep_drawn)],
+            }],
+        }],
+    };
 
     let mut frame = Frame::new();
     frame.undo_stack = vec![shallow, deep];
@@ -42,7 +48,7 @@ fn validate_history_drops_actions_exceeding_compound_depth() {
     assert_eq!(stats.undo_removed, 1);
 
     match &frame.undo_stack[0] {
-        UndoAction::Compound(actions) => {
+        UndoAction::Compound { actions } => {
             assert_eq!(actions.len(), 1, "shallow compound should be preserved");
         }
         other => panic!("expected compound action, got {:?}", other),

--- a/src/draw/frame/types.rs
+++ b/src/draw/frame/types.rs
@@ -115,7 +115,9 @@ pub enum UndoAction {
         from: usize,
         to: usize,
     },
-    Compound(Vec<UndoAction>),
+    Compound {
+        actions: Vec<UndoAction>,
+    },
 }
 
 impl UndoAction {

--- a/src/input/state/core/history.rs
+++ b/src/input/state/core/history.rs
@@ -46,7 +46,7 @@ impl InputState {
                     self.invalidate_hit_cache_for(*shape_id);
                 }
             }
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 for action in actions {
                     self.mark_dirty_from_action(action);
                 }
@@ -68,7 +68,7 @@ impl InputState {
             UndoAction::Reorder { shape_id, .. } => {
                 self.invalidate_hit_cache_for(*shape_id);
             }
-            UndoAction::Compound(actions) => {
+            UndoAction::Compound { actions } => {
                 for action in actions {
                     self.invalidate_hit_cache_from_action(action);
                 }
@@ -232,14 +232,16 @@ mod tests {
             .clone();
         let _ = state.take_dirty_regions();
 
-        state.apply_action_side_effects(&UndoAction::Compound(vec![
-            UndoAction::Create {
-                shapes: vec![(0, first)],
-            },
-            UndoAction::Delete {
-                shapes: vec![(1, second)],
-            },
-        ]));
+        state.apply_action_side_effects(&UndoAction::Compound {
+            actions: vec![
+                UndoAction::Create {
+                    shapes: vec![(0, first)],
+                },
+                UndoAction::Delete {
+                    shapes: vec![(1, second)],
+                },
+            ],
+        });
 
         assert!(state.session_dirty);
         assert!(!state.take_dirty_regions().is_empty());

--- a/src/input/state/core/properties/apply_selection/helpers.rs
+++ b/src/input/state/core/properties/apply_selection/helpers.rs
@@ -120,7 +120,7 @@ impl InputState {
         let undo_action = if actions.len() == 1 {
             actions.into_iter().next().unwrap()
         } else {
-            crate::draw::frame::UndoAction::Compound(actions)
+            crate::draw::frame::UndoAction::Compound { actions }
         };
 
         self.boards

--- a/src/input/state/core/selection_actions/reorder.rs
+++ b/src/input/state/core/selection_actions/reorder.rs
@@ -55,7 +55,7 @@ impl InputState {
 
         self.boards
             .active_frame_mut()
-            .push_undo_action(UndoAction::Compound(actions), self.undo_stack_limit);
+            .push_undo_action(UndoAction::Compound { actions }, self.undo_stack_limit);
         self.mark_session_dirty();
         true
     }

--- a/src/input/state/core/selection_actions/state.rs
+++ b/src/input/state/core/selection_actions/state.rs
@@ -49,7 +49,7 @@ impl InputState {
 
         self.boards
             .active_frame_mut()
-            .push_undo_action(UndoAction::Compound(actions), self.undo_stack_limit);
+            .push_undo_action(UndoAction::Compound { actions }, self.undo_stack_limit);
         self.mark_session_dirty();
         true
     }

--- a/src/input/state/core/selection_actions/translation/undo.rs
+++ b/src/input/state/core/selection_actions/translation/undo.rs
@@ -33,7 +33,7 @@ impl InputState {
         let undo_action = if actions.len() == 1 {
             actions.into_iter().next().unwrap()
         } else {
-            UndoAction::Compound(actions)
+            UndoAction::Compound { actions }
         };
 
         self.boards

--- a/src/session/snapshot/tests.rs
+++ b/src/session/snapshot/tests.rs
@@ -11,6 +11,7 @@ use super::types::{
     ToolStateSnapshot,
 };
 use super::{load_snapshot, save_snapshot};
+use crate::draw::frame::{ShapeSnapshot, UndoAction};
 use crate::draw::{Color, FontDescriptor, Frame, Shape};
 use crate::input::EraserMode;
 use crate::session::options::{CompressionMode, SessionOptions};
@@ -1085,6 +1086,108 @@ fn save_snapshot_keeps_empty_pages() {
         .expect("transparent pages should be present");
     assert_eq!(pages.pages.pages.len(), 3);
     assert_eq!(pages.pages.active, 2);
+}
+
+#[test]
+fn save_snapshot_serializes_compound_undo_history() {
+    let temp = tempdir().unwrap();
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "compound-history");
+    options.persist_transparent = true;
+    options.persist_history = true;
+
+    let mut frame = Frame::new();
+    let first_id = frame.add_shape(Shape::Line {
+        x1: 0,
+        y1: 0,
+        x2: 10,
+        y2: 10,
+        color: Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 2.0,
+    });
+    let second_id = frame.add_shape(Shape::Line {
+        x1: 20,
+        y1: 20,
+        x2: 30,
+        y2: 30,
+        color: Color {
+            r: 0.0,
+            g: 1.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 2.0,
+    });
+
+    let before_first = snapshot_for_shape(&frame, first_id);
+    let before_second = snapshot_for_shape(&frame, second_id);
+    translate_line(&mut frame, first_id, 5, 0);
+    translate_line(&mut frame, second_id, 5, 0);
+    let after_first = snapshot_for_shape(&frame, first_id);
+    let after_second = snapshot_for_shape(&frame, second_id);
+    frame.push_undo_action(
+        UndoAction::Compound {
+            actions: vec![
+                UndoAction::Modify {
+                    shape_id: first_id,
+                    before: before_first,
+                    after: after_first,
+                },
+                UndoAction::Modify {
+                    shape_id: second_id,
+                    before: before_second,
+                    after: after_second,
+                },
+            ],
+        },
+        usize::MAX,
+    );
+
+    let snapshot = SessionSnapshot {
+        active_board_id: "transparent".to_string(),
+        boards: vec![BoardSnapshot {
+            id: "transparent".to_string(),
+            pages: BoardPagesSnapshot {
+                pages: vec![frame],
+                active: 0,
+            },
+        }],
+        tool_state: None,
+    };
+
+    save_snapshot(&snapshot, &options).expect("save_snapshot should serialize compound history");
+
+    let raw = std::fs::read_to_string(options.session_file_path()).expect("read session json");
+    assert!(raw.contains("\"kind\": \"compound\""));
+    assert!(raw.contains("\"actions\""));
+
+    let loaded = load_snapshot(&options)
+        .expect("load_snapshot should succeed")
+        .expect("snapshot should be present");
+    let page = &loaded.boards[0].pages.pages[0];
+    assert_eq!(page.undo_stack_len(), 1);
+}
+
+fn snapshot_for_shape(frame: &Frame, shape_id: crate::draw::ShapeId) -> ShapeSnapshot {
+    let drawn = frame.shape(shape_id).expect("shape exists");
+    ShapeSnapshot {
+        shape: drawn.shape.clone(),
+        locked: drawn.locked,
+    }
+}
+
+fn translate_line(frame: &mut Frame, shape_id: crate::draw::ShapeId, dx: i32, dy: i32) {
+    let shape = frame.shape_mut(shape_id).expect("shape exists");
+    if let Shape::Line { x1, y1, x2, y2, .. } = &mut shape.shape {
+        *x1 += dx;
+        *y1 += dy;
+        *x2 += dx;
+        *y2 += dy;
+    }
 }
 
 #[test]

--- a/src/session/tests/history.rs
+++ b/src/session/tests/history.rs
@@ -198,6 +198,79 @@ fn clear_all_can_be_undone_after_restore() {
 }
 
 #[test]
+fn moved_multi_selection_with_history_survives_save_restore() {
+    let temp = crate::test_temp::tempdir().unwrap();
+    let mut options = SessionOptions::new(temp.path().to_path_buf(), "display-multi-move");
+    options.persist_transparent = true;
+    options.persist_history = true;
+
+    let mut input = dummy_input_state();
+    input.update_screen_dimensions(400, 300);
+    let first = input.boards.active_frame_mut().add_shape(Shape::Freehand {
+        points: vec![(10, 10), (20, 20)],
+        color: Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        thick: 3.0,
+    });
+    let second = input.boards.active_frame_mut().add_shape(Shape::Freehand {
+        points: vec![(40, 40), (50, 50)],
+        color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 1.0,
+            a: 1.0,
+        },
+        thick: 3.0,
+    });
+    input.set_selection(vec![first, second]);
+
+    assert!(input.translate_selection_with_undo(25, 10));
+    assert_eq!(input.boards.active_frame().undo_stack_len(), 1);
+    assert_eq!(
+        freehand_points(input.boards.active_frame(), first),
+        vec![(35, 20), (45, 30)]
+    );
+    assert_eq!(
+        freehand_points(input.boards.active_frame(), second),
+        vec![(65, 50), (75, 60)]
+    );
+
+    let snapshot = snapshot_from_input(&input, &options).expect("snapshot present");
+    save_snapshot(&snapshot, &options).expect("save snapshot with compound move history");
+    let data = fs::read_to_string(options.session_file_path()).expect("read session file");
+    assert!(data.contains("\"kind\": \"compound\""));
+    assert!(data.contains("\"actions\""));
+
+    let loaded = load_snapshot(&options)
+        .expect("load snapshot result")
+        .expect("snapshot data");
+
+    let mut restored = dummy_input_state();
+    apply_snapshot(&mut restored, loaded, &options);
+    restored.switch_board(BOARD_ID_TRANSPARENT);
+    let frame = restored.boards.active_frame_mut();
+    assert_eq!(frame.undo_stack_len(), 1);
+    assert_eq!(freehand_points(frame, first), vec![(35, 20), (45, 30)]);
+    assert_eq!(freehand_points(frame, second), vec![(65, 50), (75, 60)]);
+
+    frame.undo_last().expect("compound undo should restore");
+    assert_eq!(freehand_points(frame, first), vec![(10, 10), (20, 20)]);
+    assert_eq!(freehand_points(frame, second), vec![(40, 40), (50, 50)]);
+}
+
+fn freehand_points(frame: &crate::draw::Frame, id: crate::draw::ShapeId) -> Vec<(i32, i32)> {
+    let shape = frame.shape(id).expect("shape exists");
+    match &shape.shape {
+        Shape::Freehand { points, .. } => points.clone(),
+        other => panic!("expected freehand shape, got {other:?}"),
+    }
+}
+
+#[test]
 fn corrupted_history_is_dropped_but_shapes_load() {
     let temp = crate::test_temp::tempdir().unwrap();
     let mut options = SessionOptions::new(temp.path().to_path_buf(), "display-corrupt");


### PR DESCRIPTION
Fixes #237.

Session saves could fail after actions that create compound undo history, such as moving or editing properties for multiple selected strokes. `UndoAction` used serde internal tagging, but its `Compound(Vec<UndoAction>)` variant was a newtype variant, which `serde_json` cannot serialize. This caused the session payload serialization failure and left the previous session file in place.

This is intentionally narrow and builds on top of #236. It does not change the clear-marker, backup, recovery, or contentless-save behavior from #236; it only fixes serialization of compound undo history created by multi-selection edits