### PR TITLE
fix: publish RPM GPG key alias for repo installs

### DIFF
--- a/tools/build-package-repos.sh
+++ b/tools/build-package-repos.sh
@@ -160,7 +160,10 @@ build_rpm_repo() {
 
     cp "${RPM_MAIN}" "${rpm_root}/"
     [[ -f "${RPM_CFG}" ]] && cp "${RPM_CFG}" "${rpm_root}/"
-    [[ -f "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" ]] && cp "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" "${rpm_root}/RPM-GPG-KEY-wayscriber.asc"
+    if [[ -f "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" ]]; then
+        cp "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" "${rpm_root}/RPM-GPG-KEY-wayscriber.asc"
+        cp "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" "${rpm_root}/RPM-GPG-KEY-wayscriber"
+    fi
 
     if [[ -n "${ACTIVE_KEY}" && "${SIGN_RPMS}" == "1" ]]; then
         for rpm in "${rpm_root}"/*.rpm; do

--- a/tools/lint-and-test.sh
+++ b/tools/lint-and-test.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "$REPO_ROOT"
 
 bash tools/check-version-consistency.sh
+bash tools/test-package-repo-layout.sh
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features

--- a/tools/test-package-repo-layout.sh
+++ b/tools/test-package-repo-layout.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+ARTIFACT_ROOT="${WORK_DIR}/dist"
+OUTPUT_ROOT="${WORK_DIR}/repo-out"
+FAKE_BIN="${WORK_DIR}/bin"
+
+mkdir -p "${ARTIFACT_ROOT}" "${OUTPUT_ROOT}" "${FAKE_BIN}"
+touch "${ARTIFACT_ROOT}/wayscriber-amd64.deb"
+touch "${ARTIFACT_ROOT}/wayscriber-x86_64.rpm"
+printf '%s\n' 'fake public key' > "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc"
+
+cat > "${FAKE_BIN}/apt-ftparchive" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "fake apt-ftparchive output"
+EOF
+chmod +x "${FAKE_BIN}/apt-ftparchive"
+
+cat > "${FAKE_BIN}/createrepo_c" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+repo_root=""
+for arg in "$@"; do
+    repo_root="${arg}"
+done
+mkdir -p "${repo_root}/repodata"
+printf '%s\n' '<repomd />' > "${repo_root}/repodata/repomd.xml"
+EOF
+chmod +x "${FAKE_BIN}/createrepo_c"
+
+PATH="${FAKE_BIN}:${PATH}" \
+ARTIFACT_ROOT="${ARTIFACT_ROOT}" \
+OUTPUT_ROOT="${OUTPUT_ROOT}" \
+SIGN_RPMS=0 \
+    bash "${REPO_ROOT}/tools/build-package-repos.sh"
+
+cmp "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" "${OUTPUT_ROOT}/rpm/RPM-GPG-KEY-wayscriber.asc"
+cmp "${OUTPUT_ROOT}/WAYSCRIBER-GPG-KEY.asc" "${OUTPUT_ROOT}/rpm/RPM-GPG-KEY-wayscriber"


### PR DESCRIPTION
PR body:

## Summary

- Publish the RPM repo GPG key as both `RPM-GPG-KEY-wayscriber.asc` and `RPM-GPG-KEY-wayscriber`
- Match the extensionless key URL used by Fedora/rpm-ostree install instructions
- Add a package repo layout regression test and include it in the local lint/test gate

Closes #245.