### PR TITLE
Improve frame pacing with targeted damage regions

### DIFF
--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -233,6 +233,7 @@ pub(super) fn run_event_loop(
         }
     }
 
+    state.flush_perf_summaries(Instant::now());
     info!("Wayland backend exiting");
 
     if let Err(err) = session_save::persist_session(state) {

--- a/src/backend/wayland/backend/event_loop/render.rs
+++ b/src/backend/wayland/backend/event_loop/render.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use log::{debug, warn};
 
-use super::super::super::state::WaylandState;
+use super::super::super::state::{PerfRenderSkipReason, WaylandState};
 
 const MAX_RENDER_FAILURES: u32 = 10;
 
@@ -88,16 +88,24 @@ pub(super) fn maybe_render(
         state.begin_perf_render(render_start);
         match state.render(qh) {
             Ok(keep_rendering) => {
-                let render_duration = render_start.elapsed();
+                let render_end = Instant::now();
+                let render_duration = render_end.saturating_duration_since(render_start);
                 if render_duration > Duration::from_millis(5) {
                     debug!("Render took {:?}", render_duration);
                 }
 
                 // Reset failure counter and record render time.
                 *consecutive_render_failures = 0;
-                *last_render_time = Some(Instant::now());
+                *last_render_time = Some(render_end);
                 state.input_state.needs_redraw =
                     keep_rendering || state.input_state.has_pending_history();
+                state.record_perf_render_complete(
+                    render_start,
+                    render_end,
+                    vsync_enabled,
+                    state.config.performance.max_fps_no_vsync,
+                    keep_rendering,
+                );
                 // Only set frame_callback_pending if vsync is enabled.
                 if vsync_enabled {
                     state.surface.set_frame_callback_pending(true);
@@ -121,6 +129,20 @@ pub(super) fn maybe_render(
             }
         }
     } else {
+        let skip_reason = if !state.surface.is_configured() {
+            Some(PerfRenderSkipReason::SurfaceUnconfigured)
+        } else if !state.input_state.needs_redraw {
+            Some(PerfRenderSkipReason::NoRedraw)
+        } else if vsync_enabled && state.surface.frame_callback_pending() {
+            Some(PerfRenderSkipReason::FrameCallbackPending)
+        } else if !vsync_enabled && !frame_time_ok {
+            Some(PerfRenderSkipReason::FpsCap)
+        } else {
+            None
+        };
+        if let Some(reason) = skip_reason {
+            state.record_perf_render_skip(reason);
+        }
         state.render_layer_toolbars_if_needed();
         if state.input_state.needs_redraw {
             if vsync_enabled && state.surface.frame_callback_pending() {

--- a/src/backend/wayland/handlers/compositor.rs
+++ b/src/backend/wayland/handlers/compositor.rs
@@ -7,7 +7,7 @@ use wayland_client::{
     protocol::{wl_output, wl_surface},
 };
 
-use super::super::state::WaylandState;
+use super::super::state::{FullDamageReason, WaylandState};
 use crate::session;
 
 impl CompositorHandler for WaylandState {
@@ -25,7 +25,8 @@ impl CompositorHandler for WaylandState {
         let scale = new_factor.max(1);
         debug!("Scale factor changed to {}", scale);
         self.surface.set_scale(scale);
-        self.buffer_damage.mark_all_full();
+        self.buffer_damage
+            .mark_all_full(FullDamageReason::ScaleChanged);
         let (phys_w, phys_h) = self.surface.physical_dimensions();
         self.frozen
             .handle_resize(phys_w, phys_h, &mut self.input_state);
@@ -134,7 +135,8 @@ impl CompositorHandler for WaylandState {
             let scale = info.scale_factor.max(1);
             self.surface.set_scale(scale);
             // Mark full damage when entering output - scale may have changed, pool may be new
-            self.buffer_damage.mark_all_full();
+            self.buffer_damage
+                .mark_all_full(FullDamageReason::OutputChanged);
             self.toolbar.maybe_update_scale(Some(output), scale);
             self.toolbar.mark_dirty();
             let (logical_w, logical_h) = info

--- a/src/backend/wayland/handlers/layer.rs
+++ b/src/backend/wayland/handlers/layer.rs
@@ -6,7 +6,7 @@ use smithay_client_toolkit::shell::{
 };
 use wayland_client::{Connection, Proxy, QueueHandle};
 
-use super::super::state::WaylandState;
+use super::super::state::{FullDamageReason, WaylandState};
 use crate::session;
 
 impl LayerShellHandler for WaylandState {
@@ -58,7 +58,8 @@ impl LayerShellHandler for WaylandState {
 
             if size_changed {
                 info!("Surface size changed - recreating SlotPool");
-                self.buffer_damage.mark_all_full();
+                self.buffer_damage
+                    .mark_all_full(FullDamageReason::SurfaceResized);
             }
 
             self.input_state

--- a/src/backend/wayland/handlers/xdg.rs
+++ b/src/backend/wayland/handlers/xdg.rs
@@ -5,7 +5,7 @@ use smithay_client_toolkit::shell::xdg::window::{Window, WindowConfigure, Window
 use std::time::Instant;
 use wayland_client::{Connection, QueueHandle};
 
-use super::super::state::WaylandState;
+use super::super::state::{FullDamageReason, WaylandState};
 use crate::session;
 
 impl WindowHandler for WaylandState {
@@ -97,7 +97,8 @@ impl WindowHandler for WaylandState {
 
         if self.surface.update_dimensions(width, height) {
             info!("xdg window configured: {}x{}", width, height);
-            self.buffer_damage.mark_all_full();
+            self.buffer_damage
+                .mark_all_full(FullDamageReason::SurfaceResized);
         } else {
             debug!(
                 "xdg window configure acknowledged without size change ({}x{})",

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -103,13 +103,14 @@ mod tests;
 
 type ScreencopyManager = wayland_protocols_wlr::screencopy::v1::client::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1;
 
+pub(in crate::backend::wayland) use self::buffer_damage::FullDamageReason;
+pub(in crate::backend::wayland) use self::perf::{PerfInputSource, PerfRenderSkipReason};
 pub(super) use helpers::{
     color_log, damage_summary, debug_damage_logging_enabled, debug_toolbar_color_logging_enabled,
     debug_toolbar_drag_logging_enabled, drag_log, force_inline_toolbars_requested,
     scale_damage_regions, surface_id, toolbar_drag_preview_enabled, toolbar_drag_throttle_interval,
     toolbar_pointer_lock_enabled,
 };
-pub(in crate::backend::wayland) use perf::PerfInputSource;
 
 pub(in crate::backend::wayland) struct WaylandGlobals {
     pub registry_state: RegistryState,

--- a/src/backend/wayland/state/buffer_damage.rs
+++ b/src/backend/wayland/state/buffer_damage.rs
@@ -13,11 +13,71 @@
 //! previous canvas pointers become invalid.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::util::Rect;
 
 /// Maximum number of buffer slots to track (prevents unbounded growth).
 const MAX_TRACKED_BUFFERS: usize = 8;
+const DAMAGE_MERGE_MARGIN: i32 = 1;
+const DAMAGE_MERGE_ALIGNMENT_TOLERANCE: i32 = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(in crate::backend::wayland) enum FullDamageReason {
+    InitialFrame,
+    NewBufferSlot,
+    PoolGenerationChanged,
+    PoolGrew,
+    ScaleChanged,
+    SurfaceResized,
+    OutputChanged,
+    LayerSurfaceRecreated,
+    OverlaySuppression,
+    OverlayRestored,
+    Zoom,
+    BoardPan,
+    CanvasClear,
+    UiToast,
+    PresetFeedback,
+    BlockedFeedback,
+    TextEditEntry,
+    EmptyDamageFallback,
+    DamageRegionsCoverSurface,
+    Unknown,
+}
+
+impl FullDamageReason {
+    pub(in crate::backend::wayland) fn as_str(self) -> &'static str {
+        match self {
+            Self::InitialFrame => "initial_frame",
+            Self::NewBufferSlot => "new_buffer_slot",
+            Self::PoolGenerationChanged => "pool_generation_changed",
+            Self::PoolGrew => "pool_grew",
+            Self::ScaleChanged => "scale_changed",
+            Self::SurfaceResized => "surface_resized",
+            Self::OutputChanged => "output_changed",
+            Self::LayerSurfaceRecreated => "layer_surface_recreated",
+            Self::OverlaySuppression => "overlay_suppression",
+            Self::OverlayRestored => "overlay_restored",
+            Self::Zoom => "zoom",
+            Self::BoardPan => "board_pan",
+            Self::CanvasClear => "canvas_clear",
+            Self::UiToast => "ui_toast",
+            Self::PresetFeedback => "preset_feedback",
+            Self::BlockedFeedback => "blocked_feedback",
+            Self::TextEditEntry => "text_edit_entry",
+            Self::EmptyDamageFallback => "empty_damage_fallback",
+            Self::DamageRegionsCoverSurface => "damage_regions_cover_surface",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl fmt::Display for FullDamageReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// Damage state for a single buffer slot.
 #[derive(Debug, Default)]
@@ -26,8 +86,15 @@ struct BufferDamage {
     regions: Vec<Rect>,
     /// Force full damage on next render (e.g., new buffer or after resize).
     force_full: bool,
+    /// Reason the next render for this slot must use full damage.
+    force_full_reason: Option<FullDamageReason>,
     /// Frame counter for LRU eviction.
     last_used_frame: u64,
+}
+
+pub(in crate::backend::wayland) struct BufferDamageReport {
+    pub(in crate::backend::wayland) regions: Vec<Rect>,
+    pub(in crate::backend::wayland) full_reason: Option<FullDamageReason>,
 }
 
 /// Tracks dirty regions for each buffer slot independently.
@@ -46,6 +113,8 @@ pub struct BufferDamageTracker {
     frame_counter: u64,
     /// When true, all buffers (including new ones) get full damage.
     global_full_damage: bool,
+    /// Reason all buffers are forced to full damage.
+    global_full_reason: Option<FullDamageReason>,
     /// Pool generation - when this changes, all tracking is invalidated.
     pool_generation: u64,
     /// Pool size - when this increases, pool grew and tracking is invalidated.
@@ -59,6 +128,7 @@ impl BufferDamageTracker {
             buffers: HashMap::with_capacity(4),
             frame_counter: 0,
             global_full_damage: true, // First frame always needs full damage
+            global_full_reason: Some(FullDamageReason::InitialFrame),
             pool_generation: 0,
             pool_size: 0,
         }
@@ -73,6 +143,18 @@ impl BufferDamageTracker {
         let pool_grew = pool_size > self.pool_size;
 
         if pool_changed || pool_grew {
+            let first_pool_identity = self.pool_generation == 0
+                && self.pool_size == 0
+                && self.buffers.is_empty()
+                && self.global_full_damage;
+            let reason = if first_pool_identity {
+                self.global_full_reason
+                    .unwrap_or(FullDamageReason::InitialFrame)
+            } else if pool_changed {
+                FullDamageReason::PoolGenerationChanged
+            } else {
+                FullDamageReason::PoolGrew
+            };
             if pool_changed {
                 log::debug!(
                     "Pool generation changed {} -> {}, resetting damage tracking",
@@ -90,6 +172,7 @@ impl BufferDamageTracker {
             self.pool_size = pool_size;
             self.buffers.clear();
             self.global_full_damage = true;
+            self.global_full_reason = Some(reason);
         } else if pool_size != self.pool_size {
             // Pool shrunk (shouldn't happen normally, but track it)
             self.pool_size = pool_size;
@@ -109,10 +192,12 @@ impl BufferDamageTracker {
     }
 
     /// Marks the entire surface as dirty for all buffers (including future new ones).
-    pub fn mark_all_full(&mut self) {
+    pub fn mark_all_full(&mut self, reason: FullDamageReason) {
         self.global_full_damage = true;
+        self.global_full_reason = Some(reason);
         for damage in self.buffers.values_mut() {
             damage.force_full = true;
+            damage.force_full_reason = Some(reason);
             damage.regions.clear();
         }
     }
@@ -134,14 +219,14 @@ impl BufferDamageTracker {
     ///
     /// If this is a new slot (or global_full_damage is set), returns full damage.
     /// Otherwise returns and clears the slot's accumulated damage.
-    pub fn take_buffer_damage(
+    pub fn take_buffer_damage_report(
         &mut self,
         canvas_ptr: usize,
         width: i32,
         height: i32,
         pool_generation: u64,
         pool_size: usize,
-    ) -> Vec<Rect> {
+    ) -> BufferDamageReport {
         // Check pool identity first - resets tracking if pool changed
         self.check_pool_identity(pool_generation, pool_size);
         self.frame_counter += 1;
@@ -155,45 +240,86 @@ impl BufferDamageTracker {
             self.evict_if_needed();
         }
 
-        let damage = self
-            .buffers
-            .entry(canvas_ptr)
-            .or_insert_with(|| BufferDamage {
-                regions: Vec::new(),
-                force_full: true, // New slot always needs full damage
-                last_used_frame: frame,
-            });
+        let global_full = self.global_full_damage;
+        let global_reason = self.global_full_reason;
+        let (needs_full, full_reason, mut regions) = {
+            let damage = self
+                .buffers
+                .entry(canvas_ptr)
+                .or_insert_with(|| BufferDamage {
+                    regions: Vec::new(),
+                    force_full: true, // New slot always needs full damage
+                    force_full_reason: Some(FullDamageReason::NewBufferSlot),
+                    last_used_frame: frame,
+                });
 
-        damage.last_used_frame = frame;
+            damage.last_used_frame = frame;
 
-        // Check if we need full damage
-        let needs_full = damage.force_full || self.global_full_damage;
+            // Check if we need full damage
+            let needs_full = damage.force_full || global_full;
+            let full_reason = if global_full {
+                global_reason
+            } else if damage.force_full {
+                damage.force_full_reason
+            } else {
+                None
+            };
+
+            if needs_full {
+                damage.force_full = false;
+                damage.force_full_reason = None;
+                damage.regions.clear();
+                (true, full_reason, Vec::new())
+            } else {
+                // Take and deduplicate regions
+                let mut regions: Vec<Rect> = damage.regions.drain(..).collect();
+                regions.retain(Rect::is_valid);
+                (false, None, regions)
+            }
+        };
 
         if needs_full {
-            damage.force_full = false;
-            damage.regions.clear();
             // Clear global flag only after a buffer has received it
-            if self.global_full_damage {
+            if global_full {
                 self.global_full_damage = false;
+                self.global_full_reason = None;
             }
 
             if width > 0
                 && height > 0
                 && let Some(full) = Rect::new(0, 0, width, height)
             {
-                return vec![full];
+                return BufferDamageReport {
+                    regions: vec![full],
+                    full_reason: Some(full_reason.unwrap_or(FullDamageReason::Unknown)),
+                };
             }
-            return Vec::new();
+            return BufferDamageReport {
+                regions: Vec::new(),
+                full_reason,
+            };
         }
-
-        // Take and deduplicate regions
-        let mut regions: Vec<Rect> = damage.regions.drain(..).collect();
-        regions.retain(Rect::is_valid);
 
         // Merge overlapping regions to reduce compositor work
         merge_damage_regions(&mut regions);
 
-        regions
+        BufferDamageReport {
+            regions,
+            full_reason: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn take_buffer_damage(
+        &mut self,
+        canvas_ptr: usize,
+        width: i32,
+        height: i32,
+        pool_generation: u64,
+        pool_size: usize,
+    ) -> Vec<Rect> {
+        self.take_buffer_damage_report(canvas_ptr, width, height, pool_generation, pool_size)
+            .regions
     }
 
     /// Evicts oldest buffer if we're at capacity.
@@ -223,13 +349,14 @@ impl BufferDamageTracker {
     }
 }
 
-/// Merges overlapping or adjacent damage regions to reduce compositor work.
+/// Merges aligned overlapping or adjacent damage regions to reduce compositor work.
 fn merge_damage_regions(regions: &mut Vec<Rect>) {
     if regions.len() <= 1 {
         return;
     }
 
-    // Simple greedy merge: combine regions that overlap or touch
+    // Keep sparse diagonal/path damage split. Merging those into bounding boxes can turn an
+    // ordinary stroke into a full-surface damage rect even when most pixels are untouched.
     let mut merged = true;
     while merged && regions.len() > 1 {
         merged = false;
@@ -246,7 +373,7 @@ fn merge_damage_regions(regions: &mut Vec<Rect>) {
     }
 }
 
-/// Attempts to merge two rectangles if they overlap or are adjacent.
+/// Attempts to merge two rectangles if they overlap or are adjacent on the same row/column.
 fn try_merge_rects(a: &Rect, b: &Rect) -> Option<Rect> {
     let a_right = a.x.saturating_add(a.width);
     let a_bottom = a.y.saturating_add(a.height);
@@ -254,19 +381,34 @@ fn try_merge_rects(a: &Rect, b: &Rect) -> Option<Rect> {
     let b_bottom = b.y.saturating_add(b.height);
 
     // Check if rectangles overlap or touch (with 1px margin for adjacency)
-    let margin = 1;
-    let overlaps_x = a.x <= b_right + margin && b.x <= a_right + margin;
-    let overlaps_y = a.y <= b_bottom + margin && b.y <= a_bottom + margin;
+    let overlaps_x = ranges_touch_or_overlap(a.x, a_right, b.x, b_right);
+    let overlaps_y = ranges_touch_or_overlap(a.y, a_bottom, b.y, b_bottom);
 
-    if overlaps_x && overlaps_y {
-        let min_x = a.x.min(b.x);
-        let min_y = a.y.min(b.y);
-        let max_x = a_right.max(b_right);
-        let max_y = a_bottom.max(b_bottom);
-        Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
-    } else {
-        None
+    if !overlaps_x || !overlaps_y {
+        return None;
     }
+
+    let aligned_horizontally = ranges_aligned(a.y, a_bottom, b.y, b_bottom);
+    let aligned_vertically = ranges_aligned(a.x, a_right, b.x, b_right);
+    if !aligned_horizontally && !aligned_vertically {
+        return None;
+    }
+
+    let min_x = a.x.min(b.x);
+    let min_y = a.y.min(b.y);
+    let max_x = a_right.max(b_right);
+    let max_y = a_bottom.max(b_bottom);
+    Rect::new(min_x, min_y, max_x - min_x, max_y - min_y)
+}
+
+fn ranges_touch_or_overlap(a_start: i32, a_end: i32, b_start: i32, b_end: i32) -> bool {
+    a_start <= b_end.saturating_add(DAMAGE_MERGE_MARGIN)
+        && b_start <= a_end.saturating_add(DAMAGE_MERGE_MARGIN)
+}
+
+fn ranges_aligned(a_start: i32, a_end: i32, b_start: i32, b_end: i32) -> bool {
+    a_start.abs_diff(b_start) <= DAMAGE_MERGE_ALIGNMENT_TOLERANCE as u32
+        && a_end.abs_diff(b_end) <= DAMAGE_MERGE_ALIGNMENT_TOLERANCE as u32
 }
 
 #[cfg(test)]
@@ -334,7 +476,7 @@ mod tests {
         tracker.mark_rect(Rect::new(5, 5, 10, 10).unwrap());
 
         // Mark all full
-        tracker.mark_all_full();
+        tracker.mark_all_full(FullDamageReason::SurfaceResized);
 
         // Both slots should get full damage
         let d1 = tracker.take_buffer_damage(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
@@ -344,6 +486,21 @@ mod tests {
         let d2 = tracker.take_buffer_damage(0x2000, 800, 600, TEST_GEN, TEST_SIZE);
         assert_eq!(d2.len(), 1);
         assert_eq!(d2[0], Rect::new(0, 0, 800, 600).unwrap());
+    }
+
+    #[test]
+    fn report_exposes_full_damage_reasons() {
+        let mut tracker = BufferDamageTracker::new(2);
+
+        let initial = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
+        assert_eq!(initial.full_reason, Some(FullDamageReason::InitialFrame));
+
+        let new_slot = tracker.take_buffer_damage_report(0x2000, 800, 600, TEST_GEN, TEST_SIZE);
+        assert_eq!(new_slot.full_reason, Some(FullDamageReason::NewBufferSlot));
+
+        tracker.mark_all_full(FullDamageReason::UiToast);
+        let explicit = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
+        assert_eq!(explicit.full_reason, Some(FullDamageReason::UiToast));
     }
 
     #[test]
@@ -398,11 +555,11 @@ mod tests {
     fn merge_overlapping_regions() {
         let mut regions = vec![
             Rect::new(0, 0, 10, 10).unwrap(),
-            Rect::new(5, 5, 10, 10).unwrap(), // Overlaps first
+            Rect::new(5, 0, 10, 10).unwrap(), // Overlaps first on the same row
         ];
         merge_damage_regions(&mut regions);
         assert_eq!(regions.len(), 1);
-        assert_eq!(regions[0], Rect::new(0, 0, 15, 15).unwrap());
+        assert_eq!(regions[0], Rect::new(0, 0, 15, 10).unwrap());
     }
 
     #[test]
@@ -423,5 +580,89 @@ mod tests {
         ];
         merge_damage_regions(&mut regions);
         assert_eq!(regions.len(), 2);
+    }
+
+    #[test]
+    fn no_merge_diagonal_regions_into_surface_sized_bounds() {
+        let mut regions = (0..10)
+            .map(|index| {
+                let position = index * 10;
+                Rect::new(position, position, 20, 20).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        merge_damage_regions(&mut regions);
+
+        assert_eq!(regions.len(), 10);
+        assert!(
+            regions.iter().all(|rect| !(rect.x <= 0
+                && rect.y <= 0
+                && rect.width >= 100
+                && rect.height >= 100)),
+            "diagonal damage should stay split instead of becoming full-surface: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn buffer_damage_keeps_diagonal_path_damage_split() {
+        let mut tracker = BufferDamageTracker::new(3);
+        let _ = tracker.take_buffer_damage_report(0x1000, 100, 100, TEST_GEN, TEST_SIZE);
+
+        for index in 0..10 {
+            let position = index * 10;
+            tracker.mark_rect(Rect::new(position, position, 20, 20).unwrap());
+        }
+
+        let report = tracker.take_buffer_damage_report(0x1000, 100, 100, TEST_GEN, TEST_SIZE);
+
+        assert_eq!(report.full_reason, None);
+        assert_eq!(report.regions.len(), 10);
+        assert!(
+            report.regions.iter().all(|rect| !(rect.x <= 0
+                && rect.y <= 0
+                && rect.width >= 100
+                && rect.height >= 100)),
+            "diagonal path damage should not be reported as full damage: {:?}",
+            report.regions
+        );
+    }
+
+    #[test]
+    fn multi_buffer_path_damage_stays_split_across_reused_slots() {
+        let mut tracker = BufferDamageTracker::new(3);
+        for slot in [0x1000, 0x2000, 0x3000] {
+            let _ = tracker.take_buffer_damage_report(slot, 1000, 1000, TEST_GEN, TEST_SIZE);
+        }
+
+        for index in 0..10 {
+            let position = index * 100;
+            tracker.mark_rect(Rect::new(position, position, 120, 120).unwrap());
+        }
+
+        let first_reused =
+            tracker.take_buffer_damage_report(0x2000, 1000, 1000, TEST_GEN, TEST_SIZE);
+        assert_eq!(first_reused.full_reason, None);
+        assert_path_damage_stays_split(&first_reused.regions);
+
+        tracker.mark_rect(Rect::new(930, 930, 60, 60).unwrap());
+
+        let second_reused =
+            tracker.take_buffer_damage_report(0x3000, 1000, 1000, TEST_GEN, TEST_SIZE);
+        assert_eq!(second_reused.full_reason, None);
+        assert_path_damage_stays_split(&second_reused.regions);
+    }
+
+    fn assert_path_damage_stays_split(regions: &[Rect]) {
+        assert!(
+            regions.len() > 1,
+            "path damage should stay split across reused buffers: {regions:?}"
+        );
+        assert!(
+            regions.iter().all(|rect| !(rect.x <= 0
+                && rect.y <= 0
+                && rect.width >= 1000
+                && rect.height >= 1000)),
+            "path damage should not become a full-surface region: {regions:?}"
+        );
     }
 }

--- a/src/backend/wayland/state/core/output.rs
+++ b/src/backend/wayland/state/core/output.rs
@@ -447,7 +447,8 @@ impl WaylandState {
         self.surface.set_layer_surface(layer_surface);
         self.set_current_keyboard_interactivity(Some(desired_keyboard_mode));
         self.force_sync_overlay_interactivity();
-        self.buffer_damage.mark_all_full();
+        self.buffer_damage
+            .mark_all_full(FullDamageReason::LayerSurfaceRecreated);
         self.set_toolbar_needs_recreate(true);
     }
 }

--- a/src/backend/wayland/state/core/overlay.rs
+++ b/src/backend/wayland/state/core/overlay.rs
@@ -58,7 +58,8 @@ impl WaylandState {
         }
         self.data.overlay_suppression = reason;
         self.sync_overlay_interactivity();
-        self.buffer_damage.mark_all_full();
+        self.buffer_damage
+            .mark_all_full(FullDamageReason::OverlaySuppression);
         self.input_state.needs_redraw = true;
         self.toolbar.mark_dirty();
         true
@@ -73,7 +74,8 @@ impl WaylandState {
         }
         self.data.overlay_suppression = OverlaySuppression::None;
         self.sync_overlay_interactivity();
-        self.buffer_damage.mark_all_full();
+        self.buffer_damage
+            .mark_all_full(FullDamageReason::OverlayRestored);
         self.input_state.needs_redraw = true;
         self.toolbar.mark_dirty();
     }

--- a/src/backend/wayland/state/perf.rs
+++ b/src/backend/wayland/state/perf.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     fmt,
     time::{Duration, Instant},
 };
@@ -12,13 +12,16 @@ use crate::{
     util::Rect,
 };
 
-use super::WaylandState;
+use super::{FullDamageReason, WaylandState};
 
 const MAX_PENDING_INPUT_SAMPLES: usize = 4096;
 const MAX_RECENT_LATENCIES: usize = 2048;
+const MAX_RECENT_RENDER_DURATIONS: usize = 2048;
 const SUMMARY_FRAME_INTERVAL: u64 = 120;
 const SUMMARY_INTERVAL: Duration = Duration::from_secs(5);
 const SLOW_INPUT_TO_COMMIT: Duration = Duration::from_millis(50);
+const VSYNC_ASSUMED_FRAME_BUDGET: Duration = Duration::from_micros(16_667);
+const SLOW_RENDER_FALLBACK: Duration = Duration::from_millis(50);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(not(tablet), allow(dead_code))]
@@ -34,6 +37,25 @@ impl fmt::Display for PerfInputSource {
             Self::Pointer => f.write_str("pointer"),
             Self::Touch => f.write_str("touch"),
             Self::Stylus => f.write_str("stylus"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum PerfRenderSkipReason {
+    FrameCallbackPending,
+    FpsCap,
+    SurfaceUnconfigured,
+    NoRedraw,
+}
+
+impl fmt::Display for PerfRenderSkipReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FrameCallbackPending => f.write_str("frame_callback_pending"),
+            Self::FpsCap => f.write_str("fps_cap"),
+            Self::SurfaceUnconfigured => f.write_str("surface_unconfigured"),
+            Self::NoRedraw => f.write_str("no_redraw"),
         }
     }
 }
@@ -57,6 +79,19 @@ struct PerfFrameContext {
     dirty_area_pct: f64,
     full_damage: bool,
     damage_rects: usize,
+    force_full_reason: Option<FullDamageReason>,
+}
+
+impl Default for PerfFrameContext {
+    fn default() -> Self {
+        Self {
+            render_duration: None,
+            dirty_area_pct: 0.0,
+            full_damage: false,
+            damage_rects: 0,
+            force_full_reason: None,
+        }
+    }
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -100,16 +135,85 @@ struct PerfSummary {
     dropped_input_samples: u64,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq)]
+struct PerfFramePacingReport {
+    slow_frame: Option<PerfSlowRenderFrame>,
+    summary: Option<PerfFramePacingSummary>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, Default, PartialEq)]
+struct PerfFinalSummaryReport {
+    input: Option<PerfSummary>,
+    frame_pacing: Option<PerfFramePacingSummary>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq)]
+struct PerfSlowRenderFrame {
+    frame: u64,
+    render_ms: u64,
+    budget_ms: Option<u64>,
+    vsync_enabled: bool,
+    max_fps_no_vsync: u32,
+    dirty_area_pct: f64,
+    full_damage: bool,
+    damage_rects: usize,
+    force_full_reason: Option<FullDamageReason>,
+    keep_rendering: bool,
+    skipped_frame_callback_pending: u64,
+    skipped_fps_cap: u64,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PerfFramePacingSummary {
+    frames: u64,
+    window_frames: usize,
+    render_p50_ms: u64,
+    render_p95_ms: u64,
+    render_p99_ms: u64,
+    render_max_ms: u64,
+    render_over_8ms: u64,
+    render_over_16ms: u64,
+    render_over_33ms: u64,
+    render_over_50ms: u64,
+    full_damage_count: u64,
+    full_damage_pct: String,
+    force_full_reason: String,
+    force_full_reasons: String,
+    skipped_frame_callback_pending: u64,
+    skipped_fps_cap: u64,
+    skipped_surface_unconfigured: u64,
+    skipped_no_redraw: u64,
+}
+
 #[derive(Debug)]
 pub(super) struct PerfMetrics {
     enabled: bool,
     pending_input_samples: VecDeque<PerfInputSample>,
     recent_latencies_ms: VecDeque<u64>,
+    recent_render_ms: VecDeque<u64>,
     render_started_at: Option<Instant>,
+    last_frame_context: Option<PerfFrameContext>,
     frames_since_summary: u64,
     samples_since_summary: u64,
+    render_frame_id: u64,
+    render_frames_since_summary: u64,
+    render_over_8ms: u64,
+    render_over_16ms: u64,
+    render_over_33ms: u64,
+    render_over_50ms: u64,
+    full_damage_count: u64,
+    full_damage_reasons: BTreeMap<FullDamageReason, u64>,
+    skipped_frame_callback_pending: u64,
+    skipped_fps_cap: u64,
+    skipped_surface_unconfigured: u64,
+    skipped_no_redraw: u64,
     dropped_input_samples: u64,
     last_summary_at: Option<Instant>,
+    last_frame_pacing_summary_at: Option<Instant>,
 }
 
 impl PerfMetrics {
@@ -126,11 +230,26 @@ impl PerfMetrics {
             enabled,
             pending_input_samples: VecDeque::new(),
             recent_latencies_ms: VecDeque::new(),
+            recent_render_ms: VecDeque::new(),
             render_started_at: None,
+            last_frame_context: None,
             frames_since_summary: 0,
             samples_since_summary: 0,
+            render_frame_id: 0,
+            render_frames_since_summary: 0,
+            render_over_8ms: 0,
+            render_over_16ms: 0,
+            render_over_33ms: 0,
+            render_over_50ms: 0,
+            full_damage_count: 0,
+            full_damage_reasons: BTreeMap::new(),
+            skipped_frame_callback_pending: 0,
+            skipped_fps_cap: 0,
+            skipped_surface_unconfigured: 0,
+            skipped_no_redraw: 0,
             dropped_input_samples: 0,
             last_summary_at: None,
+            last_frame_pacing_summary_at: None,
         }
     }
 
@@ -143,6 +262,105 @@ impl PerfMetrics {
             return;
         }
         self.render_started_at = Some(now);
+    }
+
+    fn record_render_skip(&mut self, reason: PerfRenderSkipReason) {
+        if !self.enabled {
+            return;
+        }
+        match reason {
+            PerfRenderSkipReason::FrameCallbackPending => {
+                self.skipped_frame_callback_pending += 1;
+            }
+            PerfRenderSkipReason::FpsCap => {
+                self.skipped_fps_cap += 1;
+            }
+            PerfRenderSkipReason::SurfaceUnconfigured => {
+                self.skipped_surface_unconfigured += 1;
+            }
+            PerfRenderSkipReason::NoRedraw => {
+                self.skipped_no_redraw += 1;
+            }
+        }
+    }
+
+    fn record_render_complete(
+        &mut self,
+        render_started_at: Instant,
+        render_finished_at: Instant,
+        vsync_enabled: bool,
+        max_fps_no_vsync: u32,
+        keep_rendering: bool,
+    ) -> Option<PerfFramePacingReport> {
+        if !self.enabled {
+            return None;
+        }
+
+        let render_duration = render_finished_at.saturating_duration_since(render_started_at);
+        let render_ms = duration_ms(render_duration);
+        self.push_render_ms(render_ms);
+        self.render_frame_id += 1;
+        self.render_frames_since_summary += 1;
+        self.count_render_duration(render_duration);
+        if self.last_frame_pacing_summary_at.is_none() {
+            self.last_frame_pacing_summary_at = Some(render_finished_at);
+        }
+
+        let frame = self.last_frame_context.take().unwrap_or_default();
+        self.count_full_damage(&frame);
+        let budget = frame_budget_duration(vsync_enabled, max_fps_no_vsync);
+        let slow_frame = if budget.is_some_and(|budget| render_duration > budget)
+            || render_duration > SLOW_RENDER_FALLBACK
+        {
+            Some(PerfSlowRenderFrame {
+                frame: self.render_frame_id,
+                render_ms,
+                budget_ms: budget.map(duration_ms),
+                vsync_enabled,
+                max_fps_no_vsync,
+                dirty_area_pct: frame.dirty_area_pct,
+                full_damage: frame.full_damage,
+                damage_rects: frame.damage_rects,
+                force_full_reason: frame.force_full_reason,
+                keep_rendering,
+                skipped_frame_callback_pending: self.skipped_frame_callback_pending,
+                skipped_fps_cap: self.skipped_fps_cap,
+            })
+        } else {
+            None
+        };
+
+        if let Some(slow) = slow_frame.as_ref() {
+            info!(
+                "perf.slow_frame frame={} render_ms={} budget_ms={} vsync={} max_fps_no_vsync={} dirty_area_pct={:.2} full_damage={} force_full_reason={} damage_rects={} keep_rendering={} skipped_frame_callback_pending={} skipped_fps_cap={}",
+                slow.frame,
+                slow.render_ms,
+                format_optional_ms(slow.budget_ms),
+                slow.vsync_enabled,
+                slow.max_fps_no_vsync,
+                slow.dirty_area_pct,
+                slow.full_damage,
+                format_force_full_reason(slow.force_full_reason),
+                slow.damage_rects,
+                slow.keep_rendering,
+                slow.skipped_frame_callback_pending,
+                slow.skipped_fps_cap
+            );
+        }
+
+        let summary = if self.frame_pacing_summary_due(render_finished_at) {
+            let summary = self.build_frame_pacing_summary();
+            log_frame_pacing_summary(&summary, false);
+            self.reset_frame_pacing_summary(render_finished_at);
+            Some(summary)
+        } else {
+            None
+        };
+
+        Some(PerfFramePacingReport {
+            slow_frame,
+            summary,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -192,6 +410,7 @@ impl PerfMetrics {
                 .map(|start| commit_at.saturating_duration_since(start))
         });
         self.render_started_at = None;
+        self.last_frame_context = Some(frame);
 
         let mut sample_count: usize = 0;
         let mut max_latency = Duration::ZERO;
@@ -256,20 +475,8 @@ impl PerfMetrics {
 
         let summary = if self.summary_due(commit_at) && !self.recent_latencies_ms.is_empty() {
             let summary = self.build_summary();
-            info!(
-                "perf.input_to_paint_latency proxy=input_to_wayland_commit frames={} samples={} window_samples={} p50_ms={} p95_ms={} p99_ms={} max_ms={} dropped_input_samples={}",
-                summary.frames,
-                summary.samples,
-                summary.window_samples,
-                summary.p50_ms,
-                summary.p95_ms,
-                summary.p99_ms,
-                summary.max_ms,
-                summary.dropped_input_samples
-            );
-            self.frames_since_summary = 0;
-            self.samples_since_summary = 0;
-            self.last_summary_at = Some(commit_at);
+            log_input_summary(&summary, false);
+            self.reset_input_summary(commit_at);
             Some(summary)
         } else {
             None
@@ -288,6 +495,39 @@ impl PerfMetrics {
             self.recent_latencies_ms.pop_front();
         }
         self.recent_latencies_ms.push_back(latency_ms);
+    }
+
+    fn push_render_ms(&mut self, render_ms: u64) {
+        if self.recent_render_ms.len() == MAX_RECENT_RENDER_DURATIONS {
+            self.recent_render_ms.pop_front();
+        }
+        self.recent_render_ms.push_back(render_ms);
+    }
+
+    fn count_render_duration(&mut self, render_duration: Duration) {
+        if render_duration > Duration::from_millis(8) {
+            self.render_over_8ms += 1;
+        }
+        if render_duration > Duration::from_millis(16) {
+            self.render_over_16ms += 1;
+        }
+        if render_duration > Duration::from_millis(33) {
+            self.render_over_33ms += 1;
+        }
+        if render_duration > Duration::from_millis(50) {
+            self.render_over_50ms += 1;
+        }
+    }
+
+    fn count_full_damage(&mut self, frame: &PerfFrameContext) {
+        if !frame.full_damage {
+            return;
+        }
+        self.full_damage_count += 1;
+        let reason = frame
+            .force_full_reason
+            .unwrap_or(FullDamageReason::DamageRegionsCoverSurface);
+        *self.full_damage_reasons.entry(reason).or_default() += 1;
     }
 
     fn summary_due(&self, now: Instant) -> bool {
@@ -313,11 +553,121 @@ impl PerfMetrics {
             dropped_input_samples: self.dropped_input_samples,
         }
     }
+
+    fn reset_input_summary(&mut self, now: Instant) {
+        self.frames_since_summary = 0;
+        self.samples_since_summary = 0;
+        self.last_summary_at = Some(now);
+    }
+
+    fn frame_pacing_summary_due(&self, now: Instant) -> bool {
+        if self.render_frames_since_summary >= SUMMARY_FRAME_INTERVAL {
+            return true;
+        }
+        self.last_frame_pacing_summary_at
+            .is_some_and(|last| now.saturating_duration_since(last) >= SUMMARY_INTERVAL)
+    }
+
+    fn build_frame_pacing_summary(&self) -> PerfFramePacingSummary {
+        let mut sorted = self.recent_render_ms.iter().copied().collect::<Vec<_>>();
+        sorted.sort_unstable();
+
+        PerfFramePacingSummary {
+            frames: self.render_frames_since_summary,
+            window_frames: sorted.len(),
+            render_p50_ms: percentile_nearest_rank(&sorted, 50).unwrap_or(0),
+            render_p95_ms: percentile_nearest_rank(&sorted, 95).unwrap_or(0),
+            render_p99_ms: percentile_nearest_rank(&sorted, 99).unwrap_or(0),
+            render_max_ms: sorted.last().copied().unwrap_or(0),
+            render_over_8ms: self.render_over_8ms,
+            render_over_16ms: self.render_over_16ms,
+            render_over_33ms: self.render_over_33ms,
+            render_over_50ms: self.render_over_50ms,
+            full_damage_count: self.full_damage_count,
+            full_damage_pct: format_pct(self.full_damage_count, self.render_frames_since_summary),
+            force_full_reason: dominant_full_damage_reason(&self.full_damage_reasons)
+                .map_or_else(|| "none".to_string(), |reason| reason.as_str().to_string()),
+            force_full_reasons: format_full_damage_reasons(&self.full_damage_reasons),
+            skipped_frame_callback_pending: self.skipped_frame_callback_pending,
+            skipped_fps_cap: self.skipped_fps_cap,
+            skipped_surface_unconfigured: self.skipped_surface_unconfigured,
+            skipped_no_redraw: self.skipped_no_redraw,
+        }
+    }
+
+    fn reset_frame_pacing_summary(&mut self, now: Instant) {
+        self.render_frames_since_summary = 0;
+        self.render_over_8ms = 0;
+        self.render_over_16ms = 0;
+        self.render_over_33ms = 0;
+        self.render_over_50ms = 0;
+        self.full_damage_count = 0;
+        self.full_damage_reasons.clear();
+        self.skipped_frame_callback_pending = 0;
+        self.skipped_fps_cap = 0;
+        self.skipped_surface_unconfigured = 0;
+        self.skipped_no_redraw = 0;
+        self.last_frame_pacing_summary_at = Some(now);
+    }
+
+    fn flush_pending_summaries(&mut self, now: Instant) -> PerfFinalSummaryReport {
+        if !self.enabled {
+            return PerfFinalSummaryReport::default();
+        }
+
+        let input = if self.samples_since_summary > 0 && !self.recent_latencies_ms.is_empty() {
+            let summary = self.build_summary();
+            log_input_summary(&summary, true);
+            self.reset_input_summary(now);
+            Some(summary)
+        } else {
+            None
+        };
+
+        let frame_pacing =
+            if self.render_frames_since_summary > 0 && !self.recent_render_ms.is_empty() {
+                let summary = self.build_frame_pacing_summary();
+                log_frame_pacing_summary(&summary, true);
+                self.reset_frame_pacing_summary(now);
+                Some(summary)
+            } else {
+                None
+            };
+
+        PerfFinalSummaryReport {
+            input,
+            frame_pacing,
+        }
+    }
 }
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn begin_perf_render(&mut self, now: Instant) {
         self.perf.begin_render(now);
+    }
+
+    pub(in crate::backend::wayland) fn record_perf_render_skip(
+        &mut self,
+        reason: PerfRenderSkipReason,
+    ) {
+        self.perf.record_render_skip(reason);
+    }
+
+    pub(in crate::backend::wayland) fn record_perf_render_complete(
+        &mut self,
+        render_started_at: Instant,
+        render_finished_at: Instant,
+        vsync_enabled: bool,
+        max_fps_no_vsync: u32,
+        keep_rendering: bool,
+    ) {
+        let _ = self.perf.record_render_complete(
+            render_started_at,
+            render_finished_at,
+            vsync_enabled,
+            max_fps_no_vsync,
+            keep_rendering,
+        );
     }
 
     pub(in crate::backend::wayland) fn record_perf_input_sample(
@@ -354,16 +704,19 @@ impl WaylandState {
         logical_width: u32,
         logical_height: u32,
         damage_rects: usize,
+        force_full_reason: Option<FullDamageReason>,
         commit_at: Instant,
     ) {
         if !self.perf.enabled() {
             return;
         }
+        let full_damage = damage_covers_surface(damage_screen, logical_width, logical_height);
         let frame = PerfFrameContext {
             render_duration: None,
             dirty_area_pct: damage_area_pct(damage_screen, logical_width, logical_height),
-            full_damage: damage_covers_surface(damage_screen, logical_width, logical_height),
+            full_damage,
             damage_rects,
+            force_full_reason: if full_damage { force_full_reason } else { None },
         };
         let _ = self.perf.commit_frame(frame, commit_at);
     }
@@ -374,6 +727,50 @@ impl WaylandState {
         };
         Some((*tool, points.len()))
     }
+
+    pub(in crate::backend::wayland) fn flush_perf_summaries(&mut self, now: Instant) {
+        let _ = self.perf.flush_pending_summaries(now);
+    }
+}
+
+fn log_input_summary(summary: &PerfSummary, final_summary: bool) {
+    info!(
+        "perf.input_to_paint_latency proxy=input_to_wayland_commit frames={} samples={} window_samples={} p50_ms={} p95_ms={} p99_ms={} max_ms={} dropped_input_samples={} final={}",
+        summary.frames,
+        summary.samples,
+        summary.window_samples,
+        summary.p50_ms,
+        summary.p95_ms,
+        summary.p99_ms,
+        summary.max_ms,
+        summary.dropped_input_samples,
+        final_summary
+    );
+}
+
+fn log_frame_pacing_summary(summary: &PerfFramePacingSummary, final_summary: bool) {
+    info!(
+        "perf.frame_pacing frames={} window_frames={} render_p50_ms={} render_p95_ms={} render_p99_ms={} render_max_ms={} render_over_8ms={} render_over_16ms={} render_over_33ms={} render_over_50ms={} full_damage_count={} full_damage_pct={} force_full_reason={} force_full_reasons={} skipped_frame_callback_pending={} skipped_fps_cap={} skipped_surface_unconfigured={} skipped_no_redraw={} final={}",
+        summary.frames,
+        summary.window_frames,
+        summary.render_p50_ms,
+        summary.render_p95_ms,
+        summary.render_p99_ms,
+        summary.render_max_ms,
+        summary.render_over_8ms,
+        summary.render_over_16ms,
+        summary.render_over_33ms,
+        summary.render_over_50ms,
+        summary.full_damage_count,
+        summary.full_damage_pct,
+        summary.force_full_reason,
+        summary.force_full_reasons,
+        summary.skipped_frame_callback_pending,
+        summary.skipped_fps_cap,
+        summary.skipped_surface_unconfigured,
+        summary.skipped_no_redraw,
+        final_summary
+    );
 }
 
 fn perf_log_enabled_from_env() -> bool {
@@ -388,6 +785,49 @@ fn duration_ms(duration: Duration) -> u64 {
 
 fn format_optional_ms(value: Option<u64>) -> String {
     value.map_or_else(|| "n/a".to_string(), |ms| ms.to_string())
+}
+
+fn format_force_full_reason(reason: Option<FullDamageReason>) -> &'static str {
+    reason.map_or("none", FullDamageReason::as_str)
+}
+
+fn format_pct(count: u64, total: u64) -> String {
+    if total == 0 {
+        return "0.00".to_string();
+    }
+    format!("{:.2}", (count as f64 / total as f64) * 100.0)
+}
+
+fn dominant_full_damage_reason(
+    reasons: &BTreeMap<FullDamageReason, u64>,
+) -> Option<FullDamageReason> {
+    reasons
+        .iter()
+        .max_by_key(|(_, count)| **count)
+        .map(|(reason, _)| *reason)
+}
+
+fn format_full_damage_reasons(reasons: &BTreeMap<FullDamageReason, u64>) -> String {
+    if reasons.is_empty() {
+        return "none".to_string();
+    }
+    reasons
+        .iter()
+        .map(|(reason, count)| format!("{}:{}", reason.as_str(), count))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn frame_budget_duration(vsync_enabled: bool, max_fps_no_vsync: u32) -> Option<Duration> {
+    if vsync_enabled {
+        Some(VSYNC_ASSUMED_FRAME_BUDGET)
+    } else if max_fps_no_vsync == 0 {
+        None
+    } else {
+        Some(Duration::from_micros(
+            1_000_000u64 / u64::from(max_fps_no_vsync),
+        ))
+    }
 }
 
 fn percentile_nearest_rank(sorted_values: &[u64], percentile: u64) -> Option<u64> {
@@ -473,6 +913,7 @@ mod tests {
                 dirty_area_pct: 1.0,
                 full_damage: false,
                 damage_rects: 1,
+                force_full_reason: None,
             },
             base + Duration::from_millis(16),
         );
@@ -507,6 +948,7 @@ mod tests {
                     dirty_area_pct: 2.5,
                     full_damage: false,
                     damage_rects: 3,
+                    force_full_reason: None,
                 },
                 base + Duration::from_millis(70),
             )
@@ -553,6 +995,7 @@ mod tests {
                     dirty_area_pct: 0.5,
                     full_damage: false,
                     damage_rects: 1,
+                    force_full_reason: None,
                 },
                 commit_at,
             );
@@ -582,6 +1025,7 @@ mod tests {
                 dirty_area_pct: 0.5,
                 full_damage: false,
                 damage_rects: 1,
+                force_full_reason: None,
             },
             base + Duration::from_millis(10),
         );
@@ -595,6 +1039,7 @@ mod tests {
                     dirty_area_pct: 0.5,
                     full_damage: false,
                     damage_rects: 1,
+                    force_full_reason: None,
                 },
                 base + Duration::from_secs(5) + Duration::from_millis(20),
             )
@@ -605,6 +1050,204 @@ mod tests {
         assert_eq!(summary.samples, 2);
         assert_eq!(summary.p95_ms, 20);
         assert_eq!(summary.p99_ms, 20);
+    }
+
+    #[test]
+    fn final_summary_flushes_partial_frame_and_input_windows_once() {
+        let base = Instant::now();
+        let mut metrics = PerfMetrics::new(true);
+
+        record_sample(&mut metrics, base);
+        let _ = metrics.commit_frame(
+            PerfFrameContext {
+                render_duration: Some(Duration::from_millis(2)),
+                dirty_area_pct: 100.0,
+                full_damage: true,
+                damage_rects: 1,
+                force_full_reason: None,
+            },
+            base + Duration::from_millis(9),
+        );
+        let _ = metrics.record_render_complete(
+            base + Duration::from_millis(10),
+            base + Duration::from_millis(12),
+            false,
+            120,
+            false,
+        );
+
+        let report = metrics.flush_pending_summaries(base + Duration::from_millis(20));
+
+        let input = report.input.expect("partial input summary should flush");
+        assert_eq!(input.frames, 1);
+        assert_eq!(input.samples, 1);
+        assert_eq!(input.p95_ms, 9);
+
+        let frame_pacing = report
+            .frame_pacing
+            .expect("partial frame pacing summary should flush");
+        assert_eq!(frame_pacing.frames, 1);
+        assert_eq!(frame_pacing.render_p95_ms, 2);
+        assert_eq!(frame_pacing.full_damage_count, 1);
+        assert_eq!(frame_pacing.full_damage_pct, "100.00");
+        assert_eq!(
+            frame_pacing.force_full_reasons,
+            "damage_regions_cover_surface:1"
+        );
+
+        assert_eq!(metrics.frames_since_summary, 0);
+        assert_eq!(metrics.samples_since_summary, 0);
+        assert_eq!(metrics.render_frames_since_summary, 0);
+        assert_eq!(metrics.full_damage_count, 0);
+        assert_eq!(
+            metrics.flush_pending_summaries(base + Duration::from_millis(30)),
+            PerfFinalSummaryReport::default()
+        );
+    }
+
+    #[test]
+    fn slow_frame_reports_render_budget_and_damage_context() {
+        let base = Instant::now();
+        let mut metrics = PerfMetrics::new(true);
+        let _ = metrics.commit_frame(
+            PerfFrameContext {
+                render_duration: Some(Duration::from_millis(1)),
+                dirty_area_pct: 42.0,
+                full_damage: true,
+                damage_rects: 2,
+                force_full_reason: Some(FullDamageReason::UiToast),
+            },
+            base,
+        );
+
+        let report = metrics
+            .record_render_complete(base, base + Duration::from_millis(12), false, 120, false)
+            .expect("enabled metrics should report render frames");
+
+        let slow = report.slow_frame.expect("12ms exceeds the 120 FPS budget");
+        assert_eq!(slow.frame, 1);
+        assert_eq!(slow.render_ms, 12);
+        assert_eq!(slow.budget_ms, Some(8));
+        assert_eq!(slow.max_fps_no_vsync, 120);
+        assert_eq!(slow.dirty_area_pct, 42.0);
+        assert!(slow.full_damage);
+        assert_eq!(slow.force_full_reason, Some(FullDamageReason::UiToast));
+        assert_eq!(slow.damage_rects, 2);
+    }
+
+    #[test]
+    fn frame_pacing_summary_reports_render_percentiles_and_skips() {
+        let base = Instant::now();
+        let mut metrics = PerfMetrics::new(true);
+
+        metrics.record_render_skip(PerfRenderSkipReason::FrameCallbackPending);
+        metrics.record_render_skip(PerfRenderSkipReason::FpsCap);
+        metrics.record_render_skip(PerfRenderSkipReason::SurfaceUnconfigured);
+        metrics.record_render_skip(PerfRenderSkipReason::NoRedraw);
+
+        for frame in 0..SUMMARY_FRAME_INTERVAL {
+            let started_at = base + Duration::from_millis(frame * 2);
+            let duration = Duration::from_millis(frame + 1);
+            if frame % 40 == 0 {
+                let _ = metrics.commit_frame(
+                    PerfFrameContext {
+                        render_duration: Some(Duration::from_millis(1)),
+                        dirty_area_pct: 100.0,
+                        full_damage: true,
+                        damage_rects: 1,
+                        force_full_reason: Some(FullDamageReason::UiToast),
+                    },
+                    started_at,
+                );
+            }
+            let report =
+                metrics.record_render_complete(started_at, started_at + duration, true, 120, false);
+            if frame + 1 < SUMMARY_FRAME_INTERVAL {
+                assert!(report.and_then(|r| r.summary).is_none());
+            } else {
+                let summary = report
+                    .and_then(|r| r.summary)
+                    .expect("summary at frame interval");
+                assert_eq!(summary.frames, SUMMARY_FRAME_INTERVAL);
+                assert_eq!(summary.window_frames, SUMMARY_FRAME_INTERVAL as usize);
+                assert_eq!(summary.render_p95_ms, 114);
+                assert_eq!(summary.render_p99_ms, 119);
+                assert_eq!(summary.render_max_ms, 120);
+                assert_eq!(summary.skipped_frame_callback_pending, 1);
+                assert_eq!(summary.skipped_fps_cap, 1);
+                assert_eq!(summary.skipped_surface_unconfigured, 1);
+                assert_eq!(summary.skipped_no_redraw, 1);
+                assert_eq!(summary.render_over_50ms, 70);
+                assert_eq!(summary.full_damage_count, 3);
+                assert_eq!(summary.full_damage_pct, "2.50");
+                assert_eq!(summary.force_full_reason, "ui_toast");
+                assert_eq!(summary.force_full_reasons, "ui_toast:3");
+            }
+        }
+    }
+
+    #[test]
+    fn frame_pacing_summary_separates_unreasoned_full_damage_from_expected_reasons() {
+        let base = Instant::now();
+        let mut metrics = PerfMetrics::new(true);
+
+        for frame in 0..SUMMARY_FRAME_INTERVAL {
+            let started_at = base + Duration::from_millis(frame * 2);
+            let force_full_reason = match frame {
+                0 => Some(FullDamageReason::CanvasClear),
+                1 | 2 => None,
+                _ => {
+                    let _ = metrics.commit_frame(
+                        PerfFrameContext {
+                            render_duration: Some(Duration::from_millis(1)),
+                            dirty_area_pct: 0.5,
+                            full_damage: false,
+                            damage_rects: 1,
+                            force_full_reason: None,
+                        },
+                        started_at,
+                    );
+                    let report = metrics.record_render_complete(
+                        started_at,
+                        started_at + Duration::from_millis(1),
+                        false,
+                        120,
+                        false,
+                    );
+                    if frame + 1 == SUMMARY_FRAME_INTERVAL {
+                        let summary = report
+                            .and_then(|report| report.summary)
+                            .expect("summary at frame interval");
+                        assert_eq!(summary.full_damage_count, 3);
+                        assert_eq!(summary.full_damage_pct, "2.50");
+                        assert_eq!(
+                            summary.force_full_reasons,
+                            "canvas_clear:1,damage_regions_cover_surface:2"
+                        );
+                    }
+                    continue;
+                }
+            };
+
+            let _ = metrics.commit_frame(
+                PerfFrameContext {
+                    render_duration: Some(Duration::from_millis(1)),
+                    dirty_area_pct: 100.0,
+                    full_damage: true,
+                    damage_rects: 1,
+                    force_full_reason,
+                },
+                started_at,
+            );
+            let report = metrics.record_render_complete(
+                started_at,
+                started_at + Duration::from_millis(1),
+                false,
+                120,
+                false,
+            );
+            assert!(report.and_then(|report| report.summary).is_none());
+        }
     }
 
     #[test]

--- a/src/backend/wayland/state/render/mod.rs
+++ b/src/backend/wayland/state/render/mod.rs
@@ -39,18 +39,22 @@ impl WaylandState {
         // Add new dirty regions from input state to the per-buffer damage tracker.
         // We do this BEFORE acquiring the buffer/damage so the current frame's changes
         // are included in the damage for the current buffer.
-        let input_damage = self.input_state.take_dirty_regions();
+        let input_damage_report = self.input_state.take_dirty_region_report();
+        let input_damage = input_damage_report.regions;
         let logical_width = width.min(i32::MAX as u32) as i32;
         let logical_height = height.min(i32::MAX as u32) as i32;
-        let force_full_damage = self.canvas_transform_active()
-            || ui_toast_active
-            || preset_feedback_active
-            || blocked_feedback_active
-            || text_edit_entry_active;
-        if force_full_damage {
+        let force_full_damage_reason = self.render_force_full_damage_reason(
+            ui_toast_active,
+            preset_feedback_active,
+            blocked_feedback_active,
+            text_edit_entry_active,
+        );
+        if let Some(reason) = force_full_damage_reason {
             // Zoom uses a world transform and some UI effects don't emit damage; full damage avoids
             // mismatched coordinate spaces and empty damage frames.
-            self.buffer_damage.mark_all_full();
+            self.buffer_damage.mark_all_full(reason);
+        } else if let Some(reason) = input_full_damage_reason(input_damage_report.full_reason) {
+            self.buffer_damage.mark_all_full(reason);
         } else {
             self.buffer_damage.add_regions(input_damage);
         }
@@ -89,18 +93,22 @@ impl WaylandState {
         // Pool identity (generation + size) is passed to detect pool recreation/growth.
         // SlotPool reuses the same memory regions for released buffers, so the
         // canvas pointer serves as a stable slot identifier across buffer reuse.
-        let mut logical_damage = self.buffer_damage.take_buffer_damage(
+        let damage_report = self.buffer_damage.take_buffer_damage_report(
             canvas_ptr,
             logical_width,
             logical_height,
             pool_gen,
             pool_size,
         );
+        let mut logical_damage = damage_report.regions;
+        let mut full_damage_reason = damage_report.full_reason;
         if logical_damage.is_empty()
             && let Some(full) = crate::util::Rect::new(0, 0, logical_width, logical_height)
         {
             logical_damage = vec![full];
-            self.buffer_damage.mark_all_full();
+            full_damage_reason = Some(FullDamageReason::EmptyDamageFallback);
+            self.buffer_damage
+                .mark_all_full(FullDamageReason::EmptyDamageFallback);
         }
         let damage_screen = logical_damage;
         let damage_world = if self.canvas_transform_active() {
@@ -306,6 +314,7 @@ impl WaylandState {
             width,
             height,
             scaled_damage.len(),
+            full_damage_reason,
             Instant::now(),
         );
         wl_surface.commit();
@@ -320,4 +329,34 @@ impl WaylandState {
 
         Ok(keep_rendering)
     }
+
+    fn render_force_full_damage_reason(
+        &self,
+        ui_toast_active: bool,
+        preset_feedback_active: bool,
+        blocked_feedback_active: bool,
+        text_edit_entry_active: bool,
+    ) -> Option<FullDamageReason> {
+        if self.zoom.active {
+            Some(FullDamageReason::Zoom)
+        } else if self.canvas_transform_active() {
+            Some(FullDamageReason::BoardPan)
+        } else if ui_toast_active {
+            Some(FullDamageReason::UiToast)
+        } else if preset_feedback_active {
+            Some(FullDamageReason::PresetFeedback)
+        } else if blocked_feedback_active {
+            Some(FullDamageReason::BlockedFeedback)
+        } else if text_edit_entry_active {
+            Some(FullDamageReason::TextEditEntry)
+        } else {
+            None
+        }
+    }
+}
+
+fn input_full_damage_reason(
+    reason: Option<crate::draw::DirtyFullReason>,
+) -> Option<FullDamageReason> {
+    reason.map(|crate::draw::DirtyFullReason::CanvasClear| FullDamageReason::CanvasClear)
 }

--- a/src/draw/dirty.rs
+++ b/src/draw/dirty.rs
@@ -5,11 +5,23 @@
 use super::Shape;
 use crate::util::Rect;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirtyFullReason {
+    CanvasClear,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirtyRegionReport {
+    pub regions: Vec<Rect>,
+    pub full_reason: Option<DirtyFullReason>,
+}
+
 /// Tracks dirty rectangles accumulated between renders.
 #[derive(Debug, Clone)]
 pub struct DirtyTracker {
     regions: Vec<Rect>,
     force_full: bool,
+    force_full_reason: Option<DirtyFullReason>,
 }
 
 impl Default for DirtyTracker {
@@ -24,12 +36,22 @@ impl DirtyTracker {
         Self {
             regions: Vec::with_capacity(8), // Typical frame has 4-8 dirty regions
             force_full: false,
+            force_full_reason: None,
         }
     }
 
     /// Marks the entire surface as dirty. Clears any accumulated rectangles.
     pub fn mark_full(&mut self) {
+        self.mark_full_with_reason(None);
+    }
+
+    pub fn mark_full_for(&mut self, reason: DirtyFullReason) {
+        self.mark_full_with_reason(Some(reason));
+    }
+
+    fn mark_full_with_reason(&mut self, reason: Option<DirtyFullReason>) {
         self.force_full = true;
+        self.force_full_reason = reason;
         self.regions.clear();
     }
 
@@ -62,19 +84,34 @@ impl DirtyTracker {
     /// entire surface; otherwise returns accumulated rectangles.
     #[allow(dead_code)]
     pub fn take_regions(&mut self, width: i32, height: i32) -> Vec<Rect> {
+        self.take_region_report(width, height).regions
+    }
+
+    pub fn take_region_report(&mut self, width: i32, height: i32) -> DirtyRegionReport {
         if self.force_full {
             self.force_full = false;
+            let full_reason = self.force_full_reason.take();
             self.regions.clear();
             if width > 0
                 && height > 0
                 && let Some(full) = Rect::new(0, 0, width, height)
             {
-                return vec![full];
+                return DirtyRegionReport {
+                    regions: vec![full],
+                    full_reason,
+                };
             }
-            Vec::new()
+            DirtyRegionReport {
+                regions: Vec::new(),
+                full_reason,
+            }
         } else {
+            self.force_full_reason = None;
             self.regions.retain(Rect::is_valid);
-            self.regions.drain(..).collect()
+            DirtyRegionReport {
+                regions: self.regions.drain(..).collect(),
+                full_reason: None,
+            }
         }
     }
 }
@@ -166,5 +203,19 @@ mod tests {
         let rects = tracker.take_regions(100, 100);
         assert_eq!(rects.len(), 1);
         assert_eq!(rects[0], Rect::new(1, 2, 3, 4).unwrap());
+    }
+
+    #[test]
+    fn take_region_report_exposes_full_reason_and_drains_it() {
+        let mut tracker = DirtyTracker::new();
+        tracker.mark_full_for(DirtyFullReason::CanvasClear);
+
+        let report = tracker.take_region_report(100, 50);
+        assert_eq!(report.regions, vec![Rect::new(0, 0, 100, 50).unwrap()]);
+        assert_eq!(report.full_reason, Some(DirtyFullReason::CanvasClear));
+
+        let drained = tracker.take_region_report(100, 50);
+        assert!(drained.regions.is_empty());
+        assert_eq!(drained.full_reason, None);
     }
 }

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -18,7 +18,7 @@ pub mod shape;
 #[allow(unused_imports)]
 pub use canvas_set::{BoardPages, PageDeleteOutcome};
 pub use color::Color;
-pub use dirty::DirtyTracker;
+pub use dirty::{DirtyFullReason, DirtyRegionReport, DirtyTracker};
 pub use font::FontDescriptor;
 pub use frame::{DrawnShape, Frame, ShapeId};
 #[allow(unused_imports)]

--- a/src/input/state/core/dirty.rs
+++ b/src/input/state/core/dirty.rs
@@ -7,6 +7,8 @@ use crate::input::tool::{
 };
 use crate::util::Rect;
 
+const APPEND_ONLY_DAMAGE_MAX_SPAN: f64 = 128.0;
+
 impl InputState {
     /// Clears any cached provisional shape bounds and marks their damage region.
     pub(crate) fn clear_provisional_dirty(&mut self) {
@@ -15,10 +17,18 @@ impl InputState {
         }
     }
 
+    /// Takes cached provisional bounds without marking them dirty.
+    pub(crate) fn take_provisional_dirty_bounds(&mut self) -> Option<Rect> {
+        self.last_provisional_bounds.take()
+    }
+
     /// Updates tracked provisional shape bounds for dirty-region purposes.
     pub(crate) fn update_provisional_dirty(&mut self, current_x: i32, current_y: i32) {
-        if let Some(append_bounds) = self.compute_append_only_provisional_bounds() {
-            self.dirty_tracker.mark_rect(append_bounds);
+        if let Some((append_bounds, append_regions)) = self.compute_append_only_provisional_damage()
+        {
+            for region in append_regions {
+                self.dirty_tracker.mark_rect(region);
+            }
             self.last_provisional_bounds =
                 union_optional_rect(self.last_provisional_bounds, append_bounds);
             return;
@@ -80,7 +90,7 @@ impl InputState {
         }
     }
 
-    fn compute_append_only_provisional_bounds(&self) -> Option<Rect> {
+    fn compute_append_only_provisional_damage(&self) -> Option<(Rect, Vec<Rect>)> {
         let DrawingState::Drawing {
             tool,
             points,
@@ -114,7 +124,10 @@ impl InputState {
         };
 
         let start = points.len().saturating_sub(2);
-        bounding_box_for_points(&points[start..], stroke_width)
+        let tail_points = &points[start..];
+        let bounds = bounding_box_for_points(tail_points, stroke_width)?;
+        let regions = append_only_damage_regions(tail_points, stroke_width, bounds);
+        Some((bounds, regions))
     }
 
     /// Updates dirty tracking for the live text preview/caret overlay.
@@ -187,4 +200,48 @@ fn union_rect(a: Rect, b: Rect) -> Option<Rect> {
         a.y.saturating_add(a.height)
             .max(b.y.saturating_add(b.height));
     Rect::from_min_max(min_x, min_y, max_x, max_y)
+}
+
+fn append_only_damage_regions(
+    points: &[(i32, i32)],
+    stroke_width: f64,
+    fallback: Rect,
+) -> Vec<Rect> {
+    let Some((&start, &end)) = points.first().zip(points.last()) else {
+        return vec![fallback];
+    };
+    if start == end {
+        return vec![fallback];
+    }
+
+    let dx = f64::from(end.0 - start.0);
+    let dy = f64::from(end.1 - start.1);
+    let steps = (dx.abs().max(dy.abs()) / APPEND_ONLY_DAMAGE_MAX_SPAN).ceil() as usize;
+    let steps = steps.max(1);
+    if steps == 1 {
+        return vec![fallback];
+    }
+
+    let mut regions = Vec::with_capacity(steps);
+    for step in 0..steps {
+        let t0 = step as f64 / steps as f64;
+        let t1 = (step + 1) as f64 / steps as f64;
+        let p0 = (
+            (start.0 as f64 + dx * t0).round() as i32,
+            (start.1 as f64 + dy * t0).round() as i32,
+        );
+        let p1 = (
+            (start.0 as f64 + dx * t1).round() as i32,
+            (start.1 as f64 + dy * t1).round() as i32,
+        );
+        if let Some(region) = bounding_box_for_points(&[p0, p1], stroke_width) {
+            regions.push(region);
+        }
+    }
+
+    if regions.is_empty() {
+        vec![fallback]
+    } else {
+        regions
+    }
 }

--- a/src/input/state/core/selection_actions/state.rs
+++ b/src/input/state/core/selection_actions/state.rs
@@ -1,4 +1,5 @@
 use super::super::base::InputState;
+use crate::draw::DirtyFullReason;
 use crate::draw::frame::{ShapeSnapshot, UndoAction};
 use crate::util::Rect;
 
@@ -84,7 +85,8 @@ impl InputState {
         }
         self.invalidate_hit_cache();
         self.clear_selection();
-        self.dirty_tracker.mark_full();
+        self.dirty_tracker
+            .mark_full_for(DirtyFullReason::CanvasClear);
         self.needs_redraw = true;
         self.mark_session_dirty();
         true

--- a/src/input/state/core/utility/interaction.rs
+++ b/src/input/state/core/utility/interaction.rs
@@ -1,4 +1,5 @@
 use super::super::base::{DrawingState, InputState, PasteAnchor};
+use crate::draw::DirtyRegionReport;
 use crate::util::Rect;
 
 impl InputState {
@@ -245,9 +246,13 @@ impl InputState {
     /// Drains pending dirty rectangles for the current surface size.
     #[allow(dead_code)]
     pub fn take_dirty_regions(&mut self) -> Vec<Rect> {
+        self.take_dirty_region_report().regions
+    }
+
+    pub(crate) fn take_dirty_region_report(&mut self) -> DirtyRegionReport {
         let width = self.screen_width.min(i32::MAX as u32) as i32;
         let height = self.screen_height.min(i32::MAX as u32) as i32;
-        self.dirty_tracker.take_regions(width, height)
+        self.dirty_tracker.take_region_report(width, height)
     }
 }
 
@@ -383,5 +388,23 @@ mod tests {
             vec![Rect::new(0, 0, 100, 50).unwrap()]
         );
         assert!(state.take_dirty_regions().is_empty());
+    }
+
+    #[test]
+    fn take_dirty_region_report_preserves_full_reason() {
+        let mut state = make_test_input_state();
+        state.update_screen_dimensions(100, 50);
+        state
+            .dirty_tracker
+            .mark_full_for(crate::draw::DirtyFullReason::CanvasClear);
+
+        let report = state.take_dirty_region_report();
+
+        assert_eq!(report.regions, vec![Rect::new(0, 0, 100, 50).unwrap()]);
+        assert_eq!(
+            report.full_reason,
+            Some(crate::draw::DirtyFullReason::CanvasClear)
+        );
+        assert!(state.take_dirty_region_report().regions.is_empty());
     }
 }

--- a/src/input/state/mouse/release/drawing.rs
+++ b/src/input/state/mouse/release/drawing.rs
@@ -1,8 +1,13 @@
 use log::warn;
 
+use crate::draw::Shape;
 use crate::draw::frame::UndoAction;
+use crate::draw::shape::bounding_box_for_points;
 use crate::input::tool::{FinishedToolStroke, PolygonStrokeSnapshot, ToolStrokeSnapshot};
 use crate::input::{InputState, Tool};
+use crate::util::Rect;
+
+const FINISHED_PATH_DAMAGE_MAX_SPAN: f64 = 128.0;
 
 pub(super) struct DrawingRelease {
     pub(super) start: (i32, i32),
@@ -14,6 +19,11 @@ pub(super) struct DrawingRelease {
 pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: DrawingRelease) {
     let drawing_color = state.active_drag_color_or_tool(tool);
     let drawing_thickness = state.thickness_for_tool(tool);
+    let pressure_preview_exceeds_final_width = pressure_preview_exceeds_final_freehand_width(
+        release.points.len(),
+        &release.point_thicknesses,
+        drawing_thickness,
+    );
     let finished = if tool.polygon_template().is_some() {
         let snapshot = PolygonStrokeSnapshot {
             tool,
@@ -65,7 +75,9 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
     };
 
     let bounds = shape.bounding_box();
-    state.clear_provisional_dirty();
+    let path_damage = finished_path_damage_regions(&shape, bounds);
+    let preserve_provisional_cleanup =
+        matches!(shape, Shape::Freehand { .. }) && pressure_preview_exceeds_final_width;
 
     let mut limit_reached = false;
     let addition = {
@@ -98,7 +110,18 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
 
     if let Some((new_id, _snapshot)) = addition {
         state.invalidate_hit_cache_for(new_id);
-        state.dirty_tracker.mark_optional_rect(bounds);
+        if let Some(path_damage) = path_damage {
+            let provisional_bounds = state.take_provisional_dirty_bounds();
+            for region in path_damage {
+                state.dirty_tracker.mark_rect(region);
+            }
+            if preserve_provisional_cleanup {
+                state.dirty_tracker.mark_optional_rect(provisional_bounds);
+            }
+        } else {
+            state.clear_provisional_dirty();
+            state.dirty_tracker.mark_optional_rect(bounds);
+        }
         state.clear_selection();
         state.needs_redraw = true;
         state.mark_session_dirty();
@@ -109,10 +132,105 @@ pub(super) fn finish_drawing(state: &mut InputState, tool: Tool, release: Drawin
         if usage.bump_step_marker {
             state.bump_step_marker();
         }
-    } else if limit_reached {
-        warn!(
-            "Shape limit ({}) reached; discarding new shape",
-            state.max_shapes_per_frame
+    } else {
+        state.clear_provisional_dirty();
+        if limit_reached {
+            warn!(
+                "Shape limit ({}) reached; discarding new shape",
+                state.max_shapes_per_frame
+            );
+        }
+    }
+}
+
+fn pressure_preview_exceeds_final_freehand_width(
+    point_count: usize,
+    point_thicknesses: &[f32],
+    final_width: f64,
+) -> bool {
+    point_thicknesses.len() == point_count
+        && point_thicknesses
+            .iter()
+            .any(|&thickness| f64::from(thickness) > final_width)
+}
+
+fn finished_path_damage_regions(shape: &Shape, fallback: Option<Rect>) -> Option<Vec<Rect>> {
+    match shape {
+        Shape::Freehand { points, thick, .. } => {
+            Some(split_path_damage_regions(points, *thick, fallback?))
+        }
+        Shape::FreehandPressure { points, .. } => {
+            let max_thick = points
+                .iter()
+                .fold(1.0f64, |max, &(_, _, thickness)| max.max(thickness as f64));
+            let points = points.iter().map(|&(x, y, _)| (x, y)).collect::<Vec<_>>();
+            Some(split_path_damage_regions(&points, max_thick, fallback?))
+        }
+        Shape::MarkerStroke { points, thick, .. } => {
+            let inflated = (*thick * 1.35).max(*thick + 1.0);
+            Some(split_path_damage_regions(points, inflated, fallback?))
+        }
+        Shape::EraserStroke { points, brush } => Some(split_path_damage_regions(
+            points,
+            brush.size.max(1.0),
+            fallback?,
+        )),
+        _ => None,
+    }
+}
+
+fn split_path_damage_regions(
+    points: &[(i32, i32)],
+    stroke_width: f64,
+    fallback: Rect,
+) -> Vec<Rect> {
+    if points.len() < 2 {
+        return vec![fallback];
+    }
+
+    let mut regions = Vec::new();
+    for segment in points.windows(2) {
+        append_segment_damage_regions(segment[0], segment[1], stroke_width, &mut regions);
+    }
+
+    if regions.is_empty() {
+        vec![fallback]
+    } else {
+        regions
+    }
+}
+
+fn append_segment_damage_regions(
+    start: (i32, i32),
+    end: (i32, i32),
+    stroke_width: f64,
+    regions: &mut Vec<Rect>,
+) {
+    if start == end {
+        if let Some(region) = bounding_box_for_points(&[start], stroke_width) {
+            regions.push(region);
+        }
+        return;
+    }
+
+    let dx = f64::from(end.0) - f64::from(start.0);
+    let dy = f64::from(end.1) - f64::from(start.1);
+    let steps = (dx.abs().max(dy.abs()) / FINISHED_PATH_DAMAGE_MAX_SPAN).ceil() as usize;
+    let steps = steps.max(1);
+
+    for step in 0..steps {
+        let t0 = step as f64 / steps as f64;
+        let t1 = (step + 1) as f64 / steps as f64;
+        let p0 = (
+            (f64::from(start.0) + dx * t0).round() as i32,
+            (f64::from(start.1) + dy * t0).round() as i32,
         );
+        let p1 = (
+            (f64::from(start.0) + dx * t1).round() as i32,
+            (f64::from(start.1) + dy * t1).round() as i32,
+        );
+        if let Some(region) = bounding_box_for_points(&[p0, p1], stroke_width) {
+            regions.push(region);
+        }
     }
 }

--- a/src/input/state/tests/drawing.rs
+++ b/src/input/state/tests/drawing.rs
@@ -253,6 +253,146 @@ fn append_path_motion_dirties_only_new_tail_segment() {
 }
 
 #[test]
+fn append_path_long_diagonal_motion_splits_tail_damage() {
+    let mut state = create_test_input_state();
+    assert!(state.set_tool_override(Some(Tool::Pen)));
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_press(MouseButton::Left, 10, 10);
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_motion(900, 900);
+    let dirty = state.take_dirty_regions();
+    let thick = state.thickness_for_tool(Tool::Pen);
+    let full_tail_bounds =
+        crate::draw::shape::bounding_box_for_points(&[(10, 10), (900, 900)], thick)
+            .expect("long tail segment should have bounds");
+
+    assert!(
+        dirty.len() > 1,
+        "long diagonal append damage should be split; dirty={dirty:?}"
+    );
+    assert!(
+        dirty.iter().all(
+            |rect| rect.width < full_tail_bounds.width && rect.height < full_tail_bounds.height
+        ),
+        "split damage should avoid the full tail AABB; dirty={dirty:?}, full={full_tail_bounds:?}"
+    );
+    assert_eq!(
+        state.last_provisional_bounds,
+        Some(full_tail_bounds),
+        "cleanup bounds should still cover the whole active stroke"
+    );
+}
+
+#[test]
+fn append_path_long_diagonal_release_splits_finished_path_damage() {
+    let mut state = create_test_input_state();
+    assert!(state.set_tool_override(Some(Tool::Pen)));
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_press(MouseButton::Left, 10, 10);
+    let _ = state.take_dirty_regions();
+    state.on_mouse_motion(900, 900);
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_release(MouseButton::Left, 900, 900);
+    let dirty = state.take_dirty_regions();
+    let thick = state.thickness_for_tool(Tool::Pen);
+    let full_path_bounds =
+        crate::draw::shape::bounding_box_for_points(&[(10, 10), (900, 900)], thick)
+            .expect("long finished path should have bounds");
+
+    assert_eq!(state.boards.active_frame().shapes.len(), 1);
+    assert_eq!(state.last_provisional_bounds, None);
+    assert!(
+        dirty.iter().all(
+            |rect| rect.width < full_path_bounds.width && rect.height < full_path_bounds.height
+        ),
+        "release should not reintroduce the full path AABB; dirty={dirty:?}, full={full_path_bounds:?}"
+    );
+}
+
+#[test]
+fn pressure_preview_release_cleans_wide_preview_when_final_freehand_narrows() {
+    let mut state = create_test_input_state();
+    assert!(state.set_tool_override(Some(Tool::Pen)));
+    assert!(state.set_thickness(2.0));
+    state.update_screen_dimensions(1000, 1000);
+    state.pending_onboarding_usage.first_stroke_done = true;
+    state.pressure_variation_threshold = 1000.0;
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_press(MouseButton::Left, 10, 100);
+    state.set_pressure_thickness_for_active_tool(32.0);
+    state.on_mouse_motion(900, 100);
+    let wide_preview_bounds = state
+        .last_provisional_bounds
+        .expect("wide pressure preview should track cleanup bounds");
+    let wide_only_probe = crate::util::Rect::new(450, wide_preview_bounds.y, 1, 1).unwrap();
+    let final_bounds = crate::draw::shape::bounding_box_for_points(&[(10, 100), (900, 100)], 2.0)
+        .expect("final freehand should have bounds");
+    assert!(
+        !test_rects_intersect(final_bounds, wide_only_probe),
+        "test probe should be outside the final narrow stroke; final={final_bounds:?}, probe={wide_only_probe:?}"
+    );
+    let _ = state.take_dirty_regions();
+
+    state.set_pressure_thickness_for_active_tool(2.0);
+    let _ = state.take_dirty_regions();
+    state.on_mouse_release(MouseButton::Left, 900, 100);
+    let dirty = state.take_dirty_regions();
+
+    match &state.boards.active_frame().shapes[0].shape {
+        Shape::Freehand { thick, .. } => assert_eq!(*thick, 2.0),
+        other => panic!("expected final pressure samples to downgrade to Freehand, got {other:?}"),
+    }
+    assert_eq!(state.last_provisional_bounds, None);
+    assert!(
+        dirty
+            .iter()
+            .any(|rect| test_rects_intersect(*rect, wide_only_probe)),
+        "release should dirty pressure-preview pixels outside the final narrow path; dirty={dirty:?}, preview={wide_preview_bounds:?}, probe={wide_only_probe:?}"
+    );
+}
+
+#[test]
+fn append_path_limit_rejection_clears_provisional_damage() {
+    let mut state = create_test_input_state();
+    assert!(state.set_tool_override(Some(Tool::Pen)));
+    state.boards.active_frame_mut().add_shape(Shape::Line {
+        x1: 1,
+        y1: 1,
+        x2: 2,
+        y2: 2,
+        color: state.current_color,
+        thick: state.current_thickness,
+    });
+    state.max_shapes_per_frame = 1;
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_press(MouseButton::Left, 10, 10);
+    let _ = state.take_dirty_regions();
+    state.on_mouse_motion(900, 900);
+    let provisional_bounds = state
+        .last_provisional_bounds
+        .expect("active path preview should track cleanup bounds");
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_release(MouseButton::Left, 900, 900);
+    let dirty = state.take_dirty_regions();
+
+    assert_eq!(state.boards.active_frame().shapes.len(), 1);
+    assert_eq!(state.last_provisional_bounds, None);
+    assert!(
+        dirty
+            .iter()
+            .any(|rect| test_rects_intersect(*rect, provisional_bounds)),
+        "rejected path should dirty the old preview bounds for cleanup; dirty={dirty:?}, provisional={provisional_bounds:?}"
+    );
+}
+
+#[test]
 fn pressure_sample_shrink_dirties_previous_full_provisional_bounds() {
     let mut state = create_test_input_state();
     assert!(state.set_tool_override(Some(Tool::Pen)));


### PR DESCRIPTION
 ## Summary
- Add frame pacing/input latency summaries and full-damage reason reporting.
- Track buffer damage more precisely, including named full-damage fallback reasons.
- Split append/release path damage into bounded segment regions to avoid large diagonal AABB redraws.
- Preserve provisional cleanup when a pressure preview finalizes as a narrower plain freehand stroke.