### PR TITLE
Expand command palette action coverage

### DIFF
--- a/src/config/action_meta/entries/board.rs
+++ b/src/config/action_meta/entries/board.rs
@@ -67,7 +67,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         Some("Dup"),
         "Duplicate the current page",
         Board,
-        false,
+        true,
         true,
         true
     ),
@@ -77,9 +77,19 @@ pub const ENTRIES: &[ActionMeta] = &[
         Some("Del"),
         "Delete the current page",
         Board,
-        false,
+        true,
         true,
         true
+    ),
+    meta!(
+        PageRestoreDeleted,
+        "Restore Deleted Page",
+        Some("Restore"),
+        "Restore the most recently deleted page",
+        Board,
+        true,
+        true,
+        false
     ),
     meta!(
         Board1,
@@ -233,7 +243,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         Some("New"),
         "Create a new board",
         Board,
-        false,
+        true,
         true,
         true
     ),
@@ -243,7 +253,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         Some("Del"),
         "Delete the active board",
         Board,
-        false,
+        true,
         true,
         true
     ),

--- a/src/config/action_meta/entries/drawing.rs
+++ b/src/config/action_meta/entries/drawing.rs
@@ -27,7 +27,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Increase marker opacity",
         Drawing,
-        false,
+        true,
         false,
         false
     ),
@@ -37,7 +37,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Decrease marker opacity",
         Drawing,
-        false,
+        true,
         false,
         false
     ),
@@ -47,7 +47,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Make text larger",
         Drawing,
-        false,
+        true,
         true,
         false
     ),
@@ -57,7 +57,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Make text smaller",
         Drawing,
-        false,
+        true,
         true,
         false
     ),
@@ -67,7 +67,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Reset arrow label counter",
         Drawing,
-        false,
+        true,
         false,
         false
     ),
@@ -77,7 +77,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Reset step marker counter",
         Drawing,
-        false,
+        true,
         false,
         false
     ),

--- a/src/config/action_meta/entries/ui.rs
+++ b/src/config/action_meta/entries/ui.rs
@@ -133,7 +133,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Show selection properties",
         UI,
-        false,
+        true,
         true,
         false
     ),
@@ -143,7 +143,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Open the context menu",
         UI,
-        false,
+        true,
         true,
         false
     ),

--- a/src/config/action_meta/entries/zoom.rs
+++ b/src/config/action_meta/entries/zoom.rs
@@ -57,7 +57,7 @@ pub const ENTRIES: &[ActionMeta] = &[
         None,
         "Refresh zoom capture",
         Zoom,
-        false,
+        true,
         true,
         false
     ),

--- a/src/config/action_meta/tests.rs
+++ b/src/config/action_meta/tests.rs
@@ -26,6 +26,7 @@ const HELP_ACTIONS: &[Action] = &[
     Action::PageNew,
     Action::PageDuplicate,
     Action::PageDelete,
+    Action::PageRestoreDeleted,
     Action::BoardPrev,
     Action::BoardNext,
     Action::BoardNew,
@@ -143,7 +144,7 @@ const TOOLBAR_ACTIONS: &[Action] = &[
     Action::OpenConfigurator,
 ];
 
-const PALETTE_ACTIONS: &[Action] = &[
+const EXPECTED_COMMAND_PALETTE_ACTIONS: &[Action] = &[
     Action::Exit,
     Action::EnterTextMode,
     Action::EnterStickyNoteMode,
@@ -155,6 +156,11 @@ const PALETTE_ACTIONS: &[Action] = &[
     Action::SelectLineTool,
     Action::SelectRectTool,
     Action::SelectEllipseTool,
+    Action::SelectTriangleTool,
+    Action::SelectParallelogramTool,
+    Action::SelectRhombusTool,
+    Action::SelectRegularPolygonTool,
+    Action::SelectFreeformPolygonTool,
     Action::SelectArrowTool,
     Action::SelectBlurTool,
     Action::SelectHighlightTool,
@@ -164,6 +170,12 @@ const PALETTE_ACTIONS: &[Action] = &[
     Action::ToggleEraserMode,
     Action::IncreaseThickness,
     Action::DecreaseThickness,
+    Action::IncreaseMarkerOpacity,
+    Action::DecreaseMarkerOpacity,
+    Action::IncreaseFontSize,
+    Action::DecreaseFontSize,
+    Action::ResetArrowLabelCounter,
+    Action::ResetStepMarkerCounter,
     Action::ToggleFill,
     Action::ToggleWhiteboard,
     Action::ToggleBlackboard,
@@ -171,14 +183,44 @@ const PALETTE_ACTIONS: &[Action] = &[
     Action::PagePrev,
     Action::PageNext,
     Action::PageNew,
+    Action::PageDuplicate,
+    Action::PageDelete,
+    Action::PageRestoreDeleted,
+    Action::Board1,
+    Action::Board2,
+    Action::Board3,
+    Action::Board4,
+    Action::Board5,
+    Action::Board6,
+    Action::Board7,
+    Action::Board8,
+    Action::Board9,
+    Action::BoardNext,
+    Action::BoardPrev,
     Action::FocusNextOutput,
     Action::FocusPrevOutput,
+    Action::BoardNew,
+    Action::BoardDelete,
+    Action::BoardPicker,
+    Action::BoardRestoreDeleted,
+    Action::BoardDuplicate,
+    Action::BoardSwitchRecent,
     Action::ToggleHelp,
+    Action::ToggleQuickHelp,
     Action::ToggleToolbar,
     Action::ToggleStatusBar,
     Action::TogglePresenterMode,
+    Action::ToggleLightMode,
+    Action::ToggleLightModeDrawing,
+    Action::RenderProfileNext,
+    Action::RenderProfilePrevious,
+    Action::RenderProfileOff,
     Action::ToggleClickHighlight,
+    Action::ToggleRadialMenu,
+    Action::ToggleSelectionProperties,
+    Action::OpenContextMenu,
     Action::OpenConfigurator,
+    Action::ToggleCommandPalette,
     Action::ReplayTour,
     Action::SetColorRed,
     Action::SetColorGreen,
@@ -201,6 +243,7 @@ const PALETTE_ACTIONS: &[Action] = &[
     Action::ZoomOut,
     Action::ResetZoom,
     Action::ToggleZoomLock,
+    Action::RefreshZoomCapture,
     Action::SelectAll,
     Action::DeleteSelection,
     Action::DuplicateSelection,
@@ -230,12 +273,45 @@ fn assert_actions_have_flag(
 }
 
 #[test]
+fn action_meta_entries_are_unique() {
+    let mut seen = HashSet::new();
+
+    for meta in action_meta_iter() {
+        assert!(
+            seen.insert(meta.action),
+            "duplicate ActionMeta for {:?}",
+            meta.action
+        );
+    }
+}
+
+#[test]
 fn action_meta_covers_surface_actions() {
     assert_actions_have_flag(HELP_ACTIONS, "in_help", |meta| meta.in_help);
     assert_actions_have_flag(TOOLBAR_ACTIONS, "in_toolbar", |meta| meta.in_toolbar);
-    assert_actions_have_flag(PALETTE_ACTIONS, "in_command_palette", |meta| {
-        meta.in_command_palette
-    });
+    assert_actions_have_flag(
+        EXPECTED_COMMAND_PALETTE_ACTIONS,
+        "in_command_palette",
+        |meta| meta.in_command_palette,
+    );
+}
+
+#[test]
+fn command_palette_actions_match_expected_contract() {
+    let actual: HashSet<Action> = action_meta_iter()
+        .filter(|meta| meta.in_command_palette)
+        .map(|meta| meta.action)
+        .collect();
+    let expected: HashSet<Action> = EXPECTED_COMMAND_PALETTE_ACTIONS.iter().copied().collect();
+    let unexpected: HashSet<Action> = actual.difference(&expected).copied().collect();
+    let missing: HashSet<Action> = expected.difference(&actual).copied().collect();
+
+    assert!(
+        unexpected.is_empty() && missing.is_empty(),
+        "command palette contract changed; unexpected: {:?}; missing: {:?}",
+        unexpected,
+        missing
+    );
 }
 
 #[test]

--- a/src/input/state/core/command_palette/mod.rs
+++ b/src/input/state/core/command_palette/mod.rs
@@ -26,6 +26,7 @@ pub enum CommandPaletteCursorHint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::keybindings::Action;
     use crate::config::{BoardsConfig, KeybindingsConfig, PresenterModeConfig};
     use crate::draw::{Color, FontDescriptor};
     use crate::input::{ClickHighlightSettings, EraserMode, InputState};
@@ -75,6 +76,38 @@ mod tests {
         );
         state.set_action_bindings(action_bindings);
         state
+    }
+
+    fn assert_palette_finds(query: &str, action: Action) {
+        let mut state = make_state();
+        state.command_palette_query = query.to_string();
+
+        let results = state.filtered_commands();
+        assert!(
+            results.iter().any(|cmd| cmd.action == action),
+            "expected query {query:?} to find {action:?}, got {:?}",
+            results.iter().map(|cmd| cmd.action).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn board_and_page_lifecycle_commands_are_searchable() {
+        assert_palette_finds("new board", Action::BoardNew);
+        assert_palette_finds("delete board", Action::BoardDelete);
+        assert_palette_finds("duplicate page", Action::PageDuplicate);
+        assert_palette_finds("delete page", Action::PageDelete);
+        assert_palette_finds("restore page", Action::PageRestoreDeleted);
+    }
+
+    #[test]
+    fn hidden_utility_commands_are_searchable() {
+        assert_palette_finds("increase marker opacity", Action::IncreaseMarkerOpacity);
+        assert_palette_finds("decrease font size", Action::DecreaseFontSize);
+        assert_palette_finds("reset arrow labels", Action::ResetArrowLabelCounter);
+        assert_palette_finds("reset step markers", Action::ResetStepMarkerCounter);
+        assert_palette_finds("selection properties", Action::ToggleSelectionProperties);
+        assert_palette_finds("context menu", Action::OpenContextMenu);
+        assert_palette_finds("refresh zoom", Action::RefreshZoomCapture);
     }
 
     #[test]


### PR DESCRIPTION
 Body:

## Summary
- Add board/page lifecycle actions to the command palette: new/delete board, duplicate/delete/restore page
- Expose useful toolbarless utility commands such as marker opacity, font size, reset counters, selection properties, context menu, and refresh zoom
- Strengthen action metadata tests so command-palette coverage is checked as an exact contract

## Notes
- Board/page delete confirmation remains handled by the existing delete action flow
- New board and duplicate page are exposed without confirmation because they are non-destructive