### PR TITLE
perf: optimize render pipeline caching and damage

### DIFF
--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -84,6 +84,7 @@ use super::{
 mod activation;
 mod boards;
 mod buffer_damage;
+mod canvas_layer;
 mod capture;
 mod clipboard;
 mod color_picker;
@@ -166,6 +167,8 @@ pub(super) struct WaylandState {
     data: StateData,
     /// Per-buffer damage tracking for correct incremental rendering.
     pub(super) buffer_damage: buffer_damage::BufferDamageTracker,
+    /// Baked committed-shapes layer for panned canvas rendering.
+    pub(super) canvas_layer_cache: canvas_layer::CanvasLayerCache,
 
     // Configuration
     pub(super) config: Config,

--- a/src/backend/wayland/state/buffer_damage.rs
+++ b/src/backend/wayland/state/buffer_damage.rs
@@ -37,10 +37,6 @@ pub(in crate::backend::wayland) enum FullDamageReason {
     Zoom,
     BoardPan,
     CanvasClear,
-    UiToast,
-    PresetFeedback,
-    BlockedFeedback,
-    TextEditEntry,
     EmptyDamageFallback,
     DamageRegionsCoverSurface,
     Unknown,
@@ -62,10 +58,6 @@ impl FullDamageReason {
             Self::Zoom => "zoom",
             Self::BoardPan => "board_pan",
             Self::CanvasClear => "canvas_clear",
-            Self::UiToast => "ui_toast",
-            Self::PresetFeedback => "preset_feedback",
-            Self::BlockedFeedback => "blocked_feedback",
-            Self::TextEditEntry => "text_edit_entry",
             Self::EmptyDamageFallback => "empty_damage_fallback",
             Self::DamageRegionsCoverSurface => "damage_regions_cover_surface",
             Self::Unknown => "unknown",
@@ -498,9 +490,9 @@ mod tests {
         let new_slot = tracker.take_buffer_damage_report(0x2000, 800, 600, TEST_GEN, TEST_SIZE);
         assert_eq!(new_slot.full_reason, Some(FullDamageReason::NewBufferSlot));
 
-        tracker.mark_all_full(FullDamageReason::UiToast);
+        tracker.mark_all_full(FullDamageReason::CanvasClear);
         let explicit = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
-        assert_eq!(explicit.full_reason, Some(FullDamageReason::UiToast));
+        assert_eq!(explicit.full_reason, Some(FullDamageReason::CanvasClear));
     }
 
     #[test]

--- a/src/backend/wayland/state/canvas_layer.rs
+++ b/src/backend/wayland/state/canvas_layer.rs
@@ -1,0 +1,291 @@
+//! Committed-shapes layer cache for transformed (panned) canvas rendering.
+//!
+//! Board pan forces full-surface damage every frame, which previously replayed
+//! every committed shape through Cairo per frame. This cache bakes the board
+//! background plus all committed shapes into a world-space offscreen surface
+//! (view + margin) once, so pan frames become a single aligned blit; the cache
+//! is rebaked only when the view escapes the baked area or content changes.
+//!
+//! Scope: pure pan transforms (no zoom, no frozen backdrop image). Those keep
+//! the existing per-frame render path, where the backdrop transform math makes
+//! world-space baking unsound.
+
+use log::debug;
+
+use crate::draw::{Color, ShapeId};
+use crate::util::Rect;
+
+use super::WaylandState;
+
+/// Extra logical pixels baked around the view so short pans reuse the cache.
+const CANVAS_LAYER_MARGIN: i32 = 256;
+/// Upper bound for the bake surface; beyond this fall back to direct rendering.
+const MAX_CACHE_BYTES: usize = 256 * 1024 * 1024;
+/// Cairo's image surface dimension limit (with headroom).
+const CAIRO_MAX_DIM: i32 = 32000;
+
+pub(in crate::backend::wayland) struct CanvasLayerCache {
+    surface: Option<cairo::ImageSurface>,
+    /// World-space origin and logical size covered by the surface.
+    world_x: i32,
+    world_y: i32,
+    width: i32,
+    height: i32,
+    scale: i32,
+    content_generation: u64,
+    shapes_len: usize,
+    last_shape_id: Option<ShapeId>,
+    background: Option<Color>,
+    board_key: (usize, usize),
+    valid: bool,
+}
+
+impl CanvasLayerCache {
+    pub(in crate::backend::wayland) fn new() -> Self {
+        Self {
+            surface: None,
+            world_x: 0,
+            world_y: 0,
+            width: 0,
+            height: 0,
+            scale: 1,
+            content_generation: 0,
+            shapes_len: 0,
+            last_shape_id: None,
+            background: None,
+            board_key: (0, 0),
+            valid: false,
+        }
+    }
+
+    /// Invalidates the cache and releases the bake surface.
+    pub(in crate::backend::wayland) fn clear(&mut self) {
+        self.valid = false;
+        self.surface = None;
+    }
+
+    /// Paints the cached layer into a context already transformed to world
+    /// coordinates at the given device scale. Returns false when no valid
+    /// cache is available.
+    pub(in crate::backend::wayland) fn blit(&self, ctx: &cairo::Context) -> bool {
+        if !self.valid {
+            return false;
+        }
+        let Some(surface) = self.surface.as_ref() else {
+            return false;
+        };
+        let _ = ctx.save();
+        ctx.translate(self.world_x as f64, self.world_y as f64);
+        let inv = 1.0 / self.scale.max(1) as f64;
+        ctx.scale(inv, inv);
+        let ok = ctx.set_source_surface(surface, 0.0, 0.0).is_ok();
+        if ok {
+            let _ = ctx.paint();
+        }
+        let _ = ctx.restore();
+        ok
+    }
+}
+
+/// Renders one committed shape with the standard eraser/blur replay handling.
+/// Shared between the direct canvas render path and the layer-cache bake.
+pub(in crate::backend::wayland) fn render_committed_shape(
+    ctx: &cairo::Context,
+    drawn_shape: &crate::draw::DrawnShape,
+    replay_ctx: &crate::draw::EraserReplayContext<'_>,
+) {
+    match &drawn_shape.shape {
+        crate::draw::Shape::EraserStroke { points, brush } => {
+            crate::draw::render_eraser_stroke(ctx, points, brush, replay_ctx);
+        }
+        crate::draw::Shape::BlurRect {
+            x,
+            y,
+            w,
+            h,
+            strength,
+        } => {
+            crate::draw::render_blur_rect(
+                ctx,
+                crate::draw::BlurRectParams {
+                    x: *x,
+                    y: *y,
+                    w: *w,
+                    h: *h,
+                    strength: *strength,
+                    cacheable: true,
+                },
+                replay_ctx,
+            );
+        }
+        other => {
+            crate::draw::render_shape(ctx, other);
+        }
+    }
+}
+
+fn rects_intersect(a: Rect, b: Rect) -> bool {
+    let a_right = a.x.saturating_add(a.width);
+    let a_bottom = a.y.saturating_add(a.height);
+    let b_right = b.x.saturating_add(b.width);
+    let b_bottom = b.y.saturating_add(b.height);
+    !(a.x >= b_right || a_right <= b.x || a.y >= b_bottom || a_bottom <= b.y)
+}
+
+impl WaylandState {
+    /// True when committed canvas content may be served from the layer cache:
+    /// a board pan transform without zoom or a frozen backdrop image (whose
+    /// screen-anchored transforms make world-space baking unsound).
+    pub(in crate::backend::wayland) fn canvas_layer_cache_usable(&self) -> bool {
+        self.canvas_transform_active() && !self.zoom.active && self.frozen.image().is_none()
+    }
+
+    /// Ensures the layer cache covers the current view with current content,
+    /// rebaking when needed. Returns false when caching is unavailable and the
+    /// caller must render shapes directly.
+    pub(in crate::backend::wayland) fn ensure_canvas_layer_cache(
+        &mut self,
+        width: u32,
+        height: u32,
+        scale: i32,
+    ) -> bool {
+        let scale = scale.max(1);
+        let (origin_x, origin_y) = self.canvas_view_origin();
+        let view_x = origin_x.floor() as i32;
+        let view_y = origin_y.floor() as i32;
+        let logical_w = width.min(i32::MAX as u32) as i32;
+        let logical_h = height.min(i32::MAX as u32) as i32;
+        if logical_w <= 0 || logical_h <= 0 {
+            return false;
+        }
+
+        let background = match self.input_state.boards.active_background() {
+            crate::input::BoardBackground::Solid(color) => Some(*color),
+            crate::input::BoardBackground::Transparent => None,
+        };
+        let board_key = (
+            self.input_state.boards.active_index(),
+            self.input_state.boards.active_page_index(),
+        );
+        let generation = self.input_state.canvas_content_generation();
+        let frame = self.input_state.boards.active_frame();
+        let shapes_len = frame.shapes.len();
+        let last_shape_id = frame.shapes.last().map(|shape| shape.id);
+
+        let cache = &self.canvas_layer_cache;
+        let params_match = cache.valid
+            && cache.surface.is_some()
+            && cache.scale == scale
+            && cache.content_generation == generation
+            && cache.shapes_len == shapes_len
+            && cache.last_shape_id == last_shape_id
+            && cache.background == background
+            && cache.board_key == board_key;
+        let covers_view = view_x >= cache.world_x
+            && view_y >= cache.world_y
+            && view_x.saturating_add(logical_w) <= cache.world_x.saturating_add(cache.width)
+            && view_y.saturating_add(logical_h) <= cache.world_y.saturating_add(cache.height);
+        if params_match && covers_view {
+            return true;
+        }
+
+        // (Re)bake centered on the current view.
+        let world_x = view_x.saturating_sub(CANVAS_LAYER_MARGIN);
+        let world_y = view_y.saturating_sub(CANVAS_LAYER_MARGIN);
+        let bake_w = logical_w.saturating_add(CANVAS_LAYER_MARGIN * 2);
+        let bake_h = logical_h.saturating_add(CANVAS_LAYER_MARGIN * 2);
+        let phys_w = bake_w.saturating_mul(scale);
+        let phys_h = bake_h.saturating_mul(scale);
+        if phys_w <= 0 || phys_h <= 0 || phys_w > CAIRO_MAX_DIM || phys_h > CAIRO_MAX_DIM {
+            self.canvas_layer_cache.clear();
+            return false;
+        }
+        if phys_w as usize * phys_h as usize * 4 > MAX_CACHE_BYTES {
+            self.canvas_layer_cache.clear();
+            return false;
+        }
+
+        let reuse_surface = self
+            .canvas_layer_cache
+            .surface
+            .as_ref()
+            .is_some_and(|surface| surface.width() == phys_w && surface.height() == phys_h);
+        if !reuse_surface {
+            match cairo::ImageSurface::create(cairo::Format::ARgb32, phys_w, phys_h) {
+                Ok(surface) => self.canvas_layer_cache.surface = Some(surface),
+                Err(err) => {
+                    debug!("canvas layer cache: surface allocation failed: {err}");
+                    self.canvas_layer_cache.clear();
+                    return false;
+                }
+            }
+        }
+
+        {
+            let Some(surface) = self.canvas_layer_cache.surface.as_ref() else {
+                return false;
+            };
+            let Ok(bake_ctx) = cairo::Context::new(surface) else {
+                self.canvas_layer_cache.clear();
+                return false;
+            };
+
+            bake_ctx.set_operator(cairo::Operator::Clear);
+            let _ = bake_ctx.paint();
+            bake_ctx.set_operator(cairo::Operator::Over);
+            if let Some(color) = background {
+                bake_ctx.set_source_rgba(color.r, color.g, color.b, color.a);
+                let _ = bake_ctx.paint();
+            }
+            bake_ctx.scale(scale as f64, scale as f64);
+            bake_ctx.translate(-(world_x as f64), -(world_y as f64));
+
+            // Erasers clear down to the baked solid background; blur rects have
+            // no backdrop image in this mode (same as the direct render path).
+            let replay_ctx = crate::draw::EraserReplayContext {
+                pattern: None,
+                surface: None,
+                backdrop_cache_key: None,
+                bg_color: background,
+                logical_to_image_scale_x: 1.0,
+                logical_to_image_scale_y: 1.0,
+            };
+
+            let bake_bounds = Rect {
+                x: world_x,
+                y: world_y,
+                width: bake_w,
+                height: bake_h,
+            };
+            let frame = self.input_state.boards.active_frame();
+            for drawn_shape in &frame.shapes {
+                if let Some(bbox) = drawn_shape.bounding_box()
+                    && rects_intersect(bbox, bake_bounds)
+                {
+                    render_committed_shape(&bake_ctx, drawn_shape, &replay_ctx);
+                }
+            }
+        }
+        if let Some(surface) = self.canvas_layer_cache.surface.as_ref() {
+            surface.flush();
+        }
+
+        let cache = &mut self.canvas_layer_cache;
+        cache.world_x = world_x;
+        cache.world_y = world_y;
+        cache.width = bake_w;
+        cache.height = bake_h;
+        cache.scale = scale;
+        cache.content_generation = generation;
+        cache.shapes_len = shapes_len;
+        cache.last_shape_id = last_shape_id;
+        cache.background = background;
+        cache.board_key = board_key;
+        cache.valid = true;
+        debug!(
+            "canvas layer cache: baked {}x{} logical at ({}, {})",
+            bake_w, bake_h, world_x, world_y
+        );
+        true
+    }
+}

--- a/src/backend/wayland/state/core/init.rs
+++ b/src/backend/wayland/state/core/init.rs
@@ -101,6 +101,7 @@ impl WaylandState {
             toolbar: ToolbarSurfaceManager::new(),
             data,
             buffer_damage: BufferDamageTracker::new(buffer_count),
+            canvas_layer_cache: super::super::canvas_layer::CanvasLayerCache::new(),
             config,
             input_state,
             clipboard_publish_rx: None,

--- a/src/backend/wayland/state/data.rs
+++ b/src/backend/wayland/state/data.rs
@@ -135,6 +135,12 @@ pub struct StateData {
     pub(super) xdg_explicit_close_requested: bool,
     /// Reused pre-UI pixel snapshot for render-profile UI-only remapping.
     pub(super) render_profile_ui_baseline: Vec<u8>,
+    /// Previous-frame damage bounds for transient UI effects, so partial
+    /// redraws cover both the old and new footprint of each effect.
+    pub(super) prev_ui_toast_damage: Option<crate::util::Rect>,
+    pub(super) prev_preset_toast_damage: Option<crate::util::Rect>,
+    pub(super) blocked_feedback_was_active: bool,
+    pub(super) prev_text_edit_entry_damage: Option<crate::util::Rect>,
 }
 
 impl StateData {
@@ -203,6 +209,10 @@ impl StateData {
             xdg_close_guard_until: None,
             xdg_explicit_close_requested: false,
             render_profile_ui_baseline: Vec::new(),
+            prev_ui_toast_damage: None,
+            prev_preset_toast_damage: None,
+            blocked_feedback_was_active: false,
+            prev_text_edit_entry_damage: None,
         }
     }
 }

--- a/src/backend/wayland/state/pdf_export.rs
+++ b/src/backend/wayland/state/pdf_export.rs
@@ -241,7 +241,7 @@ fn frame_content_bounds(frame: &Frame) -> Option<CanvasExportRect> {
     let mut found = false;
 
     for drawn in &frame.shapes {
-        let Some(bounds) = drawn.shape.bounding_box() else {
+        let Some(bounds) = drawn.bounding_box() else {
             continue;
         };
         min_x = min_x.min(bounds.x);

--- a/src/backend/wayland/state/perf.rs
+++ b/src/backend/wayland/state/perf.rs
@@ -1115,7 +1115,7 @@ mod tests {
                 dirty_area_pct: 42.0,
                 full_damage: true,
                 damage_rects: 2,
-                force_full_reason: Some(FullDamageReason::UiToast),
+                force_full_reason: Some(FullDamageReason::CanvasClear),
             },
             base,
         );
@@ -1131,7 +1131,7 @@ mod tests {
         assert_eq!(slow.max_fps_no_vsync, 120);
         assert_eq!(slow.dirty_area_pct, 42.0);
         assert!(slow.full_damage);
-        assert_eq!(slow.force_full_reason, Some(FullDamageReason::UiToast));
+        assert_eq!(slow.force_full_reason, Some(FullDamageReason::CanvasClear));
         assert_eq!(slow.damage_rects, 2);
     }
 
@@ -1155,7 +1155,7 @@ mod tests {
                         dirty_area_pct: 100.0,
                         full_damage: true,
                         damage_rects: 1,
-                        force_full_reason: Some(FullDamageReason::UiToast),
+                        force_full_reason: Some(FullDamageReason::CanvasClear),
                     },
                     started_at,
                 );
@@ -1180,8 +1180,8 @@ mod tests {
                 assert_eq!(summary.render_over_50ms, 70);
                 assert_eq!(summary.full_damage_count, 3);
                 assert_eq!(summary.full_damage_pct, "2.50");
-                assert_eq!(summary.force_full_reason, "ui_toast");
-                assert_eq!(summary.force_full_reasons, "ui_toast:3");
+                assert_eq!(summary.force_full_reason, "canvas_clear");
+                assert_eq!(summary.force_full_reasons, "canvas_clear:3");
             }
         }
     }

--- a/src/backend/wayland/state/render/canvas/mod.rs
+++ b/src/backend/wayland/state/render/canvas/mod.rs
@@ -19,6 +19,17 @@ impl WaylandState {
     ) -> Result<()> {
         let canvas_transform_active = self.canvas_transform_active();
         let (canvas_origin_x, canvas_origin_y) = self.canvas_view_origin();
+
+        // For pure pan transforms, serve the board background and committed
+        // shapes from the baked layer cache: pan frames force full damage, so
+        // this turns an O(shapes) Cairo replay into a single aligned blit.
+        let layer_cache_ready = if self.canvas_layer_cache_usable() {
+            self.ensure_canvas_layer_cache(width, height, scale)
+        } else {
+            self.canvas_layer_cache.clear();
+            false
+        };
+
         let eraser_ctx = self.render_canvas_background(ctx, scale, phys_width, phys_height)?;
 
         // Scale subsequent drawing to logical coordinates
@@ -35,124 +46,108 @@ impl WaylandState {
             ctx.translate(-canvas_origin_x, -canvas_origin_y);
         }
 
-        // Render all completed shapes from active frame
-        debug!(
-            "Rendering {} completed shapes",
-            self.input_state.boards.active_frame().shapes.len()
-        );
-        let shapes = &self.input_state.boards.active_frame().shapes;
         let replay_ctx = eraser_ctx.replay_context();
 
-        // Manual Culling: Only render shapes that intersect with the damage regions.
-        // Cairo's internal clipping is efficient for rasterization, but sending
-        // thousands of shapes to Cairo still incurs overhead for geometry processing.
-        // A simple bounding box check here eliminates that overhead.
-        let render_drawn_shape = |drawn_shape: &crate::draw::DrawnShape| match &drawn_shape.shape {
-            crate::draw::Shape::EraserStroke { points, brush } => {
-                crate::draw::render_eraser_stroke(ctx, points, brush, &replay_ctx);
-            }
-            crate::draw::Shape::BlurRect {
-                x,
-                y,
-                w,
-                h,
-                strength,
-            } => {
-                crate::draw::render_blur_rect(
-                    ctx,
-                    crate::draw::BlurRectParams {
-                        x: *x,
-                        y: *y,
-                        w: *w,
-                        h: *h,
-                        strength: *strength,
-                        cacheable: true,
-                    },
-                    &replay_ctx,
-                );
-            }
-            other => {
-                crate::draw::render_shape(ctx, other);
-            }
-        };
+        if layer_cache_ready && self.canvas_layer_cache.blit(ctx) {
+            // Board background and committed shapes came from the baked layer.
+            debug!("Rendered committed shapes from layer cache");
+        } else {
+            // Render all completed shapes from active frame
+            debug!(
+                "Rendering {} completed shapes",
+                self.input_state.boards.active_frame().shapes.len()
+            );
+            let shapes = &self.input_state.boards.active_frame().shapes;
 
-        // Compute bounding box of all damage regions for fast rejection
-        // (Union of all dirty rects). These bounds are in world coordinates.
-        let damage_bounds = damage_world
-            .iter()
-            .fold(None, |acc: Option<crate::util::Rect>, r| match acc {
-                None => Some(*r),
-                Some(u) => {
-                    // Manual union to avoid extra allocations.
-                    let min_x = u.x.min(r.x);
-                    let min_y = u.y.min(r.y);
-                    let max_x = u.x.saturating_add(u.width).max(r.x.saturating_add(r.width));
-                    let max_y =
-                        u.y.saturating_add(u.height)
-                            .max(r.y.saturating_add(r.height));
-                    Some(crate::util::Rect {
-                        x: min_x,
-                        y: min_y,
-                        width: max_x - min_x,
-                        height: max_y - min_y,
-                    })
-                }
-            });
-
-        if let Some(bounds) = damage_bounds {
-            // Expand bounds slightly to account for line width/glow that might extend outside
-            // the logical shape bounds (though Shape::bounding_box should theoretically cover it,
-            // safety margin is good).
-            let margin = 2;
-            let safe_x = bounds.x.saturating_sub(margin);
-            let safe_y = bounds.y.saturating_sub(margin);
-            let safe_width = bounds.width.saturating_add(margin * 2);
-            let safe_height = bounds.height.saturating_add(margin * 2);
-            let safe_bounds = if canvas_transform_active {
-                crate::util::Rect::new(safe_x, safe_y, safe_width, safe_height)
-            } else {
-                // Clamp to logical surface bounds to avoid negative coords or overflow.
-                let logical_width = width as i32;
-                let logical_height = height as i32;
-                let clamped_x = safe_x.max(0);
-                let clamped_y = safe_y.max(0);
-                let max_width = logical_width.saturating_sub(clamped_x);
-                let max_height = logical_height.saturating_sub(clamped_y);
-                crate::util::Rect::new(
-                    clamped_x,
-                    clamped_y,
-                    safe_width.min(max_width),
-                    safe_height.min(max_height),
-                )
+            // Manual Culling: Only render shapes that intersect with the damage regions.
+            // Cairo's internal clipping is efficient for rasterization, but sending
+            // thousands of shapes to Cairo still incurs overhead for geometry processing.
+            // A simple bounding box check here eliminates that overhead.
+            let render_drawn_shape = |drawn_shape: &crate::draw::DrawnShape| {
+                super::super::canvas_layer::render_committed_shape(ctx, drawn_shape, &replay_ctx)
             };
 
-            if let Some(safe_bounds) = safe_bounds {
-                for drawn_shape in shapes {
-                    // If shape has no bounding box (e.g. empty freehand), skip it.
-                    // If it has one, check intersection.
-                    if let Some(bbox) = drawn_shape.shape.bounding_box() {
-                        // Check intersection:
-                        // !(bbox.left > safe.right || bbox.right < safe.left || ...)
-                        let bbox_right = bbox.x.saturating_add(bbox.width);
-                        let bbox_bottom = bbox.y.saturating_add(bbox.height);
-                        let safe_right = safe_bounds.x.saturating_add(safe_bounds.width);
-                        let safe_bottom = safe_bounds.y.saturating_add(safe_bounds.height);
+            // Compute bounding box of all damage regions for fast rejection
+            // (Union of all dirty rects). These bounds are in world coordinates.
+            let damage_bounds =
+                damage_world
+                    .iter()
+                    .fold(None, |acc: Option<crate::util::Rect>, r| match acc {
+                        None => Some(*r),
+                        Some(u) => {
+                            // Manual union to avoid extra allocations.
+                            let min_x = u.x.min(r.x);
+                            let min_y = u.y.min(r.y);
+                            let max_x =
+                                u.x.saturating_add(u.width).max(r.x.saturating_add(r.width));
+                            let max_y =
+                                u.y.saturating_add(u.height)
+                                    .max(r.y.saturating_add(r.height));
+                            Some(crate::util::Rect {
+                                x: min_x,
+                                y: min_y,
+                                width: max_x - min_x,
+                                height: max_y - min_y,
+                            })
+                        }
+                    });
 
-                        let intersects = !(bbox.x >= safe_right
-                            || bbox_right <= safe_bounds.x
-                            || bbox.y >= safe_bottom
-                            || bbox_bottom <= safe_bounds.y);
+            if let Some(bounds) = damage_bounds {
+                // Expand bounds slightly to account for line width/glow that might extend outside
+                // the logical shape bounds (though Shape::bounding_box should theoretically cover it,
+                // safety margin is good).
+                let margin = 2;
+                let safe_x = bounds.x.saturating_sub(margin);
+                let safe_y = bounds.y.saturating_sub(margin);
+                let safe_width = bounds.width.saturating_add(margin * 2);
+                let safe_height = bounds.height.saturating_add(margin * 2);
+                let safe_bounds = if canvas_transform_active {
+                    crate::util::Rect::new(safe_x, safe_y, safe_width, safe_height)
+                } else {
+                    // Clamp to logical surface bounds to avoid negative coords or overflow.
+                    let logical_width = width as i32;
+                    let logical_height = height as i32;
+                    let clamped_x = safe_x.max(0);
+                    let clamped_y = safe_y.max(0);
+                    let max_width = logical_width.saturating_sub(clamped_x);
+                    let max_height = logical_height.saturating_sub(clamped_y);
+                    crate::util::Rect::new(
+                        clamped_x,
+                        clamped_y,
+                        safe_width.min(max_width),
+                        safe_height.min(max_height),
+                    )
+                };
 
-                        if intersects {
-                            render_drawn_shape(drawn_shape);
+                if let Some(safe_bounds) = safe_bounds {
+                    for drawn_shape in shapes {
+                        // If shape has no bounding box (e.g. empty freehand), skip it.
+                        // If it has one, check intersection. Uses the per-shape
+                        // memoized bounds to avoid O(points) recomputation per frame.
+                        if let Some(bbox) = drawn_shape.bounding_box() {
+                            // Check intersection:
+                            // !(bbox.left > safe.right || bbox.right < safe.left || ...)
+                            let bbox_right = bbox.x.saturating_add(bbox.width);
+                            let bbox_bottom = bbox.y.saturating_add(bbox.height);
+                            let safe_right = safe_bounds.x.saturating_add(safe_bounds.width);
+                            let safe_bottom = safe_bounds.y.saturating_add(safe_bounds.height);
+
+                            let intersects = !(bbox.x >= safe_right
+                                || bbox_right <= safe_bounds.x
+                                || bbox.y >= safe_bottom
+                                || bbox_bottom <= safe_bounds.y);
+
+                            if intersects {
+                                render_drawn_shape(drawn_shape);
+                            }
                         }
                     }
                 }
-            }
-        } else {
-            // If we don't have damage bounds, render everything to stay correct.
-            for drawn_shape in shapes {
-                render_drawn_shape(drawn_shape);
+            } else {
+                // If we don't have damage bounds, render everything to stay correct.
+                for drawn_shape in shapes {
+                    render_drawn_shape(drawn_shape);
+                }
             }
         }
 

--- a/src/backend/wayland/state/render/mod.rs
+++ b/src/backend/wayland/state/render/mod.rs
@@ -3,6 +3,7 @@ use super::*;
 mod canvas;
 mod tool_preview;
 mod ui;
+mod ui_effect_damage;
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn render(&mut self, qh: &QueueHandle<Self>) -> Result<bool> {
@@ -43,20 +44,28 @@ impl WaylandState {
         let input_damage = input_damage_report.regions;
         let logical_width = width.min(i32::MAX as u32) as i32;
         let logical_height = height.min(i32::MAX as u32) as i32;
-        let force_full_damage_reason = self.render_force_full_damage_reason(
+        let force_full_damage_reason = self.render_force_full_damage_reason();
+        // Transient UI effects (toasts, feedback flashes) emit targeted damage
+        // instead of forcing full-surface redraws. Collect on every frame so the
+        // previous-bounds tracking stays in sync even when full damage is forced
+        // for other reasons.
+        let ui_effect_damage = self.collect_ui_effect_damage(
             ui_toast_active,
             preset_feedback_active,
             blocked_feedback_active,
             text_edit_entry_active,
+            width,
+            height,
         );
         if let Some(reason) = force_full_damage_reason {
-            // Zoom uses a world transform and some UI effects don't emit damage; full damage avoids
-            // mismatched coordinate spaces and empty damage frames.
+            // Zoom and board pan use a world transform; full damage avoids
+            // mismatched coordinate spaces.
             self.buffer_damage.mark_all_full(reason);
         } else if let Some(reason) = input_full_damage_reason(input_damage_report.full_reason) {
             self.buffer_damage.mark_all_full(reason);
         } else {
             self.buffer_damage.add_regions(input_damage);
+            self.buffer_damage.add_regions(ui_effect_damage);
         }
 
         // Get a buffer from the pool for rendering
@@ -330,25 +339,11 @@ impl WaylandState {
         Ok(keep_rendering)
     }
 
-    fn render_force_full_damage_reason(
-        &self,
-        ui_toast_active: bool,
-        preset_feedback_active: bool,
-        blocked_feedback_active: bool,
-        text_edit_entry_active: bool,
-    ) -> Option<FullDamageReason> {
+    fn render_force_full_damage_reason(&self) -> Option<FullDamageReason> {
         if self.zoom.active {
             Some(FullDamageReason::Zoom)
         } else if self.canvas_transform_active() {
             Some(FullDamageReason::BoardPan)
-        } else if ui_toast_active {
-            Some(FullDamageReason::UiToast)
-        } else if preset_feedback_active {
-            Some(FullDamageReason::PresetFeedback)
-        } else if blocked_feedback_active {
-            Some(FullDamageReason::BlockedFeedback)
-        } else if text_edit_entry_active {
-            Some(FullDamageReason::TextEditEntry)
         } else {
             None
         }

--- a/src/backend/wayland/state/render/ui_effect_damage.rs
+++ b/src/backend/wayland/state/render/ui_effect_damage.rs
@@ -1,0 +1,165 @@
+//! Targeted damage regions for transient UI effects.
+//!
+//! Toasts and feedback flashes used to force full-surface damage for every
+//! animation tick because they emit no damage of their own. Instead, compute
+//! each effect's on-screen footprint before rendering and damage only that,
+//! unioned with the footprint from the previous frame so moves, content
+//! changes, and disappearance are cleaned up correctly.
+
+use super::super::*;
+use crate::util::Rect;
+
+/// Safety margin around effect bounds for anti-aliasing bleed.
+const UI_EFFECT_DAMAGE_MARGIN: i32 = 2;
+/// Maximum radius of the text-edit entry glow pulse
+/// (see `render_text_edit_entry_animation`: 30.0 + progress * 20.0).
+const TEXT_EDIT_ENTRY_MAX_RADIUS: i32 = 50;
+
+fn effect_rect(bounds: (f64, f64, f64, f64), width: u32, height: u32) -> Option<Rect> {
+    let (x, y, w, h) = bounds;
+    let min_x = (x.floor() as i32 - UI_EFFECT_DAMAGE_MARGIN).max(0);
+    let min_y = (y.floor() as i32 - UI_EFFECT_DAMAGE_MARGIN).max(0);
+    let max_x =
+        ((x + w).ceil() as i32 + UI_EFFECT_DAMAGE_MARGIN).min(width.min(i32::MAX as u32) as i32);
+    let max_y =
+        ((y + h).ceil() as i32 + UI_EFFECT_DAMAGE_MARGIN).min(height.min(i32::MAX as u32) as i32);
+    Rect::from_min_max(min_x, min_y, max_x, max_y)
+}
+
+/// Push damage covering an effect's previous and current footprint.
+fn push_effect_damage(regions: &mut Vec<Rect>, prev: Option<Rect>, current: Option<Rect>) {
+    match (prev, current) {
+        (Some(prev), Some(current)) if prev == current => regions.push(current),
+        (prev, current) => {
+            if let Some(prev) = prev {
+                regions.push(prev);
+            }
+            if let Some(current) = current {
+                regions.push(current);
+            }
+        }
+    }
+}
+
+impl WaylandState {
+    /// Damage regions for transient UI effects (toasts, blocked-action flash,
+    /// text-edit entry glow) for the current frame. Also updates the
+    /// previous-frame tracking state, so this must be called exactly once per
+    /// rendered frame, even on frames that force full damage for other reasons.
+    pub(super) fn collect_ui_effect_damage(
+        &mut self,
+        ui_toast_active: bool,
+        preset_feedback_active: bool,
+        blocked_feedback_active: bool,
+        text_edit_entry_active: bool,
+        width: u32,
+        height: u32,
+    ) -> Vec<Rect> {
+        let mut regions = Vec::new();
+
+        let toast_rect = if ui_toast_active {
+            crate::ui::ui_toast_geometry(&self.input_state, width, height)
+                .and_then(|bounds| effect_rect(bounds, width, height))
+        } else {
+            None
+        };
+        push_effect_damage(&mut regions, self.data.prev_ui_toast_damage, toast_rect);
+        self.data.prev_ui_toast_damage = toast_rect;
+
+        let preset_rect = if preset_feedback_active {
+            crate::ui::preset_toast_geometry(&self.input_state, width, height)
+                .and_then(|bounds| effect_rect(bounds, width, height))
+        } else {
+            None
+        };
+        push_effect_damage(
+            &mut regions,
+            self.data.prev_preset_toast_damage,
+            preset_rect,
+        );
+        self.data.prev_preset_toast_damage = preset_rect;
+
+        if blocked_feedback_active || self.data.blocked_feedback_was_active {
+            regions.extend(
+                crate::ui::blocked_feedback_rects(width, height)
+                    .into_iter()
+                    .filter_map(|bounds| effect_rect(bounds, width, height)),
+            );
+        }
+        self.data.blocked_feedback_was_active = blocked_feedback_active;
+
+        let entry_rect = if text_edit_entry_active {
+            self.text_edit_entry_screen_rect(width, height)
+        } else {
+            None
+        };
+        push_effect_damage(
+            &mut regions,
+            self.data.prev_text_edit_entry_damage,
+            entry_rect,
+        );
+        self.data.prev_text_edit_entry_damage = entry_rect;
+
+        regions
+    }
+
+    /// Screen-space rect covering the text-edit entry glow at its maximum extent.
+    fn text_edit_entry_screen_rect(&self, width: u32, height: u32) -> Option<Rect> {
+        let DrawingState::TextInput { x, y, .. } = &self.input_state.state else {
+            return None;
+        };
+        // The glow renders in world coordinates inside the canvas transform;
+        // translate to screen space (zoom forces full damage, so only the
+        // pan offset matters here).
+        let (origin_x, origin_y) = self.canvas_view_origin();
+        let screen_x = *x as f64 - origin_x;
+        let screen_y = *y as f64 - origin_y;
+        let radius = TEXT_EDIT_ENTRY_MAX_RADIUS as f64;
+        effect_rect(
+            (
+                screen_x - radius,
+                screen_y - radius,
+                radius * 2.0,
+                radius * 2.0,
+            ),
+            width,
+            height,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effect_rect_expands_by_margin_and_clamps_to_screen() {
+        let rect = effect_rect((10.0, 20.0, 30.0, 40.0), 1920, 1080).expect("valid rect");
+        assert_eq!(rect, Rect::new(8, 18, 34, 44).unwrap());
+
+        let clamped = effect_rect((-5.0, -5.0, 20.0, 20.0), 100, 100).expect("clamped rect");
+        assert_eq!(clamped.x, 0);
+        assert_eq!(clamped.y, 0);
+    }
+
+    #[test]
+    fn push_effect_damage_dedupes_identical_bounds() {
+        let rect = Rect::new(5, 5, 10, 10).unwrap();
+        let mut regions = Vec::new();
+        push_effect_damage(&mut regions, Some(rect), Some(rect));
+        assert_eq!(regions, vec![rect]);
+    }
+
+    #[test]
+    fn push_effect_damage_covers_old_and_new_bounds() {
+        let prev = Rect::new(0, 0, 10, 10).unwrap();
+        let current = Rect::new(50, 50, 10, 10).unwrap();
+        let mut regions = Vec::new();
+        push_effect_damage(&mut regions, Some(prev), Some(current));
+        assert_eq!(regions, vec![prev, current]);
+
+        let mut cleanup = Vec::new();
+        push_effect_damage(&mut cleanup, Some(prev), None);
+        assert_eq!(cleanup, vec![prev]);
+    }
+}

--- a/src/draw/frame/history/frame/apply.rs
+++ b/src/draw/frame/history/frame/apply.rs
@@ -18,7 +18,7 @@ impl Frame {
                 shape_id, after, ..
             } => {
                 if let Some(target) = self.shape_mut(*shape_id) {
-                    target.shape = after.shape.clone();
+                    target.set_shape(after.shape.clone());
                     target.locked = after.locked;
                 }
             }
@@ -59,7 +59,7 @@ impl Frame {
                 shape_id, before, ..
             } => {
                 if let Some(target) = self.shape_mut(*shape_id) {
-                    target.shape = before.shape.clone();
+                    target.set_shape(before.shape.clone());
                     target.locked = before.locked;
                 }
             }
@@ -106,6 +106,7 @@ impl Frame {
             *w = bounds.w;
             *h = bounds.h;
             target.locked = bounds.locked;
+            target.invalidate_bounds();
         }
     }
 }

--- a/src/draw/frame/tests/history/basics.rs
+++ b/src/draw/frame/tests/history/basics.rs
@@ -93,6 +93,7 @@ fn modify_image_bounds_undo_redo_changes_geometry_without_replacing_payload() {
         *w = 40;
         *h = 32;
     }
+    frame.shape_mut(id).unwrap().invalidate_bounds();
     frame.push_undo_action(
         UndoAction::ModifyImageBounds {
             shape_id: id,

--- a/src/draw/frame/tests/history/limits.rs
+++ b/src/draw/frame/tests/history/limits.rs
@@ -46,12 +46,12 @@ fn clamp_history_depth_clears_both_stacks() {
             UndoAction::Create {
                 shapes: vec![(
                     index,
-                    DrawnShape {
+                    DrawnShape::with_metadata(
                         id,
-                        shape: snapshot.shape,
-                        created_at: snapshot.created_at,
-                        locked: snapshot.locked,
-                    },
+                        snapshot.shape,
+                        snapshot.created_at,
+                        snapshot.locked,
+                    ),
                 )],
             },
             10,

--- a/src/draw/frame/tests/history/prune.rs
+++ b/src/draw/frame/tests/history/prune.rs
@@ -15,18 +15,8 @@ fn prune_history_for_removed_ids_prunes_shapes_and_actions() {
         thick: 1.0,
     };
 
-    let shape1 = DrawnShape {
-        id: 1,
-        shape: base_shape.clone(),
-        created_at: 0,
-        locked: false,
-    };
-    let shape2 = DrawnShape {
-        id: 2,
-        shape: base_shape.clone(),
-        created_at: 0,
-        locked: false,
-    };
+    let shape1 = DrawnShape::with_metadata(1, base_shape.clone(), 0, false);
+    let shape2 = DrawnShape::with_metadata(2, base_shape.clone(), 0, false);
 
     let create_both = UndoAction::Create {
         shapes: vec![(0, shape1), (1, shape2.clone())],

--- a/src/draw/frame/tests/history/validate.rs
+++ b/src/draw/frame/tests/history/validate.rs
@@ -12,18 +12,8 @@ fn validate_history_drops_actions_exceeding_compound_depth() {
         thick: 1.0,
     };
 
-    let shallow_drawn = DrawnShape {
-        id: 1,
-        shape: base_shape.clone(),
-        created_at: 0,
-        locked: false,
-    };
-    let deep_drawn = DrawnShape {
-        id: 2,
-        shape: base_shape,
-        created_at: 0,
-        locked: false,
-    };
+    let shallow_drawn = DrawnShape::with_metadata(1, base_shape.clone(), 0, false);
+    let deep_drawn = DrawnShape::with_metadata(2, base_shape, 0, false);
 
     let shallow = UndoAction::Compound {
         actions: vec![UndoAction::Create {

--- a/src/draw/frame/types.rs
+++ b/src/draw/frame/types.rs
@@ -1,6 +1,7 @@
 use crate::draw::shape::Shape;
 use crate::util::Rect;
 use serde::{Deserialize, Serialize};
+use std::cell::Cell;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Unique identifier for a drawn shape within a frame.
@@ -9,6 +10,14 @@ pub type ShapeId = u64;
 /// Maximum allowed compound nesting depth in persisted history.
 pub const MAX_COMPOUND_DEPTH: usize = 16;
 
+/// Memoized bounding-box state for a [`DrawnShape`].
+#[derive(Clone, Copy, Debug, Default)]
+enum CachedBounds {
+    #[default]
+    Unknown,
+    Known(Option<Rect>),
+}
+
 /// A shape stored in a frame with additional metadata.
 #[derive(Clone, Debug)]
 pub struct DrawnShape {
@@ -16,6 +25,11 @@ pub struct DrawnShape {
     pub shape: Shape,
     pub created_at: u64,
     pub locked: bool,
+    /// Memoized `shape.bounding_box()`. Recomputing bounds is O(points) for
+    /// strokes and hits the text-measurement cache for text shapes, and the
+    /// render culling loop queries every shape every frame — so memoize.
+    /// Any code that mutates `shape` in place must call [`Self::invalidate_bounds`].
+    cached_bounds: Cell<CachedBounds>,
 }
 
 impl DrawnShape {
@@ -25,16 +39,48 @@ impl DrawnShape {
             shape,
             created_at: current_timestamp_ms(),
             locked: false,
+            cached_bounds: Cell::new(CachedBounds::Unknown),
         }
     }
 
-    pub(super) fn with_metadata(id: ShapeId, shape: Shape, created_at: u64, locked: bool) -> Self {
+    pub fn with_metadata(id: ShapeId, shape: Shape, created_at: u64, locked: bool) -> Self {
         Self {
             id,
             shape,
             created_at,
             locked,
+            cached_bounds: Cell::new(CachedBounds::Unknown),
         }
+    }
+
+    /// Bounding box of the shape, memoized across frames.
+    ///
+    /// In debug builds a stale cache (a mutation site missing
+    /// [`Self::invalidate_bounds`]) trips an assertion, so the test suite
+    /// catches invalidation bugs while release builds get the O(1) fast path.
+    pub fn bounding_box(&self) -> Option<Rect> {
+        if let CachedBounds::Known(bounds) = self.cached_bounds.get() {
+            debug_assert_eq!(
+                bounds,
+                self.shape.bounding_box(),
+                "stale DrawnShape bounds cache: a mutation site is missing invalidate_bounds()"
+            );
+            return bounds;
+        }
+        let bounds = self.shape.bounding_box();
+        self.cached_bounds.set(CachedBounds::Known(bounds));
+        bounds
+    }
+
+    /// Drops the memoized bounding box; call after mutating `shape` in place.
+    pub fn invalidate_bounds(&self) {
+        self.cached_bounds.set(CachedBounds::Unknown);
+    }
+
+    /// Replaces the shape, keeping the bounds cache consistent.
+    pub fn set_shape(&mut self, shape: Shape) {
+        self.shape = shape;
+        self.invalidate_bounds();
     }
 }
 
@@ -180,4 +226,57 @@ pub(super) fn current_timestamp_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|dur| dur.as_millis() as u64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::draw::Color;
+
+    fn line(x1: i32, y1: i32, x2: i32, y2: i32) -> Shape {
+        Shape::Line {
+            x1,
+            y1,
+            x2,
+            y2,
+            color: Color {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            },
+            thick: 2.0,
+        }
+    }
+
+    #[test]
+    fn bounding_box_is_memoized_and_stable() {
+        let drawn = DrawnShape::with_metadata(1, line(0, 0, 10, 10), 0, false);
+        let first = drawn.bounding_box();
+        let second = drawn.bounding_box();
+        assert_eq!(first, second);
+        assert_eq!(first, drawn.shape.bounding_box());
+    }
+
+    #[test]
+    fn set_shape_refreshes_cached_bounds() {
+        let mut drawn = DrawnShape::with_metadata(1, line(0, 0, 10, 10), 0, false);
+        let before = drawn.bounding_box().expect("line has bounds");
+        drawn.set_shape(line(100, 100, 150, 150));
+        let after = drawn.bounding_box().expect("moved line has bounds");
+        assert_ne!(before, after);
+        assert_eq!(Some(after), drawn.shape.bounding_box());
+    }
+
+    #[test]
+    fn invalidate_bounds_recomputes_after_in_place_mutation() {
+        let mut drawn = DrawnShape::with_metadata(1, line(0, 0, 10, 10), 0, false);
+        let _ = drawn.bounding_box();
+        if let Shape::Line { x1, x2, .. } = &mut drawn.shape {
+            *x1 += 500;
+            *x2 += 500;
+        }
+        drawn.invalidate_bounds();
+        assert_eq!(drawn.bounding_box(), drawn.shape.bounding_box());
+    }
 }

--- a/src/draw/frame/types.rs
+++ b/src/draw/frame/types.rs
@@ -43,7 +43,7 @@ impl DrawnShape {
         }
     }
 
-    pub fn with_metadata(id: ShapeId, shape: Shape, created_at: u64, locked: bool) -> Self {
+    pub(crate) fn with_metadata(id: ShapeId, shape: Shape, created_at: u64, locked: bool) -> Self {
         Self {
             id,
             shape,

--- a/src/draw/render/selection.rs
+++ b/src/draw/render/selection.rs
@@ -110,7 +110,7 @@ pub fn render_selection_halo(ctx: &cairo::Context, drawn: &DrawnShape) {
             );
         }
         Shape::BlurRect { .. } => {
-            if let Some(bounds) = drawn.shape.bounding_box() {
+            if let Some(bounds) = drawn.bounding_box() {
                 let padding = 3.0;
                 let x = bounds.x as f64 - padding;
                 let y = bounds.y as f64 - padding;
@@ -152,7 +152,7 @@ pub fn render_selection_halo(ctx: &cairo::Context, drawn: &DrawnShape) {
             render_freehand_borrowed(ctx, points, glow, outline);
         }
         Shape::Text { .. } | Shape::Image { .. } => {
-            if let Some(bounds) = drawn.shape.bounding_box() {
+            if let Some(bounds) = drawn.bounding_box() {
                 let padding = 4.0;
                 let x = bounds.x as f64 - padding;
                 let y = bounds.y as f64 - padding;
@@ -168,7 +168,7 @@ pub fn render_selection_halo(ctx: &cairo::Context, drawn: &DrawnShape) {
             }
         }
         Shape::StickyNote { .. } => {
-            if let Some(bounds) = drawn.shape.bounding_box() {
+            if let Some(bounds) = drawn.bounding_box() {
                 let padding = 4.0;
                 let x = bounds.x as f64 - padding;
                 let y = bounds.y as f64 - padding;

--- a/src/input/hit_test/mod.rs
+++ b/src/input/hit_test/mod.rs
@@ -12,7 +12,7 @@ use crate::util::Rect;
 
 /// Computes a tolerance-aware bounding rectangle for the shape.
 pub fn compute_hit_bounds(shape: &DrawnShape, tolerance: f64) -> Option<Rect> {
-    let base = shape.shape.bounding_box()?;
+    let base = shape.bounding_box()?;
     if matches!(shape.shape, Shape::EraserStroke { .. }) {
         return None;
     }
@@ -122,7 +122,7 @@ pub fn hit_test(shape: &DrawnShape, point: (i32, i32), tolerance: f64) -> bool {
         }
         Shape::BlurRect { .. } => {
             let inflate = tolerance.ceil() as i32;
-            if let Some(bounds) = shape.shape.bounding_box() {
+            if let Some(bounds) = shape.bounding_box() {
                 bounds
                     .inflated(inflate)
                     .unwrap_or(bounds)
@@ -132,7 +132,7 @@ pub fn hit_test(shape: &DrawnShape, point: (i32, i32), tolerance: f64) -> bool {
             }
         }
         Shape::Text { .. } | Shape::StickyNote { .. } | Shape::Image { .. } => {
-            if let Some(bounds) = shape.shape.bounding_box() {
+            if let Some(bounds) = shape.bounding_box() {
                 let inflate = tolerance.ceil() as i32;
                 bounds
                     .inflated(inflate)

--- a/src/input/hit_test/tests.rs
+++ b/src/input/hit_test/tests.rs
@@ -6,9 +6,9 @@ use crate::draw::{
 
 #[test]
 fn compute_hit_bounds_inflates_bounds_for_tolerance() {
-    let drawn = DrawnShape {
-        id: 1,
-        shape: Shape::Rect {
+    let drawn = DrawnShape::with_metadata(
+        1,
+        Shape::Rect {
             x: 10,
             y: 20,
             w: 30,
@@ -17,9 +17,9 @@ fn compute_hit_bounds_inflates_bounds_for_tolerance() {
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     let base = drawn
         .shape
@@ -36,18 +36,18 @@ fn compute_hit_bounds_inflates_bounds_for_tolerance() {
 
 #[test]
 fn compute_hit_bounds_ignores_eraser_strokes() {
-    let eraser = DrawnShape {
-        id: 2,
-        shape: Shape::EraserStroke {
+    let eraser = DrawnShape::with_metadata(
+        2,
+        Shape::EraserStroke {
             points: vec![(0, 0), (10, 10)],
             brush: EraserBrush {
                 size: 8.0,
                 kind: EraserKind::Circle,
             },
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(
         compute_hit_bounds(&eraser, 5.0).is_none(),
@@ -57,9 +57,9 @@ fn compute_hit_bounds_ignores_eraser_strokes() {
 
 #[test]
 fn rect_hit_handles_degenerate_dimensions() {
-    let rect = DrawnShape {
-        id: 1,
-        shape: Shape::Rect {
+    let rect = DrawnShape::with_metadata(
+        1,
+        Shape::Rect {
             x: 10,
             y: 10,
             w: 0,
@@ -68,9 +68,9 @@ fn rect_hit_handles_degenerate_dimensions() {
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(hit_test(&rect, (10, 10), 3.0));
     assert!(!hit_test(&rect, (5, 5), 2.0));
@@ -78,9 +78,9 @@ fn rect_hit_handles_degenerate_dimensions() {
 
 #[test]
 fn ellipse_hit_handles_zero_radius() {
-    let ellipse = DrawnShape {
-        id: 2,
-        shape: Shape::Ellipse {
+    let ellipse = DrawnShape::with_metadata(
+        2,
+        Shape::Ellipse {
             cx: 50,
             cy: 80,
             rx: 0,
@@ -89,9 +89,9 @@ fn ellipse_hit_handles_zero_radius() {
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(hit_test(&ellipse, (50, 80), 2.0));
     assert!(!hit_test(&ellipse, (60, 90), 1.0));
@@ -99,18 +99,18 @@ fn ellipse_hit_handles_zero_radius() {
 
 #[test]
 fn polygon_hit_tests_closed_outline_only() {
-    let polygon = DrawnShape {
-        id: 3,
-        shape: Shape::Polygon {
+    let polygon = DrawnShape::with_metadata(
+        3,
+        Shape::Polygon {
             kind: PolygonKind::Triangle,
             points: vec![(10, 10), (40, 10), (25, 40)],
             fill: true,
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(hit_test(&polygon, (25, 10), 1.0));
     assert!(
@@ -121,9 +121,9 @@ fn polygon_hit_tests_closed_outline_only() {
 
 #[test]
 fn point_targeting_hits_filled_rect_and_ellipse_interiors() {
-    let rect = DrawnShape {
-        id: 3,
-        shape: Shape::Rect {
+    let rect = DrawnShape::with_metadata(
+        3,
+        Shape::Rect {
             x: 10,
             y: 10,
             w: 40,
@@ -132,12 +132,12 @@ fn point_targeting_hits_filled_rect_and_ellipse_interiors() {
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
-    let ellipse = DrawnShape {
-        id: 4,
-        shape: Shape::Ellipse {
+        0,
+        false,
+    );
+    let ellipse = DrawnShape::with_metadata(
+        4,
+        Shape::Ellipse {
             cx: 80,
             cy: 70,
             rx: 20,
@@ -146,9 +146,9 @@ fn point_targeting_hits_filled_rect_and_ellipse_interiors() {
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(!hit_test(&rect, (30, 25), 1.0));
     assert!(hit_test_for_point_targeting(&rect, (30, 25), 1.0));
@@ -158,18 +158,18 @@ fn point_targeting_hits_filled_rect_and_ellipse_interiors() {
 
 #[test]
 fn point_targeting_hits_filled_polygon_interior() {
-    let polygon = DrawnShape {
-        id: 3,
-        shape: Shape::Polygon {
+    let polygon = DrawnShape::with_metadata(
+        3,
+        Shape::Polygon {
             kind: PolygonKind::Triangle,
             points: vec![(10, 10), (40, 10), (25, 40)],
             fill: true,
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(
         hit_test_for_point_targeting(&polygon, (25, 22), 1.0),
@@ -179,18 +179,18 @@ fn point_targeting_hits_filled_polygon_interior() {
 
 #[test]
 fn invalid_polygon_hit_test_is_false() {
-    let polygon = DrawnShape {
-        id: 4,
-        shape: Shape::Polygon {
+    let polygon = DrawnShape::with_metadata(
+        4,
+        Shape::Polygon {
             kind: PolygonKind::Freeform,
             points: vec![(10, 10), (10, 10), (40, 10)],
             fill: false,
             color: BLACK,
             thick: 2.0,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(!hit_test(&polygon, (10, 10), 10.0));
 }
@@ -220,9 +220,9 @@ fn arrow_label_hit_detects_label_bounds() {
         size: 12.0,
         font_descriptor: font.clone(),
     };
-    let drawn = DrawnShape {
-        id: 3,
-        shape: Shape::Arrow {
+    let drawn = DrawnShape::with_metadata(
+        3,
+        Shape::Arrow {
             x1: 0,
             y1: 0,
             x2: 100,
@@ -234,9 +234,9 @@ fn arrow_label_hit_detects_label_bounds() {
             head_at_end: true,
             label: Some(label),
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     let label_text = "12";
     let layout = crate::draw::shape::arrow_label_layout(100, 0, 0, 0, 2.0, label_text, 12.0, &font)
@@ -264,17 +264,17 @@ fn step_marker_hit_detects_center_and_rejects_outside_point() {
         size: 16.0,
         font_descriptor: font,
     };
-    let drawn = DrawnShape {
-        id: 4,
-        shape: Shape::StepMarker {
+    let drawn = DrawnShape::with_metadata(
+        4,
+        Shape::StepMarker {
             x: 50,
             y: 60,
             color: BLACK,
             label,
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(
         hit_test(&drawn, (50, 60), 0.1),
@@ -296,9 +296,9 @@ fn step_marker_hit_detects_center_and_rejects_outside_point() {
 
 #[test]
 fn image_hit_test_uses_display_rectangle() {
-    let drawn = DrawnShape {
-        id: 5,
-        shape: Shape::Image {
+    let drawn = DrawnShape::with_metadata(
+        5,
+        Shape::Image {
             x: 10,
             y: 20,
             w: 40,
@@ -310,9 +310,9 @@ fn image_hit_test_uses_display_rectangle() {
                 bytes: vec![1, 2, 3],
             },
         },
-        created_at: 0,
-        locked: false,
-    };
+        0,
+        false,
+    );
 
     assert!(hit_test(&drawn, (20, 30), 0.0));
     assert!(!hit_test(&drawn, (60, 60), 0.0));

--- a/src/input/state/core/base/state/init.rs
+++ b/src/input/state/core/base/state/init.rs
@@ -189,6 +189,7 @@ impl InputState {
             radial_menu_layout: None,
             radial_menu_mouse_binding: RadialMenuMouseBinding::Middle,
             hit_test_cache: HashMap::new(),
+            canvas_content_generation: 0,
             hit_test_tolerance: 6.0,
             max_linear_hit_test: 400,
             undo_stack_limit: 100,

--- a/src/input/state/core/base/state/structs.rs
+++ b/src/input/state/core/base/state/structs.rs
@@ -297,6 +297,10 @@ pub struct InputState {
     pub radial_menu_mouse_binding: RadialMenuMouseBinding,
     /// Cached hit-test bounds per shape id
     pub(in crate::input::state::core) hit_test_cache: HashMap<ShapeId, Rect>,
+    /// Monotonic counter bumped whenever committed shape content may have
+    /// changed (piggybacks on hit-cache invalidation). Used by render-side
+    /// caches to detect content changes cheaply.
+    pub(in crate::input::state::core) canvas_content_generation: u64,
     /// Hit test tolerance in pixels
     pub hit_test_tolerance: f64,
     /// Threshold before enabling spatial indexing

--- a/src/input/state/core/index.rs
+++ b/src/input/state/core/index.rs
@@ -114,7 +114,7 @@ impl InputState {
             .boards
             .active_frame()
             .shape(id)
-            .and_then(|drawn| drawn.shape.bounding_box());
+            .and_then(|drawn| drawn.bounding_box());
 
         if let Some(grid) = &mut self.spatial_index {
             // Remove shape from its old cells
@@ -286,7 +286,7 @@ impl SpatialGrid {
         let mut shape_cells: HashMap<ShapeId, Vec<(i32, i32)>> = HashMap::new();
 
         for drawn in &frame.shapes {
-            let Some(bounds) = drawn.shape.bounding_box() else {
+            let Some(bounds) = drawn.bounding_box() else {
                 continue;
             };
 

--- a/src/input/state/core/index.rs
+++ b/src/input/state/core/index.rs
@@ -89,8 +89,14 @@ impl InputState {
         hits
     }
 
+    /// Monotonic counter bumped whenever committed shape content may have changed.
+    pub fn canvas_content_generation(&self) -> u64 {
+        self.canvas_content_generation
+    }
+
     /// Clears all cached hit-test data and spatial index.
     pub fn invalidate_hit_cache(&mut self) {
+        self.canvas_content_generation = self.canvas_content_generation.wrapping_add(1);
         self.hit_test_cache.clear();
         self.spatial_index = None;
     }
@@ -100,6 +106,7 @@ impl InputState {
     /// Instead of invalidating the entire spatial index, this method updates
     /// only the affected cells, providing O(1) amortized updates instead of O(n).
     pub fn invalidate_hit_cache_for(&mut self, id: ShapeId) {
+        self.canvas_content_generation = self.canvas_content_generation.wrapping_add(1);
         self.hit_test_cache.remove(&id);
 
         // Get the shape's new bounds (if it still exists)

--- a/src/input/state/core/menus/commands.rs
+++ b/src/input/state/core/menus/commands.rs
@@ -59,9 +59,7 @@ impl InputState {
                         previous_ids
                             .iter()
                             .filter_map(|id| {
-                                frame
-                                    .shape(*id)
-                                    .and_then(|shape| shape.shape.bounding_box())
+                                frame.shape(*id).and_then(|shape| shape.bounding_box())
                             })
                             .collect::<Vec<_>>()
                     };
@@ -75,7 +73,7 @@ impl InputState {
                         let frame = self.boards.active_frame();
                         frame
                             .shape(hovered_shape)
-                            .and_then(|shape| shape.shape.bounding_box())
+                            .and_then(|shape| shape.bounding_box())
                     };
                     self.mark_selection_dirty_region(hovered_bounds);
 

--- a/src/input/state/core/properties/apply_selection/helpers.rs
+++ b/src/input/state/core/properties/apply_selection/helpers.rs
@@ -87,7 +87,7 @@ impl InputState {
                 continue;
             }
 
-            let before_bounds = drawn.shape.bounding_box();
+            let before_bounds = drawn.bounding_box();
             let before_snapshot = crate::draw::frame::ShapeSnapshot {
                 shape: drawn.shape.clone(),
                 locked: drawn.locked,
@@ -99,7 +99,7 @@ impl InputState {
                 continue;
             }
 
-            let after_bounds = drawn.shape.bounding_box();
+            let after_bounds = drawn.bounding_box();
             let after_snapshot = crate::draw::frame::ShapeSnapshot {
                 shape: drawn.shape.clone(),
                 locked: drawn.locked,

--- a/src/input/state/core/properties/apply_selection/helpers.rs
+++ b/src/input/state/core/properties/apply_selection/helpers.rs
@@ -94,6 +94,7 @@ impl InputState {
             };
 
             let changed = apply(&mut drawn.shape);
+            drawn.invalidate_bounds();
             if !changed {
                 continue;
             }

--- a/src/input/state/core/properties/panel.rs
+++ b/src/input/state/core/properties/panel.rs
@@ -92,7 +92,7 @@ impl InputState {
             if let Some(timestamp) = format_timestamp(drawn.created_at) {
                 lines.push(format!("Created: {timestamp}"));
             }
-            if let Some(bounds) = drawn.shape.bounding_box() {
+            if let Some(bounds) = drawn.bounding_box() {
                 lines.push(format!("Bounds: {}×{} px", bounds.width, bounds.height));
             }
 
@@ -163,7 +163,7 @@ impl InputState {
                 if let Some(timestamp) = format_timestamp(drawn.created_at) {
                     lines.push(format!("Created: {timestamp}"));
                 }
-                if let Some(bounds) = drawn.shape.bounding_box() {
+                if let Some(bounds) = drawn.bounding_box() {
                     lines.push(format!("Bounds: {}×{} px", bounds.width, bounds.height));
                 }
                 ("Shape Properties".to_string(), lines, false)

--- a/src/input/state/core/selection.rs
+++ b/src/input/state/core/selection.rs
@@ -97,7 +97,7 @@ impl InputState {
 
         for id in ids {
             if let Some(shape) = frame.shape(*id)
-                && let Some(bounds) = shape.shape.bounding_box()
+                && let Some(bounds) = shape.bounding_box()
             {
                 min_x = min_x.min(bounds.x);
                 min_y = min_y.min(bounds.y);

--- a/src/input/state/core/selection_actions/clipboard.rs
+++ b/src/input/state/core/selection_actions/clipboard.rs
@@ -110,7 +110,7 @@ impl InputState {
                     .find_index(new_id)
                     .and_then(|idx| frame.shape(new_id).map(|s| (idx, s.clone())))
             } {
-                self.mark_selection_dirty_region(stored.shape.bounding_box());
+                self.mark_selection_dirty_region(stored.bounding_box());
                 self.invalidate_hit_cache_for(new_id);
                 created.push((index, stored));
                 new_ids.push(new_id);
@@ -393,7 +393,7 @@ impl InputState {
             if let Some(index) = frame.find_index(new_id)
                 && let Some(stored) = frame.shape(new_id).cloned()
             {
-                dirty_bounds.push(stored.shape.bounding_box());
+                dirty_bounds.push(stored.bounding_box());
                 hit_ids.push(new_id);
                 created.push((index, stored));
                 new_ids.push(new_id);

--- a/src/input/state/core/selection_actions/clipboard/duplicate.rs
+++ b/src/input/state/core/selection_actions/clipboard/duplicate.rs
@@ -39,7 +39,7 @@ impl InputState {
                     .find_index(new_id)
                     .and_then(|idx| frame.shape(new_id).map(|s| (idx, s.clone())))
             } {
-                self.mark_selection_dirty_region(stored.shape.bounding_box());
+                self.mark_selection_dirty_region(stored.bounding_box());
                 self.invalidate_hit_cache_for(new_id);
                 created.push((index, stored));
                 new_ids.push(new_id);

--- a/src/input/state/core/selection_actions/clipboard/image_paste.rs
+++ b/src/input/state/core/selection_actions/clipboard/image_paste.rs
@@ -79,7 +79,7 @@ impl InputState {
         else {
             return false;
         };
-        let bounds = stored.shape.bounding_box();
+        let bounds = stored.bounding_box();
         frame.push_undo_action(
             UndoAction::Create {
                 shapes: vec![(index, stored)],

--- a/src/input/state/core/selection_actions/delete.rs
+++ b/src/input/state/core/selection_actions/delete.rs
@@ -39,7 +39,7 @@ impl InputState {
                     if shape.locked {
                         continue;
                     }
-                    dirty.push((shape.id, shape.shape.bounding_box()));
+                    dirty.push((shape.id, shape.bounding_box()));
                     removed.push((index, shape.clone()));
                 }
             }

--- a/src/input/state/core/selection_actions/resize.rs
+++ b/src/input/state/core/selection_actions/resize.rs
@@ -74,14 +74,14 @@ impl InputState {
             for (shape_id, snapshot) in snapshots {
                 if let Some(drawn) = frame.shape_mut(*shape_id) {
                     // Apply scaling transformation to the shape
-                    drawn.shape = Self::scale_shape(
+                    drawn.set_shape(Self::scale_shape(
                         &snapshot.shape,
                         scale_x,
                         scale_y,
                         anchor_x,
                         anchor_y,
                         original_bounds,
-                    );
+                    ));
                     ids_to_invalidate.push(*shape_id);
                 }
             }
@@ -350,7 +350,7 @@ impl InputState {
             let frame = self.boards.active_frame_mut();
             for (shape_id, snapshot) in snapshots {
                 if let Some(drawn) = frame.shape_mut(*shape_id) {
-                    drawn.shape = snapshot.shape.clone();
+                    drawn.set_shape(snapshot.shape.clone());
                     drawn.locked = snapshot.locked;
                     ids_to_invalidate.push(*shape_id);
                 }

--- a/src/input/state/core/selection_actions/text/edit.rs
+++ b/src/input/state/core/selection_actions/text/edit.rs
@@ -128,6 +128,7 @@ impl InputState {
                     }
                     _ => {}
                 }
+                shape.invalidate_bounds();
                 let after = shape.shape.bounding_box();
                 Some((before, after))
             } else {
@@ -156,7 +157,7 @@ impl InputState {
             let frame = self.boards.active_frame_mut();
             if let Some(shape) = frame.shape_mut(shape_id) {
                 let before = shape.shape.bounding_box();
-                shape.shape = snapshot.shape.clone();
+                shape.set_shape(snapshot.shape.clone());
                 shape.locked = snapshot.locked;
                 let after = shape.shape.bounding_box();
                 Some((before, after))
@@ -185,7 +186,7 @@ impl InputState {
             let frame = self.boards.active_frame_mut();
             if let Some(shape) = frame.shape_mut(shape_id) {
                 let before_bounds = shape.shape.bounding_box();
-                shape.shape = new_shape;
+                shape.set_shape(new_shape);
                 let after_bounds = shape.shape.bounding_box();
                 let after_snapshot = ShapeSnapshot {
                     shape: shape.shape.clone(),

--- a/src/input/state/core/selection_actions/text/edit.rs
+++ b/src/input/state/core/selection_actions/text/edit.rs
@@ -118,7 +118,7 @@ impl InputState {
         let cleared = {
             let frame = self.boards.active_frame_mut();
             if let Some(shape) = frame.shape_mut(shape_id) {
-                let before = shape.shape.bounding_box();
+                let before = shape.bounding_box();
                 match &mut shape.shape {
                     Shape::Text { text, .. } => {
                         text.clear();
@@ -129,7 +129,7 @@ impl InputState {
                     _ => {}
                 }
                 shape.invalidate_bounds();
-                let after = shape.shape.bounding_box();
+                let after = shape.bounding_box();
                 Some((before, after))
             } else {
                 None
@@ -156,10 +156,10 @@ impl InputState {
         let restored = {
             let frame = self.boards.active_frame_mut();
             if let Some(shape) = frame.shape_mut(shape_id) {
-                let before = shape.shape.bounding_box();
+                let before = shape.bounding_box();
                 shape.set_shape(snapshot.shape.clone());
                 shape.locked = snapshot.locked;
-                let after = shape.shape.bounding_box();
+                let after = shape.bounding_box();
                 Some((before, after))
             } else {
                 None
@@ -185,9 +185,9 @@ impl InputState {
         let updated = {
             let frame = self.boards.active_frame_mut();
             if let Some(shape) = frame.shape_mut(shape_id) {
-                let before_bounds = shape.shape.bounding_box();
+                let before_bounds = shape.bounding_box();
                 shape.set_shape(new_shape);
-                let after_bounds = shape.shape.bounding_box();
+                let after_bounds = shape.bounding_box();
                 let after_snapshot = ShapeSnapshot {
                     shape: shape.shape.clone(),
                     locked: shape.locked,

--- a/src/input/state/core/selection_actions/text/handles.rs
+++ b/src/input/state/core/selection_actions/text/handles.rs
@@ -27,7 +27,7 @@ impl InputState {
         if !matches!(shape.shape, Shape::Text { .. } | Shape::StickyNote { .. }) {
             return None;
         }
-        let bounds = shape.shape.bounding_box()?;
+        let bounds = shape.bounding_box()?;
         let handle = Self::text_resize_handle_rect(bounds)?;
         Some((shape_id, handle))
     }

--- a/src/input/state/core/selection_actions/text/wrap.rs
+++ b/src/input/state/core/selection_actions/text/wrap.rs
@@ -27,7 +27,7 @@ impl InputState {
                 if shape.locked {
                     return false;
                 }
-                let before = shape.shape.bounding_box();
+                let before = shape.bounding_box();
                 match &mut shape.shape {
                     Shape::Text { wrap_width, .. } | Shape::StickyNote { wrap_width, .. } => {
                         if *wrap_width == Some(new_width) {
@@ -38,7 +38,7 @@ impl InputState {
                     _ => return false,
                 }
                 shape.invalidate_bounds();
-                let after = shape.shape.bounding_box();
+                let after = shape.bounding_box();
                 Some((before, after))
             } else {
                 None

--- a/src/input/state/core/selection_actions/text/wrap.rs
+++ b/src/input/state/core/selection_actions/text/wrap.rs
@@ -37,6 +37,7 @@ impl InputState {
                     }
                     _ => return false,
                 }
+                shape.invalidate_bounds();
                 let after = shape.shape.bounding_box();
                 Some((before, after))
             } else {

--- a/src/input/state/core/selection_actions/translation/bounds.rs
+++ b/src/input/state/core/selection_actions/translation/bounds.rs
@@ -18,7 +18,7 @@ impl InputState {
 
         for id in ids {
             if let Some(shape) = frame.shape(*id)
-                && let Some(bounds) = shape.shape.bounding_box()
+                && let Some(bounds) = shape.bounding_box()
             {
                 min_x = min_x.min(bounds.x);
                 min_y = min_y.min(bounds.y);
@@ -53,7 +53,7 @@ impl InputState {
                 if shape.locked {
                     continue;
                 }
-                if let Some(bounds) = shape.shape.bounding_box() {
+                if let Some(bounds) = shape.bounding_box() {
                     min_x = min_x.min(bounds.x);
                     min_y = min_y.min(bounds.y);
                     max_x = max_x.max(bounds.x + bounds.width);

--- a/src/input/state/core/selection_actions/translation/mod.rs
+++ b/src/input/state/core/selection_actions/translation/mod.rs
@@ -54,10 +54,10 @@ impl InputState {
                     if shape.locked {
                         None
                     } else {
-                        let before = shape.shape.bounding_box();
+                        let before = shape.bounding_box();
                         Self::translate_shape(&mut shape.shape, dx, dy);
                         shape.invalidate_bounds();
-                        let after = shape.shape.bounding_box();
+                        let after = shape.bounding_box();
                         Some((before, after))
                     }
                 } else {

--- a/src/input/state/core/selection_actions/translation/mod.rs
+++ b/src/input/state/core/selection_actions/translation/mod.rs
@@ -56,6 +56,7 @@ impl InputState {
                     } else {
                         let before = shape.shape.bounding_box();
                         Self::translate_shape(&mut shape.shape, dx, dy);
+                        shape.invalidate_bounds();
                         let after = shape.shape.bounding_box();
                         Some((before, after))
                     }

--- a/src/input/state/core/selection_actions/translation/transform.rs
+++ b/src/input/state/core/selection_actions/translation/transform.rs
@@ -16,7 +16,7 @@ impl InputState {
                 let frame = self.boards.active_frame_mut();
                 if let Some(shape) = frame.shape_mut(shape_id) {
                     let before = shape.shape.bounding_box();
-                    shape.shape = snapshot.shape.clone();
+                    shape.set_shape(snapshot.shape.clone());
                     shape.locked = snapshot.locked;
                     let after = shape.shape.bounding_box();
                     Some((before, after))

--- a/src/input/state/core/selection_actions/translation/transform.rs
+++ b/src/input/state/core/selection_actions/translation/transform.rs
@@ -15,10 +15,10 @@ impl InputState {
             let bounds = {
                 let frame = self.boards.active_frame_mut();
                 if let Some(shape) = frame.shape_mut(shape_id) {
-                    let before = shape.shape.bounding_box();
+                    let before = shape.bounding_box();
                     shape.set_shape(snapshot.shape.clone());
                     shape.locked = snapshot.locked;
-                    let after = shape.shape.bounding_box();
+                    let after = shape.bounding_box();
                     Some((before, after))
                 } else {
                     None

--- a/src/input/state/tests/erase.rs
+++ b/src/input/state/tests/erase.rs
@@ -288,6 +288,7 @@ fn spatial_grid_eraser_hits_after_add_move_delete() {
         *y1 = 200;
         *x2 = 50;
         *y2 = 250;
+        drawn.invalidate_bounds();
     }
     state.invalidate_hit_cache_for(shape_ids[4]);
 

--- a/src/input/state/tests/transform.rs
+++ b/src/input/state/tests/transform.rs
@@ -178,7 +178,7 @@ fn move_selection_to_horizontal_edges_uses_screen_bounds() {
     {
         let frame = state.boards.active_frame();
         let shape = frame.shape(shape_id).unwrap();
-        let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+        let bounds = shape.bounding_box().expect("rect should have bounds");
         assert_eq!(bounds.x, 0);
     }
 
@@ -187,7 +187,7 @@ fn move_selection_to_horizontal_edges_uses_screen_bounds() {
     {
         let frame = state.boards.active_frame();
         let shape = frame.shape(shape_id).unwrap();
-        let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+        let bounds = shape.bounding_box().expect("rect should have bounds");
         assert_eq!(bounds.x + bounds.width, 200);
     }
 }
@@ -213,7 +213,7 @@ fn move_selection_to_horizontal_edges_ignores_last_axis() {
     {
         let frame = state.boards.active_frame();
         let shape = frame.shape(shape_id).unwrap();
-        let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+        let bounds = shape.bounding_box().expect("rect should have bounds");
         assert_eq!(bounds.x, 0);
     }
 
@@ -222,7 +222,7 @@ fn move_selection_to_horizontal_edges_ignores_last_axis() {
     {
         let frame = state.boards.active_frame();
         let shape = frame.shape(shape_id).unwrap();
-        let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+        let bounds = shape.bounding_box().expect("rect should have bounds");
         assert_eq!(bounds.x + bounds.width, 200);
     }
 }
@@ -247,7 +247,7 @@ fn move_selection_to_vertical_edges_explicit_actions() {
     {
         let frame = state.boards.active_frame();
         let shape = frame.shape(shape_id).unwrap();
-        let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+        let bounds = shape.bounding_box().expect("rect should have bounds");
         assert_eq!(bounds.y, 0);
     }
 
@@ -256,7 +256,7 @@ fn move_selection_to_vertical_edges_explicit_actions() {
     {
         let frame = state.boards.active_frame();
         let shape = frame.shape(shape_id).unwrap();
-        let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+        let bounds = shape.bounding_box().expect("rect should have bounds");
         assert_eq!(bounds.y + bounds.height, 100);
     }
 }
@@ -305,7 +305,7 @@ fn nudge_selection_clamps_left_and_top_edges() {
 
     let frame = state.boards.active_frame();
     let shape = frame.shape(shape_id).unwrap();
-    let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+    let bounds = shape.bounding_box().expect("rect should have bounds");
     assert_eq!((bounds.x, bounds.y), (0, 0));
 }
 
@@ -329,7 +329,7 @@ fn nudge_selection_clamps_right_and_bottom_edges() {
 
     let frame = state.boards.active_frame();
     let shape = frame.shape(shape_id).unwrap();
-    let bounds = shape.shape.bounding_box().expect("rect should have bounds");
+    let bounds = shape.bounding_box().expect("rect should have bounds");
     assert_eq!(
         (bounds.x + bounds.width, bounds.y + bounds.height),
         (100, 100)

--- a/src/session/snapshot/tests.rs
+++ b/src/session/snapshot/tests.rs
@@ -1939,6 +1939,7 @@ fn translate_line(frame: &mut Frame, shape_id: crate::draw::ShapeId, dx: i32, dy
         *x2 += dx;
         *y2 += dy;
     }
+    shape.invalidate_bounds();
 }
 
 #[test]

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -337,7 +337,10 @@ fn save_snapshot_drops_history_when_modified_stroke_exceeds_limit() {
             locked: current.locked,
         };
         let after_shape = large_freehand(point_count, 1);
-        frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+        frame
+            .shape_mut(id)
+            .expect("shape should exist")
+            .set_shape(after_shape.clone());
         frame.push_undo_action(
             UndoAction::Modify {
                 shape_id: id,
@@ -437,7 +440,10 @@ fn save_snapshot_keeps_largest_recent_history_depth_that_fits() {
                 locked: current.locked,
             };
             let after_shape = large_freehand(point_count, offset);
-            frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+            frame
+                .shape_mut(id)
+                .expect("shape should exist")
+                .set_shape(after_shape.clone());
             frame.push_undo_action(
                 UndoAction::Modify {
                     shape_id: id,
@@ -524,7 +530,10 @@ fn autosave_snapshot_uses_bounded_history_fallback() {
                 locked: current.locked,
             };
             let after_shape = large_freehand(point_count, offset);
-            frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+            frame
+                .shape_mut(id)
+                .expect("shape should exist")
+                .set_shape(after_shape.clone());
             frame.push_undo_action(
                 UndoAction::Modify {
                     shape_id: id,
@@ -617,7 +626,10 @@ fn save_snapshot_keeps_depth_one_when_visible_payload_is_near_limit() {
                 locked: current.locked,
             };
             let after_shape = large_freehand(40, offset);
-            frame.shape_mut(id).expect("shape should exist").shape = after_shape.clone();
+            frame
+                .shape_mut(id)
+                .expect("shape should exist")
+                .set_shape(after_shape.clone());
             frame.push_undo_action(
                 UndoAction::Modify {
                     shape_id: id,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -29,5 +29,8 @@ pub use status::{
     render_editing_badge, render_frozen_badge, render_page_badge, render_pan_badge,
     render_status_bar, render_zoom_badge,
 };
-pub use toasts::{render_blocked_feedback, render_preset_toast, render_ui_toast};
+pub use toasts::{
+    blocked_feedback_rects, preset_toast_geometry, render_blocked_feedback, render_preset_toast,
+    render_ui_toast, ui_toast_geometry,
+};
 pub use tour::render_tour;

--- a/src/ui/toasts.rs
+++ b/src/ui/toasts.rs
@@ -7,7 +7,7 @@ use super::constants::{
     TOAST_SUCCESS, TOAST_WARNING,
 };
 use super::primitives::draw_rounded_rect;
-use crate::ui_text::{UiTextStyle, text_layout};
+use crate::ui_text::{UiTextStyle, measure_text, text_layout};
 
 /// Border width for blocked action feedback edge flash.
 const BLOCKED_FEEDBACK_BORDER: f64 = 6.0;
@@ -19,18 +19,42 @@ const UI_TOAST_HOLD_RATIO: f64 = 0.75;
 /// Vertical position for preset toast (percentage of screen height from top)
 const PRESET_TOAST_Y_RATIO: f64 = 0.2;
 
-/// Render a transient toast for preset actions (apply/save/clear).
-pub fn render_preset_toast(
-    ctx: &cairo::Context,
-    input_state: &InputState,
+const UI_TOAST_FONT_SIZE: f64 = 15.0;
+const PRESET_TOAST_FONT_SIZE: f64 = 16.0;
+const TOAST_PADDING_X: f64 = 16.0;
+const TOAST_PADDING_Y: f64 = 9.0;
+
+fn toast_text_style(size: f64) -> UiTextStyle<'static> {
+    UiTextStyle {
+        family: "Sans",
+        slant: cairo::FontSlant::Normal,
+        weight: cairo::FontWeight::Bold,
+        size,
+    }
+}
+
+/// Box geometry for a toast label centered horizontally at a screen-height ratio.
+fn toast_box_geometry(
+    label: &str,
+    font_size: f64,
     screen_width: u32,
     screen_height: u32,
-) {
-    if !input_state.show_preset_toasts {
-        return;
-    }
+    y_ratio: f64,
+) -> Option<(f64, f64, f64, f64)> {
+    let extents = measure_text(toast_text_style(font_size), label, None)?;
+    let width = extents.width() + TOAST_PADDING_X * 2.0;
+    let height = extents.height() + TOAST_PADDING_Y * 2.0;
+    let x = (screen_width as f64 - width) / 2.0;
+    let center_y = screen_height as f64 * y_ratio;
+    let y = center_y - height / 2.0;
+    Some((x, y, width, height))
+}
 
-    let now = Instant::now();
+/// The most recent, still-animating preset feedback entry: (slot, kind, progress).
+fn latest_preset_feedback(
+    input_state: &InputState,
+    now: Instant,
+) -> Option<(usize, PresetFeedbackKind, f32)> {
     let duration_secs = PRESET_TOAST_DURATION_MS as f32 / 1000.0;
     let mut latest: Option<(usize, PresetFeedbackKind, Instant, f32)> = None;
 
@@ -51,34 +75,109 @@ pub fn render_preset_toast(
         }
     }
 
-    let Some((slot, kind, _started, progress)) = latest else {
-        return;
-    };
+    latest.map(|(slot, kind, _started, progress)| (slot, kind, progress))
+}
 
-    let label = match kind {
+fn preset_feedback_label(slot: usize, kind: PresetFeedbackKind) -> String {
+    match kind {
         PresetFeedbackKind::Apply => format!("Preset {} applied", slot),
         PresetFeedbackKind::Save => format!("Preset {} saved", slot),
         PresetFeedbackKind::Clear => format!("Preset {} cleared", slot),
+    }
+}
+
+fn ui_toast_full_label(input_state: &InputState) -> Option<String> {
+    let toast = input_state.ui_toast.as_ref()?;
+    let action_suffix = toast
+        .action
+        .as_ref()
+        .map(|a| format!(" [{}]", a.label))
+        .unwrap_or_default();
+    Some(format!("{}{}", toast.message, action_suffix))
+}
+
+/// On-screen bounds (x, y, width, height) the active UI toast occupies, without
+/// rendering it. Used for damage tracking; measurement goes through the same
+/// layout cache as rendering, so the two always agree.
+pub fn ui_toast_geometry(
+    input_state: &InputState,
+    screen_width: u32,
+    screen_height: u32,
+) -> Option<(f64, f64, f64, f64)> {
+    let full_label = ui_toast_full_label(input_state)?;
+    toast_box_geometry(
+        &full_label,
+        UI_TOAST_FONT_SIZE,
+        screen_width,
+        screen_height,
+        UI_TOAST_Y_RATIO,
+    )
+}
+
+/// On-screen bounds (x, y, width, height) of the active preset toast, without
+/// rendering it. Returns `None` when no preset toast would be drawn.
+pub fn preset_toast_geometry(
+    input_state: &InputState,
+    screen_width: u32,
+    screen_height: u32,
+) -> Option<(f64, f64, f64, f64)> {
+    if !input_state.show_preset_toasts {
+        return None;
+    }
+    let (slot, kind, _progress) = latest_preset_feedback(input_state, Instant::now())?;
+    let label = preset_feedback_label(slot, kind);
+    toast_box_geometry(
+        &label,
+        PRESET_TOAST_FONT_SIZE,
+        screen_width,
+        screen_height,
+        PRESET_TOAST_Y_RATIO,
+    )
+}
+
+/// The four screen-edge strips flashed by blocked-action feedback.
+pub fn blocked_feedback_rects(screen_width: u32, screen_height: u32) -> [(f64, f64, f64, f64); 4] {
+    let w = screen_width as f64;
+    let h = screen_height as f64;
+    let b = BLOCKED_FEEDBACK_BORDER;
+    [
+        (0.0, 0.0, w, b),
+        (0.0, h - b, w, b),
+        (0.0, b, b, h - 2.0 * b),
+        (w - b, b, b, h - 2.0 * b),
+    ]
+}
+
+/// Render a transient toast for preset actions (apply/save/clear).
+pub fn render_preset_toast(
+    ctx: &cairo::Context,
+    input_state: &InputState,
+    screen_width: u32,
+    screen_height: u32,
+) {
+    if !input_state.show_preset_toasts {
+        return;
+    }
+
+    let Some((slot, kind, progress)) = latest_preset_feedback(input_state, Instant::now()) else {
+        return;
     };
 
-    let font_size = 16.0;
-    let padding_x = 16.0;
-    let padding_y = 9.0;
+    let label = preset_feedback_label(slot, kind);
     let radius = 10.0;
 
-    let text_style = UiTextStyle {
-        family: "Sans",
-        slant: cairo::FontSlant::Normal,
-        weight: cairo::FontWeight::Bold,
-        size: font_size,
-    };
+    let text_style = toast_text_style(PRESET_TOAST_FONT_SIZE);
     let layout = text_layout(ctx, text_style, &label, None);
     let extents = layout.ink_extents();
-    let width = extents.width() + padding_x * 2.0;
-    let height = extents.height() + padding_y * 2.0;
-    let x = (screen_width as f64 - width) / 2.0;
-    let center_y = screen_height as f64 * PRESET_TOAST_Y_RATIO;
-    let y = center_y - height / 2.0;
+    let Some((x, y, width, height)) = toast_box_geometry(
+        &label,
+        PRESET_TOAST_FONT_SIZE,
+        screen_width,
+        screen_height,
+        PRESET_TOAST_Y_RATIO,
+    ) else {
+        return;
+    };
 
     let fade = if (progress as f64) <= UI_TOAST_HOLD_RATIO {
         1.0
@@ -121,9 +220,7 @@ pub fn render_ui_toast(
     }
 
     let label = toast.message.as_str();
-    let font_size = 15.0;
-    let padding_x = 16.0;
-    let padding_y = 9.0;
+    let padding_x = TOAST_PADDING_X;
     let radius = 10.0;
 
     // Calculate label with optional action suffix
@@ -134,19 +231,16 @@ pub fn render_ui_toast(
         .unwrap_or_default();
     let full_label = format!("{}{}", label, action_suffix);
 
-    let text_style = UiTextStyle {
-        family: "Sans",
-        slant: cairo::FontSlant::Normal,
-        weight: cairo::FontWeight::Bold,
-        size: font_size,
-    };
+    let text_style = toast_text_style(UI_TOAST_FONT_SIZE);
     let full_layout = text_layout(ctx, text_style, &full_label, None);
     let full_extents = full_layout.ink_extents();
-    let width = full_extents.width() + padding_x * 2.0;
-    let height = full_extents.height() + padding_y * 2.0;
-    let x = (screen_width as f64 - width) / 2.0;
-    let center_y = screen_height as f64 * UI_TOAST_Y_RATIO;
-    let y = center_y - height / 2.0;
+    let (x, y, width, height) = toast_box_geometry(
+        &full_label,
+        UI_TOAST_FONT_SIZE,
+        screen_width,
+        screen_height,
+        UI_TOAST_Y_RATIO,
+    )?;
 
     let fade = (1.0 - progress as f64).clamp(0.0, 1.0);
     let (r, g, b) = match toast.kind {
@@ -252,26 +346,10 @@ pub fn render_blocked_feedback(
         0.22 * (1.0 - (progress - 0.4) / 0.6)
     };
 
-    let w = screen_width as f64;
-    let h = screen_height as f64;
-    let b = BLOCKED_FEEDBACK_BORDER;
-
     // Red tint on all four screen edges
     constants::set_color_alpha(ctx, BLOCKED_FLASH, alpha);
-
-    // Top edge
-    ctx.rectangle(0.0, 0.0, w, b);
-    let _ = ctx.fill();
-
-    // Bottom edge
-    ctx.rectangle(0.0, h - b, w, b);
-    let _ = ctx.fill();
-
-    // Left edge (between top and bottom)
-    ctx.rectangle(0.0, b, b, h - 2.0 * b);
-    let _ = ctx.fill();
-
-    // Right edge (between top and bottom)
-    ctx.rectangle(w - b, b, b, h - 2.0 * b);
-    let _ = ctx.fill();
+    for (x, y, w, h) in blocked_feedback_rects(screen_width, screen_height) {
+        ctx.rectangle(x, y, w, h);
+        let _ = ctx.fill();
+    }
 }

--- a/src/ui_text.rs
+++ b/src/ui_text.rs
@@ -81,9 +81,6 @@ struct UiLayoutCacheKey {
 
 struct CachedUiLayout {
     layout: pango::Layout,
-    ink_rect: pango::Rectangle,
-    logical_rect: pango::Rectangle,
-    baseline: f64,
     last_used: u64,
 }
 
@@ -106,20 +103,12 @@ impl UiLayoutCache {
         }
     }
 
-    fn get(
-        &mut self,
-        key: &UiLayoutCacheKey,
-    ) -> Option<(pango::Layout, pango::Rectangle, pango::Rectangle, f64)> {
+    fn get(&mut self, key: &UiLayoutCacheKey) -> Option<pango::Layout> {
         self.tick += 1;
         let tick = self.tick;
         let entry = self.entries.get_mut(key)?;
         entry.last_used = tick;
-        Some((
-            entry.layout.clone(),
-            entry.ink_rect,
-            entry.logical_rect,
-            entry.baseline,
-        ))
+        Some(entry.layout.clone())
     }
 
     fn insert(&mut self, key: UiLayoutCacheKey, mut entry: CachedUiLayout) {
@@ -199,10 +188,11 @@ pub(crate) fn text_layout(
     };
 
     let cached = UI_LAYOUT_CACHE.with(|cache| cache.borrow_mut().get(&key));
-    if let Some((layout, ink_rect, logical_rect, baseline)) = cached {
+    if let Some(layout) = cached {
         // Re-bind the cached layout to the current Cairo context (font options,
         // resolution, transformation) without re-shaping the text.
         pangocairo::functions::update_layout(ctx, &layout);
+        let (ink_rect, logical_rect, baseline) = layout_metrics(&layout);
         return UiTextLayout {
             layout,
             ink_rect,
@@ -219,17 +209,13 @@ pub(crate) fn text_layout(
         layout.set_width(wrap_units);
         layout.set_wrap(pango::WrapMode::WordChar);
     }
-    let (ink_rect, logical_rect) = layout.extents();
-    let baseline = layout.baseline() as f64 / pango::SCALE as f64;
+    let (ink_rect, logical_rect, baseline) = layout_metrics(&layout);
 
     UI_LAYOUT_CACHE.with(|cache| {
         cache.borrow_mut().insert(
             key,
             CachedUiLayout {
                 layout: layout.clone(),
-                ink_rect,
-                logical_rect,
-                baseline,
                 last_used: 0,
             },
         );
@@ -309,6 +295,12 @@ fn to_pango_units_f64(value: f64) -> f64 {
     scaled.clamp(i32::MIN as f64, i32::MAX as f64)
 }
 
+fn layout_metrics(layout: &pango::Layout) -> (pango::Rectangle, pango::Rectangle, f64) {
+    let (ink_rect, logical_rect) = layout.extents();
+    let baseline = layout.baseline() as f64 / pango::SCALE as f64;
+    (ink_rect, logical_rect, baseline)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,6 +312,31 @@ mod tests {
             weight: cairo::FontWeight::Bold,
             size,
         }
+    }
+
+    fn uncached_text_extents(
+        ctx: &cairo::Context,
+        style: UiTextStyle<'_>,
+        text: &str,
+        wrap_width: Option<f64>,
+    ) -> UiTextExtents {
+        let layout = pangocairo::functions::create_layout(ctx);
+        let font_desc = font_description(style);
+        layout.set_font_description(Some(&font_desc));
+        layout.set_text(text);
+        if let Some(width) = wrap_width {
+            layout.set_width(to_pango_units(width.max(1.0)));
+            layout.set_wrap(pango::WrapMode::WordChar);
+        }
+        let (ink_rect, logical_rect, baseline) = layout_metrics(&layout);
+        rect_to_extents(ink_rect, logical_rect, baseline)
+    }
+
+    fn assert_extents_eq(actual: UiTextExtents, expected: UiTextExtents) {
+        assert_eq!(actual.width(), expected.width());
+        assert_eq!(actual.height(), expected.height());
+        assert_eq!(actual.x_bearing(), expected.x_bearing());
+        assert_eq!(actual.y_bearing(), expected.y_bearing());
     }
 
     #[test]
@@ -334,6 +351,28 @@ mod tests {
         assert_eq!(first.height(), second.height());
         assert_eq!(first.x_bearing(), second.x_bearing());
         assert_eq!(first.y_bearing(), second.y_bearing());
+    }
+
+    #[test]
+    fn cached_layout_recomputes_extents_after_context_update() {
+        let first_surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 64, 64).unwrap();
+        let first_ctx = cairo::Context::new(&first_surface).unwrap();
+        let scaled_surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 64, 64).unwrap();
+        let scaled_ctx = cairo::Context::new(&scaled_surface).unwrap();
+        scaled_ctx.scale(2.0, 2.0);
+
+        let style = style(18.0);
+        let text = "cache scale";
+        let first = text_layout(&first_ctx, style, text, None).ink_extents();
+        let expected_scaled = uncached_text_extents(&scaled_ctx, style, text, None);
+        assert_ne!(
+            first.width(),
+            expected_scaled.width(),
+            "test setup must exercise context-sensitive text extents"
+        );
+
+        let cached_scaled = text_layout(&scaled_ctx, style, text, None).ink_extents();
+        assert_extents_eq(cached_scaled, expected_scaled);
     }
 
     #[test]

--- a/src/ui_text.rs
+++ b/src/ui_text.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct UiTextStyle<'a> {
     pub family: &'a str,
@@ -63,23 +66,175 @@ impl UiTextLayout {
     }
 }
 
+/// Cache key identifying a shaped UI text layout.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct UiLayoutCacheKey {
+    family: String,
+    slant: u8,
+    weight: u8,
+    /// Size in hundredths of a unit for stable hashing.
+    size_hundredths: i64,
+    /// Wrap width in pango units, or -1 for no wrap.
+    wrap_units: i32,
+    text: String,
+}
+
+struct CachedUiLayout {
+    layout: pango::Layout,
+    ink_rect: pango::Rectangle,
+    logical_rect: pango::Rectangle,
+    baseline: f64,
+    last_used: u64,
+}
+
+/// LRU cache for shaped Pango layouts. The UI layer re-renders every frame,
+/// but its text rarely changes; re-shaping (font itemization + HarfBuzz) is
+/// one of the most expensive per-frame CPU costs, so cache the shaped layout
+/// and re-bind it to the current Cairo context on reuse.
+struct UiLayoutCache {
+    entries: HashMap<UiLayoutCacheKey, CachedUiLayout>,
+    tick: u64,
+    max_entries: usize,
+}
+
+impl UiLayoutCache {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(max_entries),
+            tick: 0,
+            max_entries,
+        }
+    }
+
+    fn get(
+        &mut self,
+        key: &UiLayoutCacheKey,
+    ) -> Option<(pango::Layout, pango::Rectangle, pango::Rectangle, f64)> {
+        self.tick += 1;
+        let tick = self.tick;
+        let entry = self.entries.get_mut(key)?;
+        entry.last_used = tick;
+        Some((
+            entry.layout.clone(),
+            entry.ink_rect,
+            entry.logical_rect,
+            entry.baseline,
+        ))
+    }
+
+    fn insert(&mut self, key: UiLayoutCacheKey, mut entry: CachedUiLayout) {
+        self.tick += 1;
+        entry.last_used = self.tick;
+        // Evict least-recently-used entries. O(n) scan, but only on cache
+        // misses once the cache is full; hits stay O(1).
+        while self.entries.len() >= self.max_entries {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, e)| e.last_used)
+                .map(|(k, _)| k.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+        self.entries.insert(key, entry);
+    }
+}
+
+thread_local! {
+    static UI_LAYOUT_CACHE: RefCell<UiLayoutCache> = RefCell::new(UiLayoutCache::new(512));
+    /// Shared 1x1 surface + context for measuring text without a target surface.
+    static MEASUREMENT_CONTEXT: RefCell<Option<cairo::Context>> = const { RefCell::new(None) };
+}
+
+/// Measure UI text without a rendering context (e.g. for damage computation
+/// before a frame buffer exists). Goes through the same layout cache as
+/// `text_layout`, so measurements agree exactly with subsequent rendering.
+pub(crate) fn measure_text(
+    style: UiTextStyle<'_>,
+    text: &str,
+    wrap_width: Option<f64>,
+) -> Option<UiTextExtents> {
+    MEASUREMENT_CONTEXT.with(|cell| {
+        let mut ctx_ref = cell.borrow_mut();
+        if ctx_ref.is_none() {
+            let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 1, 1).ok()?;
+            *ctx_ref = cairo::Context::new(&surface).ok();
+        }
+        let ctx = ctx_ref.as_ref()?;
+        Some(text_layout(ctx, style, text, wrap_width).ink_extents())
+    })
+}
+
+fn slant_key(slant: cairo::FontSlant) -> u8 {
+    match slant {
+        cairo::FontSlant::Italic => 1,
+        cairo::FontSlant::Oblique => 2,
+        _ => 0,
+    }
+}
+
+fn weight_key(weight: cairo::FontWeight) -> u8 {
+    match weight {
+        cairo::FontWeight::Bold => 1,
+        _ => 0,
+    }
+}
+
 pub(crate) fn text_layout(
     ctx: &cairo::Context,
     style: UiTextStyle<'_>,
     text: &str,
     wrap_width: Option<f64>,
 ) -> UiTextLayout {
+    let wrap_units = wrap_width.map_or(-1, |width| to_pango_units(width.max(1.0)));
+    let key = UiLayoutCacheKey {
+        family: style.family.to_string(),
+        slant: slant_key(style.slant),
+        weight: weight_key(style.weight),
+        size_hundredths: (style.size * 100.0).round() as i64,
+        wrap_units,
+        text: text.to_string(),
+    };
+
+    let cached = UI_LAYOUT_CACHE.with(|cache| cache.borrow_mut().get(&key));
+    if let Some((layout, ink_rect, logical_rect, baseline)) = cached {
+        // Re-bind the cached layout to the current Cairo context (font options,
+        // resolution, transformation) without re-shaping the text.
+        pangocairo::functions::update_layout(ctx, &layout);
+        return UiTextLayout {
+            layout,
+            ink_rect,
+            logical_rect,
+            baseline,
+        };
+    }
+
     let layout = pangocairo::functions::create_layout(ctx);
     let font_desc = font_description(style);
     layout.set_font_description(Some(&font_desc));
     layout.set_text(text);
-    if let Some(width) = wrap_width {
-        let width = width.max(1.0);
-        layout.set_width(to_pango_units(width));
+    if wrap_units >= 0 {
+        layout.set_width(wrap_units);
         layout.set_wrap(pango::WrapMode::WordChar);
     }
     let (ink_rect, logical_rect) = layout.extents();
     let baseline = layout.baseline() as f64 / pango::SCALE as f64;
+
+    UI_LAYOUT_CACHE.with(|cache| {
+        cache.borrow_mut().insert(
+            key,
+            CachedUiLayout {
+                layout: layout.clone(),
+                ink_rect,
+                logical_rect,
+                baseline,
+                last_used: 0,
+            },
+        );
+    });
+
     UiTextLayout {
         layout,
         ink_rect,
@@ -152,4 +307,60 @@ fn to_pango_units(value: f64) -> i32 {
 fn to_pango_units_f64(value: f64) -> f64 {
     let scaled = value * pango::SCALE as f64;
     scaled.clamp(i32::MIN as f64, i32::MAX as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn style(size: f64) -> UiTextStyle<'static> {
+        UiTextStyle {
+            family: "Sans",
+            slant: cairo::FontSlant::Normal,
+            weight: cairo::FontWeight::Bold,
+            size,
+        }
+    }
+
+    #[test]
+    fn cached_layout_returns_identical_extents() {
+        let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 4, 4).unwrap();
+        let ctx = cairo::Context::new(&surface).unwrap();
+
+        let first = text_layout(&ctx, style(15.0), "cache me", None).ink_extents();
+        let second = text_layout(&ctx, style(15.0), "cache me", None).ink_extents();
+
+        assert_eq!(first.width(), second.width());
+        assert_eq!(first.height(), second.height());
+        assert_eq!(first.x_bearing(), second.x_bearing());
+        assert_eq!(first.y_bearing(), second.y_bearing());
+    }
+
+    #[test]
+    fn measure_text_matches_rendered_layout_extents() {
+        let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 4, 4).unwrap();
+        let ctx = cairo::Context::new(&surface).unwrap();
+
+        let measured = measure_text(style(16.0), "toast body", None).expect("measurement");
+        let rendered = text_layout(&ctx, style(16.0), "toast body", None).ink_extents();
+
+        assert_eq!(measured.width(), rendered.width());
+        assert_eq!(measured.height(), rendered.height());
+    }
+
+    #[test]
+    fn different_styles_produce_distinct_cache_entries() {
+        let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 4, 4).unwrap();
+        let ctx = cairo::Context::new(&surface).unwrap();
+
+        let small = text_layout(&ctx, style(10.0), "sized", None).ink_extents();
+        let large = text_layout(&ctx, style(30.0), "sized", None).ink_extents();
+        assert!(large.width() > small.width());
+
+        // Wrap width participates in the key: same text, different layouts.
+        let unwrapped = text_layout(&ctx, style(12.0), "wrap wrap wrap wrap", None).ink_extents();
+        let wrapped =
+            text_layout(&ctx, style(12.0), "wrap wrap wrap wrap", Some(40.0)).ink_extents();
+        assert!(wrapped.height() >= unwrapped.height());
+    }
 }

--- a/src/ui_text.rs
+++ b/src/ui_text.rs
@@ -363,13 +363,8 @@ mod tests {
 
         let style = style(18.0);
         let text = "cache scale";
-        let first = text_layout(&first_ctx, style, text, None).ink_extents();
+        let _ = text_layout(&first_ctx, style, text, None).ink_extents();
         let expected_scaled = uncached_text_extents(&scaled_ctx, style, text, None);
-        assert_ne!(
-            first.width(),
-            expected_scaled.width(),
-            "test setup must exercise context-sensitive text extents"
-        );
 
         let cached_scaled = text_layout(&scaled_ctx, style, text, None).ink_extents();
         assert_extents_eq(cached_scaled, expected_scaled);


### PR DESCRIPTION
## Summary

- Cache shaped Pango layouts for repeated UI text rendering, while refreshing context-sensitive metrics after `update_layout()`.
- Emit targeted damage for transient UI effects like toasts, preset feedback, blocked-action flashes, and text-edit glow instead of repainting the full surface.
- Memoize committed shape bounds on `DrawnShape` and route hot hit-test, selection, export, clipboard, and translation paths through the cached bounds.
- Add a panned canvas layer cache so solid-board pan frames can blit cached committed content instead of replaying every shape.

## Why

This targets the expensive render paths that show up on shape-heavy boards: repeated UI text shaping, full-surface damage from short-lived UI effects, per-frame shape bounds recomputation, and full committed-shape replay while panning.

Zoom, frozen-image backdrops, and paths that need direct rendering keep the existing behavior.