### PR TITLE
Add render pipeline perf diagnostics

### DIFF
--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -105,7 +105,10 @@ mod tests;
 type ScreencopyManager = wayland_protocols_wlr::screencopy::v1::client::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1;
 
 pub(in crate::backend::wayland) use self::buffer_damage::FullDamageReason;
-pub(in crate::backend::wayland) use self::perf::{PerfInputSource, PerfRenderSkipReason};
+pub(in crate::backend::wayland) use self::perf::{
+    PerfDamageDiagnostics, PerfFrameDamageContext, PerfInputSource, PerfRenderBreakdown,
+    PerfRenderProfileKind, PerfRenderSkipReason, damage_covers_logical_surface,
+};
 pub(super) use helpers::{
     color_log, damage_summary, debug_damage_logging_enabled, debug_toolbar_color_logging_enabled,
     debug_toolbar_drag_logging_enabled, drag_log, force_inline_toolbars_requested,

--- a/src/backend/wayland/state/buffer_damage.rs
+++ b/src/backend/wayland/state/buffer_damage.rs
@@ -37,6 +37,7 @@ pub(in crate::backend::wayland) enum FullDamageReason {
     Zoom,
     BoardPan,
     CanvasClear,
+    FirstRunOnboarding,
     EmptyDamageFallback,
     DamageRegionsCoverSurface,
     Unknown,
@@ -58,6 +59,7 @@ impl FullDamageReason {
             Self::Zoom => "zoom",
             Self::BoardPan => "board_pan",
             Self::CanvasClear => "canvas_clear",
+            Self::FirstRunOnboarding => "first_run_onboarding",
             Self::EmptyDamageFallback => "empty_damage_fallback",
             Self::DamageRegionsCoverSurface => "damage_regions_cover_surface",
             Self::Unknown => "unknown",
@@ -87,6 +89,8 @@ struct BufferDamage {
 pub(in crate::backend::wayland) struct BufferDamageReport {
     pub(in crate::backend::wayland) regions: Vec<Rect>,
     pub(in crate::backend::wayland) full_reason: Option<FullDamageReason>,
+    pub(in crate::backend::wayland) regions_before_merge: usize,
+    pub(in crate::backend::wayland) regions_after_merge: usize,
 }
 
 /// Tracks dirty regions for each buffer slot independently.
@@ -284,20 +288,28 @@ impl BufferDamageTracker {
                 return BufferDamageReport {
                     regions: vec![full],
                     full_reason: Some(full_reason.unwrap_or(FullDamageReason::Unknown)),
+                    regions_before_merge: 0,
+                    regions_after_merge: 0,
                 };
             }
             return BufferDamageReport {
                 regions: Vec::new(),
                 full_reason,
+                regions_before_merge: 0,
+                regions_after_merge: 0,
             };
         }
 
+        let regions_before_merge = regions.len();
         // Merge overlapping regions to reduce compositor work
         merge_damage_regions(&mut regions);
+        let regions_after_merge = regions.len();
 
         BufferDamageReport {
             regions,
             full_reason: None,
+            regions_before_merge,
+            regions_after_merge,
         }
     }
 
@@ -486,6 +498,8 @@ mod tests {
 
         let initial = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
         assert_eq!(initial.full_reason, Some(FullDamageReason::InitialFrame));
+        assert_eq!(initial.regions_before_merge, 0);
+        assert_eq!(initial.regions_after_merge, 0);
 
         let new_slot = tracker.take_buffer_damage_report(0x2000, 800, 600, TEST_GEN, TEST_SIZE);
         assert_eq!(new_slot.full_reason, Some(FullDamageReason::NewBufferSlot));
@@ -493,6 +507,22 @@ mod tests {
         tracker.mark_all_full(FullDamageReason::CanvasClear);
         let explicit = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
         assert_eq!(explicit.full_reason, Some(FullDamageReason::CanvasClear));
+    }
+
+    #[test]
+    fn report_exposes_merge_counts() {
+        let mut tracker = BufferDamageTracker::new(2);
+        let _ = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
+        tracker.mark_rect(Rect::new(0, 0, 10, 10).unwrap());
+        tracker.mark_rect(Rect::new(5, 0, 10, 10).unwrap());
+        tracker.mark_rect(Rect::new(100, 100, 10, 10).unwrap());
+
+        let report = tracker.take_buffer_damage_report(0x1000, 800, 600, TEST_GEN, TEST_SIZE);
+
+        assert_eq!(report.full_reason, None);
+        assert_eq!(report.regions_before_merge, 3);
+        assert_eq!(report.regions_after_merge, 2);
+        assert_eq!(report.regions.len(), 2);
     }
 
     #[test]

--- a/src/backend/wayland/state/onboarding/first_run.rs
+++ b/src/backend/wayland/state/onboarding/first_run.rs
@@ -1,6 +1,10 @@
 use crate::backend::wayland::state::WaylandState;
 use crate::config::{RadialMenuMouseBinding, keybindings::Action};
-use crate::input::{Key, state::UiToastKind};
+use crate::draw::DirtyFullReason;
+use crate::input::{
+    Key,
+    state::{PendingOnboardingUsage, UiToastKind},
+};
 use crate::onboarding::{FirstRunStep, OnboardingState};
 use crate::ui::{OnboardingCard, OnboardingChecklistItem};
 
@@ -51,7 +55,9 @@ impl WaylandState {
                 .set_ui_toast(UiToastKind::Info, "Skipped background mode setup for now.");
         }
 
-        self.input_state.dirty_tracker.mark_full();
+        self.input_state
+            .dirty_tracker
+            .mark_full_for(DirtyFullReason::FirstRunOnboarding);
         self.input_state.needs_redraw = true;
         true
     }
@@ -185,53 +191,47 @@ impl WaylandState {
         let toolbar_visible = self.input_state.toolbar_visible();
 
         let mut changed = false;
+        let mut first_run_ui_changed = false;
         let mut completed_now = false;
 
         {
             let state = self.onboarding.state_mut();
+            let first_run_active = state.first_run_active();
 
-            if usage.first_stroke_done && !state.first_stroke_done {
-                state.first_stroke_done = true;
+            if apply_persisted_usage_signals(state, &usage) {
                 changed = true;
-            }
-            if usage.first_undo_done && !state.first_undo_done {
-                state.first_undo_done = true;
-                changed = true;
-            }
-            if usage.used_toolbar_toggle && !state.used_toolbar_toggle {
-                state.used_toolbar_toggle = true;
-                changed = true;
-            }
-            if usage.used_radial_menu && !state.used_radial_menu {
-                state.used_radial_menu = true;
-                changed = true;
-            }
-            if usage.used_context_menu_right_click && !state.used_context_menu_right_click {
-                state.used_context_menu_right_click = true;
-                changed = true;
-            }
-            if usage.used_context_menu_keyboard && !state.used_context_menu_keyboard {
-                state.used_context_menu_keyboard = true;
-                changed = true;
-            }
-            if usage.used_help_overlay && !state.used_help_overlay {
-                state.used_help_overlay = true;
-                changed = true;
-            }
-            if usage.used_command_palette && !state.used_command_palette {
-                state.used_command_palette = true;
-                changed = true;
+                first_run_ui_changed |= first_run_active;
             }
 
-            if !state.first_run_active() {
+            if first_run_active {
+                if usage.first_stroke_done && !state.first_stroke_done {
+                    state.first_stroke_done = true;
+                    changed = true;
+                    first_run_ui_changed = true;
+                }
+                if usage.first_undo_done && !state.first_undo_done {
+                    state.first_undo_done = true;
+                    changed = true;
+                    first_run_ui_changed = true;
+                }
+                if usage.used_toolbar_toggle && !state.used_toolbar_toggle {
+                    state.used_toolbar_toggle = true;
+                    changed = true;
+                    first_run_ui_changed = true;
+                }
+            }
+
+            if !first_run_active {
                 if state.active_step.is_some() || state.quick_access_requires_toolbar {
                     state.active_step = None;
                     state.quick_access_requires_toolbar = false;
                     changed = true;
+                    first_run_ui_changed = true;
                 }
             } else if state.active_step.is_none() {
                 state.active_step = Some(FirstRunStep::BackgroundModeSetup);
                 changed = true;
+                first_run_ui_changed = true;
             }
 
             while let Some(step) = state.active_step {
@@ -242,6 +242,7 @@ impl WaylandState {
                         }
                         state.active_step = Some(FirstRunStep::WaitDraw);
                         changed = true;
+                        first_run_ui_changed = true;
                     }
                     FirstRunStep::WaitDraw => {
                         if !state.first_stroke_done {
@@ -249,6 +250,7 @@ impl WaylandState {
                         }
                         state.active_step = Some(FirstRunStep::DrawUndo);
                         changed = true;
+                        first_run_ui_changed = true;
                     }
                     FirstRunStep::DrawUndo => {
                         if !state.first_undo_done {
@@ -257,6 +259,7 @@ impl WaylandState {
                         state.active_step = Some(FirstRunStep::QuickAccess);
                         state.quick_access_requires_toolbar = !toolbar_visible;
                         changed = true;
+                        first_run_ui_changed = true;
                     }
                     FirstRunStep::QuickAccess => {
                         if !quick_access_completed(
@@ -272,6 +275,7 @@ impl WaylandState {
                         state.active_step = Some(FirstRunStep::Reference);
                         state.quick_access_requires_toolbar = false;
                         changed = true;
+                        first_run_ui_changed = true;
                     }
                     FirstRunStep::Reference => {
                         if !(state.used_help_overlay && state.used_command_palette) {
@@ -282,6 +286,7 @@ impl WaylandState {
                         state.active_step = None;
                         state.quick_access_requires_toolbar = false;
                         changed = true;
+                        first_run_ui_changed = true;
                         completed_now = true;
                         break;
                     }
@@ -291,7 +296,11 @@ impl WaylandState {
 
         if changed {
             self.onboarding.save();
-            self.input_state.dirty_tracker.mark_full();
+        }
+        if first_run_ui_changed {
+            self.input_state
+                .dirty_tracker
+                .mark_full_for(DirtyFullReason::FirstRunOnboarding);
             self.input_state.needs_redraw = true;
         }
         if completed_now && self.input_state.ui_toast.is_none() {
@@ -429,6 +438,36 @@ pub(super) fn quick_access_completed(
     }
 
     done
+}
+
+pub(super) fn apply_persisted_usage_signals(
+    state: &mut OnboardingState,
+    usage: &PendingOnboardingUsage,
+) -> bool {
+    let mut changed = false;
+
+    if usage.used_radial_menu && !state.used_radial_menu {
+        state.used_radial_menu = true;
+        changed = true;
+    }
+    if usage.used_context_menu_right_click && !state.used_context_menu_right_click {
+        state.used_context_menu_right_click = true;
+        changed = true;
+    }
+    if usage.used_context_menu_keyboard && !state.used_context_menu_keyboard {
+        state.used_context_menu_keyboard = true;
+        changed = true;
+    }
+    if usage.used_help_overlay && !state.used_help_overlay {
+        state.used_help_overlay = true;
+        changed = true;
+    }
+    if usage.used_command_palette && !state.used_command_palette {
+        state.used_command_palette = true;
+        changed = true;
+    }
+
+    changed
 }
 
 pub(super) fn background_mode_prompt_active(state: &OnboardingState, card_visible: bool) -> bool {

--- a/src/backend/wayland/state/onboarding/tests.rs
+++ b/src/backend/wayland/state/onboarding/tests.rs
@@ -1,10 +1,10 @@
 use super::first_run::{
-    background_mode_prompt_active, background_mode_prompt_choice,
+    apply_persisted_usage_signals, background_mode_prompt_active, background_mode_prompt_choice,
     first_run_card_hidden_by_ui_state, first_run_skip_allowed, first_run_step_eyebrow,
     quick_access_completed,
 };
 use crate::config::RadialMenuMouseBinding;
-use crate::input::Key;
+use crate::input::{Key, state::PendingOnboardingUsage};
 use crate::onboarding::{FirstRunStep, OnboardingState};
 
 #[test]
@@ -141,4 +141,34 @@ fn quick_access_blocks_when_toolbar_required_and_still_hidden() {
         false,
         false,
     ));
+}
+
+#[test]
+fn persisted_usage_signals_apply_after_first_run_completion() {
+    let mut state = OnboardingState {
+        first_run_completed: true,
+        first_run_skipped: true,
+        ..OnboardingState::default()
+    };
+    let usage = PendingOnboardingUsage {
+        first_stroke_done: true,
+        first_undo_done: true,
+        used_toolbar_toggle: true,
+        used_radial_menu: true,
+        used_context_menu_right_click: true,
+        used_context_menu_keyboard: true,
+        used_help_overlay: true,
+        used_command_palette: true,
+    };
+
+    assert!(apply_persisted_usage_signals(&mut state, &usage));
+
+    assert!(!state.first_stroke_done);
+    assert!(!state.first_undo_done);
+    assert!(!state.used_toolbar_toggle);
+    assert!(state.used_radial_menu);
+    assert!(state.used_context_menu_right_click);
+    assert!(state.used_context_menu_keyboard);
+    assert!(state.used_help_overlay);
+    assert!(state.used_command_palette);
 }

--- a/src/backend/wayland/state/perf.rs
+++ b/src/backend/wayland/state/perf.rs
@@ -1331,7 +1331,7 @@ mod tests {
     }
 
     #[test]
-    fn render_breakdown_summary_reports_stage_culling_and_cache_hits() {
+    fn render_breakdown_summary_reports_stage_culling_and_cache_use() {
         let base = Instant::now();
         let mut metrics = PerfMetrics::new(true);
         metrics.record_render_breakdown(PerfRenderBreakdown {
@@ -1346,7 +1346,7 @@ mod tests {
             shapes_rendered: 3,
             provisional_points: 42,
             render_profile: PerfRenderProfileKind::Canvas,
-            canvas_layer_cache_hit: true,
+            canvas_layer_cache_used: true,
         });
         let _ = metrics.commit_frame(
             frame_context(Some(Duration::from_millis(1)), 1.0, false, 2, None),
@@ -1375,7 +1375,7 @@ mod tests {
         assert_eq!(summary.shape_cull_pct, "75.00");
         assert_eq!(summary.provisional_points_max, 42);
         assert_eq!(summary.render_profile_frames, 1);
-        assert_eq!(summary.canvas_layer_cache_hits, 1);
+        assert_eq!(summary.canvas_layer_cache_used_frames, 1);
     }
 
     #[test]

--- a/src/backend/wayland/state/perf.rs
+++ b/src/backend/wayland/state/perf.rs
@@ -9,10 +9,32 @@ use log::info;
 use crate::{
     env_vars::PERF_LOG_ENV,
     input::{DrawingState, Tool},
-    util::Rect,
 };
 
 use super::{FullDamageReason, WaylandState};
+
+#[path = "perf_modules/damage_diagnostics.rs"]
+mod damage_diagnostics;
+#[path = "perf_modules/render_breakdown.rs"]
+mod render_breakdown;
+
+pub(in crate::backend::wayland) use damage_diagnostics::{
+    PerfDamageDiagnostics, PerfFrameDamageContext, damage_covers_logical_surface,
+};
+use damage_diagnostics::{
+    damage_area_pct, damage_covers_surface, effective_full_damage_reason,
+    format_effective_full_damage_reason, format_pct_hundredths, full_damage_source,
+    largest_region_area_pct_hundredths,
+};
+#[cfg(test)]
+use render_breakdown::PerfRenderStageDurations;
+pub(in crate::backend::wayland) use render_breakdown::{
+    PerfRenderBreakdown, PerfRenderProfileKind,
+};
+use render_breakdown::{
+    PerfRenderBreakdownAccumulator, PerfRenderBreakdownSummary, log_render_stage_frame,
+    log_render_stage_summary,
+};
 
 const MAX_PENDING_INPUT_SAMPLES: usize = 4096;
 const MAX_RECENT_LATENCIES: usize = 2048;
@@ -58,84 +80,6 @@ impl fmt::Display for PerfRenderSkipReason {
             Self::NoRedraw => f.write_str("no_redraw"),
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(in crate::backend::wayland) enum PerfRenderProfileKind {
-    #[default]
-    None,
-    Canvas,
-    Ui,
-    CanvasAndUi,
-}
-
-impl PerfRenderProfileKind {
-    pub(in crate::backend::wayland) fn from_flags(canvas: bool, ui: bool) -> Self {
-        match (canvas, ui) {
-            (false, false) => Self::None,
-            (true, false) => Self::Canvas,
-            (false, true) => Self::Ui,
-            (true, true) => Self::CanvasAndUi,
-        }
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::None => "none",
-            Self::Canvas => "canvas",
-            Self::Ui => "ui",
-            Self::CanvasAndUi => "canvas_and_ui",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(in crate::backend::wayland) struct PerfRenderStageDurations {
-    pub(in crate::backend::wayland) advance_animations: Duration,
-    pub(in crate::backend::wayland) dirty_collect: Duration,
-    pub(in crate::backend::wayland) buffer_acquire: Duration,
-    pub(in crate::backend::wayland) cairo_surface: Duration,
-    pub(in crate::backend::wayland) clear_clip: Duration,
-    pub(in crate::backend::wayland) background: Duration,
-    pub(in crate::backend::wayland) completed_shapes: Duration,
-    pub(in crate::backend::wayland) provisional: Duration,
-    pub(in crate::backend::wayland) ui: Duration,
-    pub(in crate::backend::wayland) render_profile: Duration,
-    pub(in crate::backend::wayland) damage_commit: Duration,
-    pub(in crate::backend::wayland) toolbar: Duration,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(in crate::backend::wayland) struct PerfRenderBreakdown {
-    pub(in crate::backend::wayland) stages: PerfRenderStageDurations,
-    pub(in crate::backend::wayland) surface_px: u64,
-    pub(in crate::backend::wayland) shapes_total: usize,
-    pub(in crate::backend::wayland) shapes_tested: usize,
-    pub(in crate::backend::wayland) shapes_rendered: usize,
-    pub(in crate::backend::wayland) provisional_points: usize,
-    pub(in crate::backend::wayland) render_profile: PerfRenderProfileKind,
-    pub(in crate::backend::wayland) canvas_layer_cache_hit: bool,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(in crate::backend::wayland) struct PerfDamageDiagnostics {
-    pub(in crate::backend::wayland) input_regions: usize,
-    pub(in crate::backend::wayland) input_full_reason: Option<FullDamageReason>,
-    pub(in crate::backend::wayland) input_covers_surface: bool,
-    pub(in crate::backend::wayland) buffer_regions_before_merge: usize,
-    pub(in crate::backend::wayland) buffer_regions_after_merge: usize,
-    pub(in crate::backend::wayland) buffer_covers_surface: bool,
-    pub(in crate::backend::wayland) final_single_surface_rect: bool,
-    pub(in crate::backend::wayland) largest_region_area_pct_hundredths: u32,
-}
-
-pub(in crate::backend::wayland) struct PerfFrameDamageContext<'a> {
-    pub(in crate::backend::wayland) damage_screen: &'a [Rect],
-    pub(in crate::backend::wayland) logical_width: u32,
-    pub(in crate::backend::wayland) logical_height: u32,
-    pub(in crate::backend::wayland) damage_rects: usize,
-    pub(in crate::backend::wayland) force_full_reason: Option<FullDamageReason>,
-    pub(in crate::backend::wayland) diagnostics: PerfDamageDiagnostics,
 }
 
 #[derive(Clone, Debug)]
@@ -274,24 +218,6 @@ struct PerfFramePacingSummary {
     skipped_no_redraw: u64,
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct PerfRenderBreakdownSummary {
-    frames: u64,
-    samples: u64,
-    dominant_stage: String,
-    dominant_stage_avg: Duration,
-    stage_avg: PerfRenderStageDurations,
-    surface_px_max: u64,
-    shapes_total_max: usize,
-    shapes_tested_avg: u64,
-    shapes_rendered_avg: u64,
-    shape_cull_pct: String,
-    provisional_points_max: usize,
-    render_profile_frames: u64,
-    canvas_layer_cache_hits: u64,
-}
-
 #[derive(Debug)]
 pub(super) struct PerfMetrics {
     enabled: bool,
@@ -311,15 +237,7 @@ pub(super) struct PerfMetrics {
     render_over_50ms: u64,
     full_damage_count: u64,
     full_damage_reasons: BTreeMap<FullDamageReason, u64>,
-    render_breakdown_frames: u64,
-    render_stage_totals: PerfRenderStageDurations,
-    render_surface_px_max: u64,
-    render_shapes_total_max: usize,
-    render_shapes_tested_total: u64,
-    render_shapes_rendered_total: u64,
-    render_provisional_points_max: usize,
-    render_profile_frames: u64,
-    canvas_layer_cache_hits: u64,
+    render_breakdown: PerfRenderBreakdownAccumulator,
     skipped_frame_callback_pending: u64,
     skipped_fps_cap: u64,
     skipped_surface_unconfigured: u64,
@@ -357,15 +275,7 @@ impl PerfMetrics {
             render_over_50ms: 0,
             full_damage_count: 0,
             full_damage_reasons: BTreeMap::new(),
-            render_breakdown_frames: 0,
-            render_stage_totals: PerfRenderStageDurations::default(),
-            render_surface_px_max: 0,
-            render_shapes_total_max: 0,
-            render_shapes_tested_total: 0,
-            render_shapes_rendered_total: 0,
-            render_provisional_points_max: 0,
-            render_profile_frames: 0,
-            canvas_layer_cache_hits: 0,
+            render_breakdown: PerfRenderBreakdownAccumulator::default(),
             skipped_frame_callback_pending: 0,
             skipped_fps_cap: 0,
             skipped_surface_unconfigured: 0,
@@ -498,7 +408,7 @@ impl PerfMetrics {
                 slow.skipped_fps_cap
             );
             if let Some(breakdown) = slow.render_breakdown.as_ref() {
-                log_render_stage_frame(slow, breakdown);
+                log_render_stage_frame(slow.frame, slow.render_ms, breakdown);
             }
         }
 
@@ -696,25 +606,7 @@ impl PerfMetrics {
     }
 
     fn count_render_breakdown(&mut self, breakdown: &PerfRenderBreakdown) {
-        self.render_breakdown_frames += 1;
-        add_stage_totals(&mut self.render_stage_totals, &breakdown.stages);
-        self.render_surface_px_max = self.render_surface_px_max.max(breakdown.surface_px);
-        self.render_shapes_total_max = self.render_shapes_total_max.max(breakdown.shapes_total);
-        self.render_shapes_tested_total = self
-            .render_shapes_tested_total
-            .saturating_add(breakdown.shapes_tested as u64);
-        self.render_shapes_rendered_total = self
-            .render_shapes_rendered_total
-            .saturating_add(breakdown.shapes_rendered as u64);
-        self.render_provisional_points_max = self
-            .render_provisional_points_max
-            .max(breakdown.provisional_points);
-        if breakdown.render_profile != PerfRenderProfileKind::None {
-            self.render_profile_frames += 1;
-        }
-        if breakdown.canvas_layer_cache_hit {
-            self.canvas_layer_cache_hits += 1;
-        }
+        self.render_breakdown.record(breakdown);
     }
 
     fn summary_due(&self, now: Instant) -> bool {
@@ -783,38 +675,8 @@ impl PerfMetrics {
     }
 
     fn build_render_breakdown_summary(&self) -> Option<PerfRenderBreakdownSummary> {
-        if self.render_breakdown_frames == 0 {
-            return None;
-        }
-
-        let stage_avg =
-            average_stage_durations(&self.render_stage_totals, self.render_breakdown_frames);
-        let (dominant_stage, dominant_stage_avg) = dominant_render_stage(&stage_avg);
-
-        Some(PerfRenderBreakdownSummary {
-            frames: self.render_frames_since_summary,
-            samples: self.render_breakdown_frames,
-            dominant_stage: dominant_stage.to_string(),
-            dominant_stage_avg,
-            stage_avg,
-            surface_px_max: self.render_surface_px_max,
-            shapes_total_max: self.render_shapes_total_max,
-            shapes_tested_avg: average_count(
-                self.render_shapes_tested_total,
-                self.render_breakdown_frames,
-            ),
-            shapes_rendered_avg: average_count(
-                self.render_shapes_rendered_total,
-                self.render_breakdown_frames,
-            ),
-            shape_cull_pct: shape_cull_pct_from_counts(
-                self.render_shapes_tested_total,
-                self.render_shapes_rendered_total,
-            ),
-            provisional_points_max: self.render_provisional_points_max,
-            render_profile_frames: self.render_profile_frames,
-            canvas_layer_cache_hits: self.canvas_layer_cache_hits,
-        })
+        self.render_breakdown
+            .build_summary(self.render_frames_since_summary)
     }
 
     fn reset_frame_pacing_summary(&mut self, now: Instant) {
@@ -825,15 +687,7 @@ impl PerfMetrics {
         self.render_over_50ms = 0;
         self.full_damage_count = 0;
         self.full_damage_reasons.clear();
-        self.render_breakdown_frames = 0;
-        self.render_stage_totals = PerfRenderStageDurations::default();
-        self.render_surface_px_max = 0;
-        self.render_shapes_total_max = 0;
-        self.render_shapes_tested_total = 0;
-        self.render_shapes_rendered_total = 0;
-        self.render_provisional_points_max = 0;
-        self.render_profile_frames = 0;
-        self.canvas_layer_cache_hits = 0;
+        self.render_breakdown.reset();
         self.skipped_frame_callback_pending = 0;
         self.skipped_fps_cap = 0;
         self.skipped_surface_unconfigured = 0;
@@ -1037,71 +891,6 @@ fn log_frame_pacing_summary(summary: &PerfFramePacingSummary, final_summary: boo
     );
 }
 
-fn log_render_stage_frame(slow: &PerfSlowRenderFrame, breakdown: &PerfRenderBreakdown) {
-    let dominant = dominant_render_stage(&breakdown.stages);
-    info!(
-        "perf.render_stage frame={} render_ms={} dominant_stage={} dominant_stage_ms={} advance_animations_ms={} dirty_collect_ms={} buffer_acquire_ms={} cairo_surface_ms={} clear_clip_ms={} background_ms={} completed_shapes_ms={} provisional_ms={} ui_ms={} render_profile_ms={} damage_commit_ms={} toolbar_ms={} surface_px={} shapes_total={} shapes_tested={} shapes_rendered={} shape_cull_pct={} provisional_points={} render_profile_active={} canvas_layer_cache_hit={}",
-        slow.frame,
-        slow.render_ms,
-        dominant.0,
-        format_duration_ms(dominant.1),
-        format_duration_ms(breakdown.stages.advance_animations),
-        format_duration_ms(breakdown.stages.dirty_collect),
-        format_duration_ms(breakdown.stages.buffer_acquire),
-        format_duration_ms(breakdown.stages.cairo_surface),
-        format_duration_ms(breakdown.stages.clear_clip),
-        format_duration_ms(breakdown.stages.background),
-        format_duration_ms(breakdown.stages.completed_shapes),
-        format_duration_ms(breakdown.stages.provisional),
-        format_duration_ms(breakdown.stages.ui),
-        format_duration_ms(breakdown.stages.render_profile),
-        format_duration_ms(breakdown.stages.damage_commit),
-        format_duration_ms(breakdown.stages.toolbar),
-        breakdown.surface_px,
-        breakdown.shapes_total,
-        breakdown.shapes_tested,
-        breakdown.shapes_rendered,
-        shape_cull_pct_from_counts(
-            breakdown.shapes_tested as u64,
-            breakdown.shapes_rendered as u64
-        ),
-        breakdown.provisional_points,
-        breakdown.render_profile.as_str(),
-        breakdown.canvas_layer_cache_hit
-    );
-}
-
-fn log_render_stage_summary(summary: &PerfRenderBreakdownSummary, final_summary: bool) {
-    info!(
-        "perf.render_stage_summary frames={} samples={} dominant_stage={} dominant_stage_avg_ms={} advance_animations_avg_ms={} dirty_collect_avg_ms={} buffer_acquire_avg_ms={} cairo_surface_avg_ms={} clear_clip_avg_ms={} background_avg_ms={} completed_shapes_avg_ms={} provisional_avg_ms={} ui_avg_ms={} render_profile_avg_ms={} damage_commit_avg_ms={} toolbar_avg_ms={} surface_px_max={} shapes_total_max={} shapes_tested_avg={} shapes_rendered_avg={} shape_cull_pct={} provisional_points_max={} render_profile_frames={} canvas_layer_cache_hits={} final={}",
-        summary.frames,
-        summary.samples,
-        summary.dominant_stage,
-        format_duration_ms(summary.dominant_stage_avg),
-        format_duration_ms(summary.stage_avg.advance_animations),
-        format_duration_ms(summary.stage_avg.dirty_collect),
-        format_duration_ms(summary.stage_avg.buffer_acquire),
-        format_duration_ms(summary.stage_avg.cairo_surface),
-        format_duration_ms(summary.stage_avg.clear_clip),
-        format_duration_ms(summary.stage_avg.background),
-        format_duration_ms(summary.stage_avg.completed_shapes),
-        format_duration_ms(summary.stage_avg.provisional),
-        format_duration_ms(summary.stage_avg.ui),
-        format_duration_ms(summary.stage_avg.render_profile),
-        format_duration_ms(summary.stage_avg.damage_commit),
-        format_duration_ms(summary.stage_avg.toolbar),
-        summary.surface_px_max,
-        summary.shapes_total_max,
-        summary.shapes_tested_avg,
-        summary.shapes_rendered_avg,
-        summary.shape_cull_pct,
-        summary.provisional_points_max,
-        summary.render_profile_frames,
-        summary.canvas_layer_cache_hits,
-        final_summary
-    );
-}
-
 fn perf_log_enabled_from_env() -> bool {
     std::env::var(PERF_LOG_ENV)
         .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "on" | "ON"))
@@ -1120,59 +909,11 @@ fn format_force_full_reason(reason: Option<FullDamageReason>) -> &'static str {
     reason.map_or("none", FullDamageReason::as_str)
 }
 
-fn format_effective_full_damage_reason(
-    full_damage: bool,
-    force_full_reason: Option<FullDamageReason>,
-) -> &'static str {
-    format_force_full_reason(effective_full_damage_reason(full_damage, force_full_reason))
-}
-
-fn effective_full_damage_reason(
-    full_damage: bool,
-    force_full_reason: Option<FullDamageReason>,
-) -> Option<FullDamageReason> {
-    if !full_damage {
-        None
-    } else {
-        Some(force_full_reason.unwrap_or(FullDamageReason::DamageRegionsCoverSurface))
-    }
-}
-
-fn full_damage_source(
-    full_damage: bool,
-    force_full_reason: Option<FullDamageReason>,
-    diagnostics: &PerfDamageDiagnostics,
-) -> &'static str {
-    if !full_damage {
-        "none"
-    } else if diagnostics.input_full_reason.is_some() {
-        "input_full"
-    } else if force_full_reason.is_some() {
-        "explicit_force"
-    } else if diagnostics.input_covers_surface {
-        "input_regions_cover_surface"
-    } else if diagnostics.buffer_covers_surface {
-        "buffer_regions_cover_surface"
-    } else if diagnostics.final_single_surface_rect {
-        "final_single_surface_rect"
-    } else {
-        "unknown"
-    }
-}
-
 fn format_pct(count: u64, total: u64) -> String {
     if total == 0 {
         return "0.00".to_string();
     }
     format!("{:.2}", (count as f64 / total as f64) * 100.0)
-}
-
-fn format_pct_hundredths(value: u32) -> String {
-    format!("{}.{:02}", value / 100, value % 100)
-}
-
-fn format_duration_ms(duration: Duration) -> String {
-    format!("{:.2}", duration.as_secs_f64() * 1000.0)
 }
 
 fn dominant_full_damage_reason(
@@ -1193,86 +934,6 @@ fn format_full_damage_reasons(reasons: &BTreeMap<FullDamageReason, u64>) -> Stri
         .map(|(reason, count)| format!("{}:{}", reason.as_str(), count))
         .collect::<Vec<_>>()
         .join(",")
-}
-
-fn add_stage_totals(total: &mut PerfRenderStageDurations, frame: &PerfRenderStageDurations) {
-    total.advance_animations = total
-        .advance_animations
-        .saturating_add(frame.advance_animations);
-    total.dirty_collect = total.dirty_collect.saturating_add(frame.dirty_collect);
-    total.buffer_acquire = total.buffer_acquire.saturating_add(frame.buffer_acquire);
-    total.cairo_surface = total.cairo_surface.saturating_add(frame.cairo_surface);
-    total.clear_clip = total.clear_clip.saturating_add(frame.clear_clip);
-    total.background = total.background.saturating_add(frame.background);
-    total.completed_shapes = total
-        .completed_shapes
-        .saturating_add(frame.completed_shapes);
-    total.provisional = total.provisional.saturating_add(frame.provisional);
-    total.ui = total.ui.saturating_add(frame.ui);
-    total.render_profile = total.render_profile.saturating_add(frame.render_profile);
-    total.damage_commit = total.damage_commit.saturating_add(frame.damage_commit);
-    total.toolbar = total.toolbar.saturating_add(frame.toolbar);
-}
-
-fn average_stage_durations(
-    total: &PerfRenderStageDurations,
-    samples: u64,
-) -> PerfRenderStageDurations {
-    PerfRenderStageDurations {
-        advance_animations: average_duration(total.advance_animations, samples),
-        dirty_collect: average_duration(total.dirty_collect, samples),
-        buffer_acquire: average_duration(total.buffer_acquire, samples),
-        cairo_surface: average_duration(total.cairo_surface, samples),
-        clear_clip: average_duration(total.clear_clip, samples),
-        background: average_duration(total.background, samples),
-        completed_shapes: average_duration(total.completed_shapes, samples),
-        provisional: average_duration(total.provisional, samples),
-        ui: average_duration(total.ui, samples),
-        render_profile: average_duration(total.render_profile, samples),
-        damage_commit: average_duration(total.damage_commit, samples),
-        toolbar: average_duration(total.toolbar, samples),
-    }
-}
-
-fn average_duration(total: Duration, samples: u64) -> Duration {
-    let nanos = total
-        .as_nanos()
-        .checked_div(u128::from(samples))
-        .unwrap_or(0);
-    Duration::from_nanos(nanos.min(u128::from(u64::MAX)) as u64)
-}
-
-fn average_count(total: u64, samples: u64) -> u64 {
-    total.checked_div(samples).unwrap_or(0)
-}
-
-fn dominant_render_stage(stages: &PerfRenderStageDurations) -> (&'static str, Duration) {
-    [
-        ("advance_animations", stages.advance_animations),
-        ("dirty_collect", stages.dirty_collect),
-        ("buffer_acquire", stages.buffer_acquire),
-        ("cairo_surface", stages.cairo_surface),
-        ("clear_clip", stages.clear_clip),
-        ("background", stages.background),
-        ("completed_shapes", stages.completed_shapes),
-        ("provisional", stages.provisional),
-        ("ui", stages.ui),
-        ("render_profile", stages.render_profile),
-        ("damage_commit", stages.damage_commit),
-        ("toolbar", stages.toolbar),
-    ]
-    .into_iter()
-    .max_by_key(|(_, duration)| *duration)
-    .unwrap_or(("none", Duration::ZERO))
-}
-
-fn shape_cull_pct_from_counts(tested: u64, rendered: u64) -> String {
-    if tested == 0 {
-        "n/a".to_string()
-    } else {
-        let culled = tested.saturating_sub(rendered);
-        format_pct(culled, tested)
-    }
 }
 
 fn frame_budget_duration(vsync_enabled: bool, max_fps_no_vsync: u32) -> Option<Duration> {
@@ -1296,70 +957,10 @@ fn percentile_nearest_rank(sorted_values: &[u64], percentile: u64) -> Option<u64
     sorted_values.get(index).copied()
 }
 
-fn damage_area_pct(damage: &[Rect], logical_width: u32, logical_height: u32) -> f64 {
-    let surface_area = u64::from(logical_width).saturating_mul(u64::from(logical_height));
-    if surface_area == 0 {
-        return 0.0;
-    }
-
-    let damage_area = damage
-        .iter()
-        .map(|rect| clamped_rect_area(*rect, logical_width, logical_height))
-        .sum::<u64>();
-    ((damage_area as f64 / surface_area as f64) * 100.0).min(100.0)
-}
-
-fn largest_region_area_pct_hundredths(
-    damage: &[Rect],
-    logical_width: u32,
-    logical_height: u32,
-) -> u32 {
-    let surface_area = u64::from(logical_width).saturating_mul(u64::from(logical_height));
-    if surface_area == 0 {
-        return 0;
-    }
-
-    let largest = damage
-        .iter()
-        .map(|rect| clamped_rect_area(*rect, logical_width, logical_height))
-        .max()
-        .unwrap_or(0);
-    let hundredths = (u128::from(largest) * 10_000) / u128::from(surface_area);
-    hundredths.min(10_000) as u32
-}
-
-fn damage_covers_surface(damage: &[Rect], logical_width: u32, logical_height: u32) -> bool {
-    let width = logical_width.min(i32::MAX as u32) as i32;
-    let height = logical_height.min(i32::MAX as u32) as i32;
-    damage_covers_logical_surface(damage, width, height)
-}
-
-pub(in crate::backend::wayland) fn damage_covers_logical_surface(
-    damage: &[Rect],
-    logical_width: i32,
-    logical_height: i32,
-) -> bool {
-    damage.iter().any(|rect| {
-        rect.x <= 0 && rect.y <= 0 && rect.width >= logical_width && rect.height >= logical_height
-    })
-}
-
-fn clamped_rect_area(rect: Rect, logical_width: u32, logical_height: u32) -> u64 {
-    let max_x = logical_width.min(i32::MAX as u32) as i32;
-    let max_y = logical_height.min(i32::MAX as u32) as i32;
-    let left = rect.x.clamp(0, max_x);
-    let top = rect.y.clamp(0, max_y);
-    let right = rect.x.saturating_add(rect.width).clamp(0, max_x);
-    let bottom = rect.y.saturating_add(rect.height).clamp(0, max_y);
-    if right <= left || bottom <= top {
-        return 0;
-    }
-    (right - left) as u64 * (bottom - top) as u64
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::Rect;
 
     fn record_sample(metrics: &mut PerfMetrics, received_at: Instant) {
         metrics.record_input_sample(

--- a/src/backend/wayland/state/perf.rs
+++ b/src/backend/wayland/state/perf.rs
@@ -60,6 +60,84 @@ impl fmt::Display for PerfRenderSkipReason {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum PerfRenderProfileKind {
+    #[default]
+    None,
+    Canvas,
+    Ui,
+    CanvasAndUi,
+}
+
+impl PerfRenderProfileKind {
+    pub(in crate::backend::wayland) fn from_flags(canvas: bool, ui: bool) -> Self {
+        match (canvas, ui) {
+            (false, false) => Self::None,
+            (true, false) => Self::Canvas,
+            (false, true) => Self::Ui,
+            (true, true) => Self::CanvasAndUi,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Canvas => "canvas",
+            Self::Ui => "ui",
+            Self::CanvasAndUi => "canvas_and_ui",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct PerfRenderStageDurations {
+    pub(in crate::backend::wayland) advance_animations: Duration,
+    pub(in crate::backend::wayland) dirty_collect: Duration,
+    pub(in crate::backend::wayland) buffer_acquire: Duration,
+    pub(in crate::backend::wayland) cairo_surface: Duration,
+    pub(in crate::backend::wayland) clear_clip: Duration,
+    pub(in crate::backend::wayland) background: Duration,
+    pub(in crate::backend::wayland) completed_shapes: Duration,
+    pub(in crate::backend::wayland) provisional: Duration,
+    pub(in crate::backend::wayland) ui: Duration,
+    pub(in crate::backend::wayland) render_profile: Duration,
+    pub(in crate::backend::wayland) damage_commit: Duration,
+    pub(in crate::backend::wayland) toolbar: Duration,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct PerfRenderBreakdown {
+    pub(in crate::backend::wayland) stages: PerfRenderStageDurations,
+    pub(in crate::backend::wayland) surface_px: u64,
+    pub(in crate::backend::wayland) shapes_total: usize,
+    pub(in crate::backend::wayland) shapes_tested: usize,
+    pub(in crate::backend::wayland) shapes_rendered: usize,
+    pub(in crate::backend::wayland) provisional_points: usize,
+    pub(in crate::backend::wayland) render_profile: PerfRenderProfileKind,
+    pub(in crate::backend::wayland) canvas_layer_cache_hit: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct PerfDamageDiagnostics {
+    pub(in crate::backend::wayland) input_regions: usize,
+    pub(in crate::backend::wayland) input_full_reason: Option<FullDamageReason>,
+    pub(in crate::backend::wayland) input_covers_surface: bool,
+    pub(in crate::backend::wayland) buffer_regions_before_merge: usize,
+    pub(in crate::backend::wayland) buffer_regions_after_merge: usize,
+    pub(in crate::backend::wayland) buffer_covers_surface: bool,
+    pub(in crate::backend::wayland) final_single_surface_rect: bool,
+    pub(in crate::backend::wayland) largest_region_area_pct_hundredths: u32,
+}
+
+pub(in crate::backend::wayland) struct PerfFrameDamageContext<'a> {
+    pub(in crate::backend::wayland) damage_screen: &'a [Rect],
+    pub(in crate::backend::wayland) logical_width: u32,
+    pub(in crate::backend::wayland) logical_height: u32,
+    pub(in crate::backend::wayland) damage_rects: usize,
+    pub(in crate::backend::wayland) force_full_reason: Option<FullDamageReason>,
+    pub(in crate::backend::wayland) diagnostics: PerfDamageDiagnostics,
+}
+
 #[derive(Clone, Debug)]
 struct PerfInputSample {
     received_at: Instant,
@@ -80,6 +158,7 @@ struct PerfFrameContext {
     full_damage: bool,
     damage_rects: usize,
     force_full_reason: Option<FullDamageReason>,
+    damage_diagnostics: PerfDamageDiagnostics,
 }
 
 impl Default for PerfFrameContext {
@@ -90,6 +169,7 @@ impl Default for PerfFrameContext {
             full_damage: false,
             damage_rects: 0,
             force_full_reason: None,
+            damage_diagnostics: PerfDamageDiagnostics::default(),
         }
     }
 }
@@ -118,6 +198,7 @@ struct PerfSlowFrame {
     render_ms: Option<u64>,
     dirty_area_pct: f64,
     full_damage: bool,
+    full_damage_reason: Option<FullDamageReason>,
     damage_rects: usize,
     dropped_input_samples: u64,
 }
@@ -140,6 +221,7 @@ struct PerfSummary {
 struct PerfFramePacingReport {
     slow_frame: Option<PerfSlowRenderFrame>,
     summary: Option<PerfFramePacingSummary>,
+    render_breakdown_summary: Option<PerfRenderBreakdownSummary>,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -147,6 +229,7 @@ struct PerfFramePacingReport {
 struct PerfFinalSummaryReport {
     input: Option<PerfSummary>,
     frame_pacing: Option<PerfFramePacingSummary>,
+    render_breakdown: Option<PerfRenderBreakdownSummary>,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -158,9 +241,11 @@ struct PerfSlowRenderFrame {
     vsync_enabled: bool,
     max_fps_no_vsync: u32,
     dirty_area_pct: f64,
+    render_breakdown: Option<PerfRenderBreakdown>,
     full_damage: bool,
     damage_rects: usize,
     force_full_reason: Option<FullDamageReason>,
+    damage_diagnostics: PerfDamageDiagnostics,
     keep_rendering: bool,
     skipped_frame_callback_pending: u64,
     skipped_fps_cap: u64,
@@ -189,6 +274,24 @@ struct PerfFramePacingSummary {
     skipped_no_redraw: u64,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PerfRenderBreakdownSummary {
+    frames: u64,
+    samples: u64,
+    dominant_stage: String,
+    dominant_stage_avg: Duration,
+    stage_avg: PerfRenderStageDurations,
+    surface_px_max: u64,
+    shapes_total_max: usize,
+    shapes_tested_avg: u64,
+    shapes_rendered_avg: u64,
+    shape_cull_pct: String,
+    provisional_points_max: usize,
+    render_profile_frames: u64,
+    canvas_layer_cache_hits: u64,
+}
+
 #[derive(Debug)]
 pub(super) struct PerfMetrics {
     enabled: bool,
@@ -197,6 +300,7 @@ pub(super) struct PerfMetrics {
     recent_render_ms: VecDeque<u64>,
     render_started_at: Option<Instant>,
     last_frame_context: Option<PerfFrameContext>,
+    last_render_breakdown: Option<PerfRenderBreakdown>,
     frames_since_summary: u64,
     samples_since_summary: u64,
     render_frame_id: u64,
@@ -207,6 +311,15 @@ pub(super) struct PerfMetrics {
     render_over_50ms: u64,
     full_damage_count: u64,
     full_damage_reasons: BTreeMap<FullDamageReason, u64>,
+    render_breakdown_frames: u64,
+    render_stage_totals: PerfRenderStageDurations,
+    render_surface_px_max: u64,
+    render_shapes_total_max: usize,
+    render_shapes_tested_total: u64,
+    render_shapes_rendered_total: u64,
+    render_provisional_points_max: usize,
+    render_profile_frames: u64,
+    canvas_layer_cache_hits: u64,
     skipped_frame_callback_pending: u64,
     skipped_fps_cap: u64,
     skipped_surface_unconfigured: u64,
@@ -233,6 +346,7 @@ impl PerfMetrics {
             recent_render_ms: VecDeque::new(),
             render_started_at: None,
             last_frame_context: None,
+            last_render_breakdown: None,
             frames_since_summary: 0,
             samples_since_summary: 0,
             render_frame_id: 0,
@@ -243,6 +357,15 @@ impl PerfMetrics {
             render_over_50ms: 0,
             full_damage_count: 0,
             full_damage_reasons: BTreeMap::new(),
+            render_breakdown_frames: 0,
+            render_stage_totals: PerfRenderStageDurations::default(),
+            render_surface_px_max: 0,
+            render_shapes_total_max: 0,
+            render_shapes_tested_total: 0,
+            render_shapes_rendered_total: 0,
+            render_provisional_points_max: 0,
+            render_profile_frames: 0,
+            canvas_layer_cache_hits: 0,
             skipped_frame_callback_pending: 0,
             skipped_fps_cap: 0,
             skipped_surface_unconfigured: 0,
@@ -262,6 +385,14 @@ impl PerfMetrics {
             return;
         }
         self.render_started_at = Some(now);
+        self.last_render_breakdown = None;
+    }
+
+    fn record_render_breakdown(&mut self, breakdown: PerfRenderBreakdown) {
+        if !self.enabled {
+            return;
+        }
+        self.last_render_breakdown = Some(breakdown);
     }
 
     fn record_render_skip(&mut self, reason: PerfRenderSkipReason) {
@@ -307,7 +438,11 @@ impl PerfMetrics {
         }
 
         let frame = self.last_frame_context.take().unwrap_or_default();
+        let render_breakdown = self.last_render_breakdown.take();
         self.count_full_damage(&frame);
+        if let Some(breakdown) = render_breakdown.as_ref() {
+            self.count_render_breakdown(breakdown);
+        }
         let budget = frame_budget_duration(vsync_enabled, max_fps_no_vsync);
         let slow_frame = if budget.is_some_and(|budget| render_duration > budget)
             || render_duration > SLOW_RENDER_FALLBACK
@@ -319,9 +454,11 @@ impl PerfMetrics {
                 vsync_enabled,
                 max_fps_no_vsync,
                 dirty_area_pct: frame.dirty_area_pct,
+                render_breakdown,
                 full_damage: frame.full_damage,
                 damage_rects: frame.damage_rects,
                 force_full_reason: frame.force_full_reason,
+                damage_diagnostics: frame.damage_diagnostics,
                 keep_rendering,
                 skipped_frame_callback_pending: self.skipped_frame_callback_pending,
                 skipped_fps_cap: self.skipped_fps_cap,
@@ -332,7 +469,7 @@ impl PerfMetrics {
 
         if let Some(slow) = slow_frame.as_ref() {
             info!(
-                "perf.slow_frame frame={} render_ms={} budget_ms={} vsync={} max_fps_no_vsync={} dirty_area_pct={:.2} full_damage={} force_full_reason={} damage_rects={} keep_rendering={} skipped_frame_callback_pending={} skipped_fps_cap={}",
+                "perf.slow_frame frame={} render_ms={} budget_ms={} vsync={} max_fps_no_vsync={} dirty_area_pct={:.2} full_damage={} full_damage_reason={} force_full_reason={} full_damage_source={} damage_rects={} input_damage_rects={} input_full_reason={} input_covers_surface={} buffer_damage_rects_before_merge={} buffer_damage_rects_after_merge={} buffer_covers_surface={} final_single_surface_rect={} largest_damage_rect_pct={} keep_rendering={} skipped_frame_callback_pending={} skipped_fps_cap={}",
                 slow.frame,
                 slow.render_ms,
                 format_optional_ms(slow.budget_ms),
@@ -340,26 +477,49 @@ impl PerfMetrics {
                 slow.max_fps_no_vsync,
                 slow.dirty_area_pct,
                 slow.full_damage,
+                format_effective_full_damage_reason(slow.full_damage, slow.force_full_reason),
                 format_force_full_reason(slow.force_full_reason),
+                full_damage_source(
+                    slow.full_damage,
+                    slow.force_full_reason,
+                    &slow.damage_diagnostics
+                ),
                 slow.damage_rects,
+                slow.damage_diagnostics.input_regions,
+                format_force_full_reason(slow.damage_diagnostics.input_full_reason),
+                slow.damage_diagnostics.input_covers_surface,
+                slow.damage_diagnostics.buffer_regions_before_merge,
+                slow.damage_diagnostics.buffer_regions_after_merge,
+                slow.damage_diagnostics.buffer_covers_surface,
+                slow.damage_diagnostics.final_single_surface_rect,
+                format_pct_hundredths(slow.damage_diagnostics.largest_region_area_pct_hundredths),
                 slow.keep_rendering,
                 slow.skipped_frame_callback_pending,
                 slow.skipped_fps_cap
             );
+            if let Some(breakdown) = slow.render_breakdown.as_ref() {
+                log_render_stage_frame(slow, breakdown);
+            }
         }
 
-        let summary = if self.frame_pacing_summary_due(render_finished_at) {
-            let summary = self.build_frame_pacing_summary();
-            log_frame_pacing_summary(&summary, false);
-            self.reset_frame_pacing_summary(render_finished_at);
-            Some(summary)
-        } else {
-            None
-        };
+        let (summary, render_breakdown_summary) =
+            if self.frame_pacing_summary_due(render_finished_at) {
+                let summary = self.build_frame_pacing_summary();
+                let render_breakdown_summary = self.build_render_breakdown_summary();
+                log_frame_pacing_summary(&summary, false);
+                if let Some(summary) = render_breakdown_summary.as_ref() {
+                    log_render_stage_summary(summary, false);
+                }
+                self.reset_frame_pacing_summary(render_finished_at);
+                (Some(summary), render_breakdown_summary)
+            } else {
+                (None, None)
+            };
 
         Some(PerfFramePacingReport {
             slow_frame,
             summary,
+            render_breakdown_summary,
         })
     }
 
@@ -446,6 +606,10 @@ impl PerfMetrics {
                 render_ms: render_duration.map(duration_ms),
                 dirty_area_pct: frame.dirty_area_pct,
                 full_damage: frame.full_damage,
+                full_damage_reason: effective_full_damage_reason(
+                    frame.full_damage,
+                    frame.force_full_reason,
+                ),
                 damage_rects: frame.damage_rects,
                 dropped_input_samples: self.dropped_input_samples,
             })
@@ -455,7 +619,7 @@ impl PerfMetrics {
 
         if let Some(slow) = slow_frame.as_ref() {
             info!(
-                "perf.slow_input_to_paint proxy=input_to_wayland_commit latency_ms={} source={} tool={:?} points={} pressure_sample={} screen=({}, {}) canvas=({}, {}) render_ms={} dirty_area_pct={:.2} full_damage={} damage_rects={} dropped_input_samples={}",
+                "perf.slow_input_to_paint proxy=input_to_wayland_commit latency_ms={} source={} tool={:?} points={} pressure_sample={} screen=({}, {}) canvas=({}, {}) render_ms={} dirty_area_pct={:.2} full_damage={} full_damage_reason={} damage_rects={} dropped_input_samples={}",
                 slow.latency_ms,
                 slow.source,
                 slow.tool,
@@ -468,6 +632,7 @@ impl PerfMetrics {
                 format_optional_ms(slow.render_ms),
                 slow.dirty_area_pct,
                 slow.full_damage,
+                format_force_full_reason(slow.full_damage_reason),
                 slow.damage_rects,
                 slow.dropped_input_samples
             );
@@ -528,6 +693,28 @@ impl PerfMetrics {
             .force_full_reason
             .unwrap_or(FullDamageReason::DamageRegionsCoverSurface);
         *self.full_damage_reasons.entry(reason).or_default() += 1;
+    }
+
+    fn count_render_breakdown(&mut self, breakdown: &PerfRenderBreakdown) {
+        self.render_breakdown_frames += 1;
+        add_stage_totals(&mut self.render_stage_totals, &breakdown.stages);
+        self.render_surface_px_max = self.render_surface_px_max.max(breakdown.surface_px);
+        self.render_shapes_total_max = self.render_shapes_total_max.max(breakdown.shapes_total);
+        self.render_shapes_tested_total = self
+            .render_shapes_tested_total
+            .saturating_add(breakdown.shapes_tested as u64);
+        self.render_shapes_rendered_total = self
+            .render_shapes_rendered_total
+            .saturating_add(breakdown.shapes_rendered as u64);
+        self.render_provisional_points_max = self
+            .render_provisional_points_max
+            .max(breakdown.provisional_points);
+        if breakdown.render_profile != PerfRenderProfileKind::None {
+            self.render_profile_frames += 1;
+        }
+        if breakdown.canvas_layer_cache_hit {
+            self.canvas_layer_cache_hits += 1;
+        }
     }
 
     fn summary_due(&self, now: Instant) -> bool {
@@ -595,6 +782,41 @@ impl PerfMetrics {
         }
     }
 
+    fn build_render_breakdown_summary(&self) -> Option<PerfRenderBreakdownSummary> {
+        if self.render_breakdown_frames == 0 {
+            return None;
+        }
+
+        let stage_avg =
+            average_stage_durations(&self.render_stage_totals, self.render_breakdown_frames);
+        let (dominant_stage, dominant_stage_avg) = dominant_render_stage(&stage_avg);
+
+        Some(PerfRenderBreakdownSummary {
+            frames: self.render_frames_since_summary,
+            samples: self.render_breakdown_frames,
+            dominant_stage: dominant_stage.to_string(),
+            dominant_stage_avg,
+            stage_avg,
+            surface_px_max: self.render_surface_px_max,
+            shapes_total_max: self.render_shapes_total_max,
+            shapes_tested_avg: average_count(
+                self.render_shapes_tested_total,
+                self.render_breakdown_frames,
+            ),
+            shapes_rendered_avg: average_count(
+                self.render_shapes_rendered_total,
+                self.render_breakdown_frames,
+            ),
+            shape_cull_pct: shape_cull_pct_from_counts(
+                self.render_shapes_tested_total,
+                self.render_shapes_rendered_total,
+            ),
+            provisional_points_max: self.render_provisional_points_max,
+            render_profile_frames: self.render_profile_frames,
+            canvas_layer_cache_hits: self.canvas_layer_cache_hits,
+        })
+    }
+
     fn reset_frame_pacing_summary(&mut self, now: Instant) {
         self.render_frames_since_summary = 0;
         self.render_over_8ms = 0;
@@ -603,6 +825,15 @@ impl PerfMetrics {
         self.render_over_50ms = 0;
         self.full_damage_count = 0;
         self.full_damage_reasons.clear();
+        self.render_breakdown_frames = 0;
+        self.render_stage_totals = PerfRenderStageDurations::default();
+        self.render_surface_px_max = 0;
+        self.render_shapes_total_max = 0;
+        self.render_shapes_tested_total = 0;
+        self.render_shapes_rendered_total = 0;
+        self.render_provisional_points_max = 0;
+        self.render_profile_frames = 0;
+        self.canvas_layer_cache_hits = 0;
         self.skipped_frame_callback_pending = 0;
         self.skipped_fps_cap = 0;
         self.skipped_surface_unconfigured = 0;
@@ -624,26 +855,42 @@ impl PerfMetrics {
             None
         };
 
-        let frame_pacing =
+        let (frame_pacing, render_breakdown) =
             if self.render_frames_since_summary > 0 && !self.recent_render_ms.is_empty() {
                 let summary = self.build_frame_pacing_summary();
+                let render_breakdown_summary = self.build_render_breakdown_summary();
                 log_frame_pacing_summary(&summary, true);
+                if let Some(summary) = render_breakdown_summary.as_ref() {
+                    log_render_stage_summary(summary, true);
+                }
                 self.reset_frame_pacing_summary(now);
-                Some(summary)
+                (Some(summary), render_breakdown_summary)
             } else {
-                None
+                (None, None)
             };
 
         PerfFinalSummaryReport {
             input,
             frame_pacing,
+            render_breakdown,
         }
     }
 }
 
 impl WaylandState {
+    pub(in crate::backend::wayland) fn perf_enabled(&self) -> bool {
+        self.perf.enabled()
+    }
+
     pub(in crate::backend::wayland) fn begin_perf_render(&mut self, now: Instant) {
         self.perf.begin_render(now);
+    }
+
+    pub(in crate::backend::wayland) fn record_perf_render_breakdown(
+        &mut self,
+        breakdown: PerfRenderBreakdown,
+    ) {
+        self.perf.record_render_breakdown(breakdown);
     }
 
     pub(in crate::backend::wayland) fn record_perf_render_skip(
@@ -700,23 +947,40 @@ impl WaylandState {
 
     pub(in crate::backend::wayland) fn commit_perf_frame(
         &mut self,
-        damage_screen: &[Rect],
-        logical_width: u32,
-        logical_height: u32,
-        damage_rects: usize,
-        force_full_reason: Option<FullDamageReason>,
+        damage: PerfFrameDamageContext<'_>,
         commit_at: Instant,
     ) {
         if !self.perf.enabled() {
             return;
         }
-        let full_damage = damage_covers_surface(damage_screen, logical_width, logical_height);
+        let full_damage = damage_covers_surface(
+            damage.damage_screen,
+            damage.logical_width,
+            damage.logical_height,
+        );
+        let mut damage_diagnostics = damage.diagnostics;
+        damage_diagnostics.final_single_surface_rect =
+            damage.damage_screen.len() == 1 && full_damage;
+        damage_diagnostics.largest_region_area_pct_hundredths = largest_region_area_pct_hundredths(
+            damage.damage_screen,
+            damage.logical_width,
+            damage.logical_height,
+        );
         let frame = PerfFrameContext {
             render_duration: None,
-            dirty_area_pct: damage_area_pct(damage_screen, logical_width, logical_height),
+            dirty_area_pct: damage_area_pct(
+                damage.damage_screen,
+                damage.logical_width,
+                damage.logical_height,
+            ),
             full_damage,
-            damage_rects,
-            force_full_reason: if full_damage { force_full_reason } else { None },
+            damage_rects: damage.damage_rects,
+            force_full_reason: if full_damage {
+                damage.force_full_reason
+            } else {
+                None
+            },
+            damage_diagnostics,
         };
         let _ = self.perf.commit_frame(frame, commit_at);
     }
@@ -773,6 +1037,71 @@ fn log_frame_pacing_summary(summary: &PerfFramePacingSummary, final_summary: boo
     );
 }
 
+fn log_render_stage_frame(slow: &PerfSlowRenderFrame, breakdown: &PerfRenderBreakdown) {
+    let dominant = dominant_render_stage(&breakdown.stages);
+    info!(
+        "perf.render_stage frame={} render_ms={} dominant_stage={} dominant_stage_ms={} advance_animations_ms={} dirty_collect_ms={} buffer_acquire_ms={} cairo_surface_ms={} clear_clip_ms={} background_ms={} completed_shapes_ms={} provisional_ms={} ui_ms={} render_profile_ms={} damage_commit_ms={} toolbar_ms={} surface_px={} shapes_total={} shapes_tested={} shapes_rendered={} shape_cull_pct={} provisional_points={} render_profile_active={} canvas_layer_cache_hit={}",
+        slow.frame,
+        slow.render_ms,
+        dominant.0,
+        format_duration_ms(dominant.1),
+        format_duration_ms(breakdown.stages.advance_animations),
+        format_duration_ms(breakdown.stages.dirty_collect),
+        format_duration_ms(breakdown.stages.buffer_acquire),
+        format_duration_ms(breakdown.stages.cairo_surface),
+        format_duration_ms(breakdown.stages.clear_clip),
+        format_duration_ms(breakdown.stages.background),
+        format_duration_ms(breakdown.stages.completed_shapes),
+        format_duration_ms(breakdown.stages.provisional),
+        format_duration_ms(breakdown.stages.ui),
+        format_duration_ms(breakdown.stages.render_profile),
+        format_duration_ms(breakdown.stages.damage_commit),
+        format_duration_ms(breakdown.stages.toolbar),
+        breakdown.surface_px,
+        breakdown.shapes_total,
+        breakdown.shapes_tested,
+        breakdown.shapes_rendered,
+        shape_cull_pct_from_counts(
+            breakdown.shapes_tested as u64,
+            breakdown.shapes_rendered as u64
+        ),
+        breakdown.provisional_points,
+        breakdown.render_profile.as_str(),
+        breakdown.canvas_layer_cache_hit
+    );
+}
+
+fn log_render_stage_summary(summary: &PerfRenderBreakdownSummary, final_summary: bool) {
+    info!(
+        "perf.render_stage_summary frames={} samples={} dominant_stage={} dominant_stage_avg_ms={} advance_animations_avg_ms={} dirty_collect_avg_ms={} buffer_acquire_avg_ms={} cairo_surface_avg_ms={} clear_clip_avg_ms={} background_avg_ms={} completed_shapes_avg_ms={} provisional_avg_ms={} ui_avg_ms={} render_profile_avg_ms={} damage_commit_avg_ms={} toolbar_avg_ms={} surface_px_max={} shapes_total_max={} shapes_tested_avg={} shapes_rendered_avg={} shape_cull_pct={} provisional_points_max={} render_profile_frames={} canvas_layer_cache_hits={} final={}",
+        summary.frames,
+        summary.samples,
+        summary.dominant_stage,
+        format_duration_ms(summary.dominant_stage_avg),
+        format_duration_ms(summary.stage_avg.advance_animations),
+        format_duration_ms(summary.stage_avg.dirty_collect),
+        format_duration_ms(summary.stage_avg.buffer_acquire),
+        format_duration_ms(summary.stage_avg.cairo_surface),
+        format_duration_ms(summary.stage_avg.clear_clip),
+        format_duration_ms(summary.stage_avg.background),
+        format_duration_ms(summary.stage_avg.completed_shapes),
+        format_duration_ms(summary.stage_avg.provisional),
+        format_duration_ms(summary.stage_avg.ui),
+        format_duration_ms(summary.stage_avg.render_profile),
+        format_duration_ms(summary.stage_avg.damage_commit),
+        format_duration_ms(summary.stage_avg.toolbar),
+        summary.surface_px_max,
+        summary.shapes_total_max,
+        summary.shapes_tested_avg,
+        summary.shapes_rendered_avg,
+        summary.shape_cull_pct,
+        summary.provisional_points_max,
+        summary.render_profile_frames,
+        summary.canvas_layer_cache_hits,
+        final_summary
+    );
+}
+
 fn perf_log_enabled_from_env() -> bool {
     std::env::var(PERF_LOG_ENV)
         .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "on" | "ON"))
@@ -791,11 +1120,59 @@ fn format_force_full_reason(reason: Option<FullDamageReason>) -> &'static str {
     reason.map_or("none", FullDamageReason::as_str)
 }
 
+fn format_effective_full_damage_reason(
+    full_damage: bool,
+    force_full_reason: Option<FullDamageReason>,
+) -> &'static str {
+    format_force_full_reason(effective_full_damage_reason(full_damage, force_full_reason))
+}
+
+fn effective_full_damage_reason(
+    full_damage: bool,
+    force_full_reason: Option<FullDamageReason>,
+) -> Option<FullDamageReason> {
+    if !full_damage {
+        None
+    } else {
+        Some(force_full_reason.unwrap_or(FullDamageReason::DamageRegionsCoverSurface))
+    }
+}
+
+fn full_damage_source(
+    full_damage: bool,
+    force_full_reason: Option<FullDamageReason>,
+    diagnostics: &PerfDamageDiagnostics,
+) -> &'static str {
+    if !full_damage {
+        "none"
+    } else if diagnostics.input_full_reason.is_some() {
+        "input_full"
+    } else if force_full_reason.is_some() {
+        "explicit_force"
+    } else if diagnostics.input_covers_surface {
+        "input_regions_cover_surface"
+    } else if diagnostics.buffer_covers_surface {
+        "buffer_regions_cover_surface"
+    } else if diagnostics.final_single_surface_rect {
+        "final_single_surface_rect"
+    } else {
+        "unknown"
+    }
+}
+
 fn format_pct(count: u64, total: u64) -> String {
     if total == 0 {
         return "0.00".to_string();
     }
     format!("{:.2}", (count as f64 / total as f64) * 100.0)
+}
+
+fn format_pct_hundredths(value: u32) -> String {
+    format!("{}.{:02}", value / 100, value % 100)
+}
+
+fn format_duration_ms(duration: Duration) -> String {
+    format!("{:.2}", duration.as_secs_f64() * 1000.0)
 }
 
 fn dominant_full_damage_reason(
@@ -816,6 +1193,86 @@ fn format_full_damage_reasons(reasons: &BTreeMap<FullDamageReason, u64>) -> Stri
         .map(|(reason, count)| format!("{}:{}", reason.as_str(), count))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn add_stage_totals(total: &mut PerfRenderStageDurations, frame: &PerfRenderStageDurations) {
+    total.advance_animations = total
+        .advance_animations
+        .saturating_add(frame.advance_animations);
+    total.dirty_collect = total.dirty_collect.saturating_add(frame.dirty_collect);
+    total.buffer_acquire = total.buffer_acquire.saturating_add(frame.buffer_acquire);
+    total.cairo_surface = total.cairo_surface.saturating_add(frame.cairo_surface);
+    total.clear_clip = total.clear_clip.saturating_add(frame.clear_clip);
+    total.background = total.background.saturating_add(frame.background);
+    total.completed_shapes = total
+        .completed_shapes
+        .saturating_add(frame.completed_shapes);
+    total.provisional = total.provisional.saturating_add(frame.provisional);
+    total.ui = total.ui.saturating_add(frame.ui);
+    total.render_profile = total.render_profile.saturating_add(frame.render_profile);
+    total.damage_commit = total.damage_commit.saturating_add(frame.damage_commit);
+    total.toolbar = total.toolbar.saturating_add(frame.toolbar);
+}
+
+fn average_stage_durations(
+    total: &PerfRenderStageDurations,
+    samples: u64,
+) -> PerfRenderStageDurations {
+    PerfRenderStageDurations {
+        advance_animations: average_duration(total.advance_animations, samples),
+        dirty_collect: average_duration(total.dirty_collect, samples),
+        buffer_acquire: average_duration(total.buffer_acquire, samples),
+        cairo_surface: average_duration(total.cairo_surface, samples),
+        clear_clip: average_duration(total.clear_clip, samples),
+        background: average_duration(total.background, samples),
+        completed_shapes: average_duration(total.completed_shapes, samples),
+        provisional: average_duration(total.provisional, samples),
+        ui: average_duration(total.ui, samples),
+        render_profile: average_duration(total.render_profile, samples),
+        damage_commit: average_duration(total.damage_commit, samples),
+        toolbar: average_duration(total.toolbar, samples),
+    }
+}
+
+fn average_duration(total: Duration, samples: u64) -> Duration {
+    let nanos = total
+        .as_nanos()
+        .checked_div(u128::from(samples))
+        .unwrap_or(0);
+    Duration::from_nanos(nanos.min(u128::from(u64::MAX)) as u64)
+}
+
+fn average_count(total: u64, samples: u64) -> u64 {
+    total.checked_div(samples).unwrap_or(0)
+}
+
+fn dominant_render_stage(stages: &PerfRenderStageDurations) -> (&'static str, Duration) {
+    [
+        ("advance_animations", stages.advance_animations),
+        ("dirty_collect", stages.dirty_collect),
+        ("buffer_acquire", stages.buffer_acquire),
+        ("cairo_surface", stages.cairo_surface),
+        ("clear_clip", stages.clear_clip),
+        ("background", stages.background),
+        ("completed_shapes", stages.completed_shapes),
+        ("provisional", stages.provisional),
+        ("ui", stages.ui),
+        ("render_profile", stages.render_profile),
+        ("damage_commit", stages.damage_commit),
+        ("toolbar", stages.toolbar),
+    ]
+    .into_iter()
+    .max_by_key(|(_, duration)| *duration)
+    .unwrap_or(("none", Duration::ZERO))
+}
+
+fn shape_cull_pct_from_counts(tested: u64, rendered: u64) -> String {
+    if tested == 0 {
+        "n/a".to_string()
+    } else {
+        let culled = tested.saturating_sub(rendered);
+        format_pct(culled, tested)
+    }
 }
 
 fn frame_budget_duration(vsync_enabled: bool, max_fps_no_vsync: u32) -> Option<Duration> {
@@ -852,12 +1309,39 @@ fn damage_area_pct(damage: &[Rect], logical_width: u32, logical_height: u32) -> 
     ((damage_area as f64 / surface_area as f64) * 100.0).min(100.0)
 }
 
+fn largest_region_area_pct_hundredths(
+    damage: &[Rect],
+    logical_width: u32,
+    logical_height: u32,
+) -> u32 {
+    let surface_area = u64::from(logical_width).saturating_mul(u64::from(logical_height));
+    if surface_area == 0 {
+        return 0;
+    }
+
+    let largest = damage
+        .iter()
+        .map(|rect| clamped_rect_area(*rect, logical_width, logical_height))
+        .max()
+        .unwrap_or(0);
+    let hundredths = (u128::from(largest) * 10_000) / u128::from(surface_area);
+    hundredths.min(10_000) as u32
+}
+
 fn damage_covers_surface(damage: &[Rect], logical_width: u32, logical_height: u32) -> bool {
     let width = logical_width.min(i32::MAX as u32) as i32;
     let height = logical_height.min(i32::MAX as u32) as i32;
-    damage
-        .iter()
-        .any(|rect| rect.x <= 0 && rect.y <= 0 && rect.width >= width && rect.height >= height)
+    damage_covers_logical_surface(damage, width, height)
+}
+
+pub(in crate::backend::wayland) fn damage_covers_logical_surface(
+    damage: &[Rect],
+    logical_width: i32,
+    logical_height: i32,
+) -> bool {
+    damage.iter().any(|rect| {
+        rect.x <= 0 && rect.y <= 0 && rect.width >= logical_width && rect.height >= logical_height
+    })
 }
 
 fn clamped_rect_area(rect: Rect, logical_width: u32, logical_height: u32) -> u64 {
@@ -891,6 +1375,23 @@ mod tests {
         );
     }
 
+    fn frame_context(
+        render_duration: Option<Duration>,
+        dirty_area_pct: f64,
+        full_damage: bool,
+        damage_rects: usize,
+        force_full_reason: Option<FullDamageReason>,
+    ) -> PerfFrameContext {
+        PerfFrameContext {
+            render_duration,
+            dirty_area_pct,
+            full_damage,
+            damage_rects,
+            force_full_reason,
+            damage_diagnostics: PerfDamageDiagnostics::default(),
+        }
+    }
+
     #[test]
     fn percentile_uses_nearest_rank() {
         let values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -908,13 +1409,7 @@ mod tests {
 
         record_sample(&mut metrics, base);
         let report = metrics.commit_frame(
-            PerfFrameContext {
-                render_duration: Some(Duration::from_millis(2)),
-                dirty_area_pct: 1.0,
-                full_damage: false,
-                damage_rects: 1,
-                force_full_reason: None,
-            },
+            frame_context(Some(Duration::from_millis(2)), 1.0, false, 1, None),
             base + Duration::from_millis(16),
         );
 
@@ -943,13 +1438,7 @@ mod tests {
 
         let report = metrics
             .commit_frame(
-                PerfFrameContext {
-                    render_duration: None,
-                    dirty_area_pct: 2.5,
-                    full_damage: false,
-                    damage_rects: 3,
-                    force_full_reason: None,
-                },
+                frame_context(None, 2.5, false, 3, None),
                 base + Duration::from_millis(70),
             )
             .expect("enabled metrics should report commits");
@@ -990,13 +1479,7 @@ mod tests {
                 commit_at - Duration::from_millis(frame + 1),
             );
             let report = metrics.commit_frame(
-                PerfFrameContext {
-                    render_duration: Some(Duration::from_millis(1)),
-                    dirty_area_pct: 0.5,
-                    full_damage: false,
-                    damage_rects: 1,
-                    force_full_reason: None,
-                },
+                frame_context(Some(Duration::from_millis(1)), 0.5, false, 1, None),
                 commit_at,
             );
             if frame + 1 < SUMMARY_FRAME_INTERVAL {
@@ -1020,13 +1503,7 @@ mod tests {
         let mut metrics = PerfMetrics::new(true);
         record_sample(&mut metrics, base);
         let first_report = metrics.commit_frame(
-            PerfFrameContext {
-                render_duration: Some(Duration::from_millis(1)),
-                dirty_area_pct: 0.5,
-                full_damage: false,
-                damage_rects: 1,
-                force_full_reason: None,
-            },
+            frame_context(Some(Duration::from_millis(1)), 0.5, false, 1, None),
             base + Duration::from_millis(10),
         );
         assert!(first_report.and_then(|report| report.summary).is_none());
@@ -1034,13 +1511,7 @@ mod tests {
         record_sample(&mut metrics, base + Duration::from_secs(5));
         let second_report = metrics
             .commit_frame(
-                PerfFrameContext {
-                    render_duration: Some(Duration::from_millis(1)),
-                    dirty_area_pct: 0.5,
-                    full_damage: false,
-                    damage_rects: 1,
-                    force_full_reason: None,
-                },
+                frame_context(Some(Duration::from_millis(1)), 0.5, false, 1, None),
                 base + Duration::from_secs(5) + Duration::from_millis(20),
             )
             .expect("enabled metrics should report commits");
@@ -1059,13 +1530,7 @@ mod tests {
 
         record_sample(&mut metrics, base);
         let _ = metrics.commit_frame(
-            PerfFrameContext {
-                render_duration: Some(Duration::from_millis(2)),
-                dirty_area_pct: 100.0,
-                full_damage: true,
-                damage_rects: 1,
-                force_full_reason: None,
-            },
+            frame_context(Some(Duration::from_millis(2)), 100.0, true, 1, None),
             base + Duration::from_millis(9),
         );
         let _ = metrics.record_render_complete(
@@ -1110,13 +1575,13 @@ mod tests {
         let base = Instant::now();
         let mut metrics = PerfMetrics::new(true);
         let _ = metrics.commit_frame(
-            PerfFrameContext {
-                render_duration: Some(Duration::from_millis(1)),
-                dirty_area_pct: 42.0,
-                full_damage: true,
-                damage_rects: 2,
-                force_full_reason: Some(FullDamageReason::CanvasClear),
-            },
+            frame_context(
+                Some(Duration::from_millis(1)),
+                42.0,
+                true,
+                2,
+                Some(FullDamageReason::CanvasClear),
+            ),
             base,
         );
 
@@ -1150,13 +1615,13 @@ mod tests {
             let duration = Duration::from_millis(frame + 1);
             if frame % 40 == 0 {
                 let _ = metrics.commit_frame(
-                    PerfFrameContext {
-                        render_duration: Some(Duration::from_millis(1)),
-                        dirty_area_pct: 100.0,
-                        full_damage: true,
-                        damage_rects: 1,
-                        force_full_reason: Some(FullDamageReason::CanvasClear),
-                    },
+                    frame_context(
+                        Some(Duration::from_millis(1)),
+                        100.0,
+                        true,
+                        1,
+                        Some(FullDamageReason::CanvasClear),
+                    ),
                     started_at,
                 );
             }
@@ -1198,13 +1663,7 @@ mod tests {
                 1 | 2 => None,
                 _ => {
                     let _ = metrics.commit_frame(
-                        PerfFrameContext {
-                            render_duration: Some(Duration::from_millis(1)),
-                            dirty_area_pct: 0.5,
-                            full_damage: false,
-                            damage_rects: 1,
-                            force_full_reason: None,
-                        },
+                        frame_context(Some(Duration::from_millis(1)), 0.5, false, 1, None),
                         started_at,
                     );
                     let report = metrics.record_render_complete(
@@ -1230,13 +1689,13 @@ mod tests {
             };
 
             let _ = metrics.commit_frame(
-                PerfFrameContext {
-                    render_duration: Some(Duration::from_millis(1)),
-                    dirty_area_pct: 100.0,
-                    full_damage: true,
-                    damage_rects: 1,
+                frame_context(
+                    Some(Duration::from_millis(1)),
+                    100.0,
+                    true,
+                    1,
                     force_full_reason,
-                },
+                ),
                 started_at,
             );
             let report = metrics.record_render_complete(
@@ -1248,6 +1707,74 @@ mod tests {
             );
             assert!(report.and_then(|report| report.summary).is_none());
         }
+    }
+
+    #[test]
+    fn full_damage_source_prefers_input_full_over_generic_force() {
+        let diagnostics = PerfDamageDiagnostics {
+            input_full_reason: Some(FullDamageReason::FirstRunOnboarding),
+            input_covers_surface: true,
+            buffer_covers_surface: true,
+            final_single_surface_rect: true,
+            ..PerfDamageDiagnostics::default()
+        };
+
+        assert_eq!(
+            full_damage_source(
+                true,
+                Some(FullDamageReason::FirstRunOnboarding),
+                &diagnostics
+            ),
+            "input_full"
+        );
+    }
+
+    #[test]
+    fn render_breakdown_summary_reports_stage_culling_and_cache_hits() {
+        let base = Instant::now();
+        let mut metrics = PerfMetrics::new(true);
+        metrics.record_render_breakdown(PerfRenderBreakdown {
+            stages: PerfRenderStageDurations {
+                completed_shapes: Duration::from_millis(9),
+                provisional: Duration::from_millis(3),
+                ..PerfRenderStageDurations::default()
+            },
+            surface_px: 2_000_000,
+            shapes_total: 20,
+            shapes_tested: 12,
+            shapes_rendered: 3,
+            provisional_points: 42,
+            render_profile: PerfRenderProfileKind::Canvas,
+            canvas_layer_cache_hit: true,
+        });
+        let _ = metrics.commit_frame(
+            frame_context(Some(Duration::from_millis(1)), 1.0, false, 2, None),
+            base,
+        );
+        let _ = metrics.record_render_complete(
+            base,
+            base + Duration::from_millis(12),
+            false,
+            120,
+            false,
+        );
+
+        let report = metrics.flush_pending_summaries(base + Duration::from_millis(20));
+        let summary = report
+            .render_breakdown
+            .expect("render breakdown summary should flush");
+
+        assert_eq!(summary.samples, 1);
+        assert_eq!(summary.dominant_stage, "completed_shapes");
+        assert_eq!(summary.dominant_stage_avg, Duration::from_millis(9));
+        assert_eq!(summary.surface_px_max, 2_000_000);
+        assert_eq!(summary.shapes_total_max, 20);
+        assert_eq!(summary.shapes_tested_avg, 12);
+        assert_eq!(summary.shapes_rendered_avg, 3);
+        assert_eq!(summary.shape_cull_pct, "75.00");
+        assert_eq!(summary.provisional_points_max, 42);
+        assert_eq!(summary.render_profile_frames, 1);
+        assert_eq!(summary.canvas_layer_cache_hits, 1);
     }
 
     #[test]

--- a/src/backend/wayland/state/perf_modules/damage_diagnostics.rs
+++ b/src/backend/wayland/state/perf_modules/damage_diagnostics.rs
@@ -1,0 +1,137 @@
+use crate::util::Rect;
+
+use super::super::FullDamageReason;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct PerfDamageDiagnostics {
+    pub(in crate::backend::wayland) input_regions: usize,
+    pub(in crate::backend::wayland) input_full_reason: Option<FullDamageReason>,
+    pub(in crate::backend::wayland) input_covers_surface: bool,
+    pub(in crate::backend::wayland) buffer_regions_before_merge: usize,
+    pub(in crate::backend::wayland) buffer_regions_after_merge: usize,
+    pub(in crate::backend::wayland) buffer_covers_surface: bool,
+    pub(in crate::backend::wayland) final_single_surface_rect: bool,
+    pub(in crate::backend::wayland) largest_region_area_pct_hundredths: u32,
+}
+
+pub(in crate::backend::wayland) struct PerfFrameDamageContext<'a> {
+    pub(in crate::backend::wayland) damage_screen: &'a [Rect],
+    pub(in crate::backend::wayland) logical_width: u32,
+    pub(in crate::backend::wayland) logical_height: u32,
+    pub(in crate::backend::wayland) damage_rects: usize,
+    pub(in crate::backend::wayland) force_full_reason: Option<FullDamageReason>,
+    pub(in crate::backend::wayland) diagnostics: PerfDamageDiagnostics,
+}
+
+pub(super) fn format_effective_full_damage_reason(
+    full_damage: bool,
+    force_full_reason: Option<FullDamageReason>,
+) -> &'static str {
+    format_damage_reason(effective_full_damage_reason(full_damage, force_full_reason))
+}
+
+pub(super) fn effective_full_damage_reason(
+    full_damage: bool,
+    force_full_reason: Option<FullDamageReason>,
+) -> Option<FullDamageReason> {
+    if !full_damage {
+        None
+    } else {
+        Some(force_full_reason.unwrap_or(FullDamageReason::DamageRegionsCoverSurface))
+    }
+}
+
+pub(super) fn full_damage_source(
+    full_damage: bool,
+    force_full_reason: Option<FullDamageReason>,
+    diagnostics: &PerfDamageDiagnostics,
+) -> &'static str {
+    if !full_damage {
+        "none"
+    } else if diagnostics.input_full_reason.is_some() {
+        "input_full"
+    } else if force_full_reason.is_some() {
+        "explicit_force"
+    } else if diagnostics.input_covers_surface {
+        "input_regions_cover_surface"
+    } else if diagnostics.buffer_covers_surface {
+        "buffer_regions_cover_surface"
+    } else if diagnostics.final_single_surface_rect {
+        "final_single_surface_rect"
+    } else {
+        "unknown"
+    }
+}
+
+pub(super) fn format_pct_hundredths(value: u32) -> String {
+    format!("{}.{:02}", value / 100, value % 100)
+}
+
+pub(super) fn damage_area_pct(damage: &[Rect], logical_width: u32, logical_height: u32) -> f64 {
+    let surface_area = u64::from(logical_width).saturating_mul(u64::from(logical_height));
+    if surface_area == 0 {
+        return 0.0;
+    }
+
+    let damage_area = damage
+        .iter()
+        .map(|rect| clamped_rect_area(*rect, logical_width, logical_height))
+        .sum::<u64>();
+    ((damage_area as f64 / surface_area as f64) * 100.0).min(100.0)
+}
+
+pub(super) fn largest_region_area_pct_hundredths(
+    damage: &[Rect],
+    logical_width: u32,
+    logical_height: u32,
+) -> u32 {
+    let surface_area = u64::from(logical_width).saturating_mul(u64::from(logical_height));
+    if surface_area == 0 {
+        return 0;
+    }
+
+    let largest = damage
+        .iter()
+        .map(|rect| clamped_rect_area(*rect, logical_width, logical_height))
+        .max()
+        .unwrap_or(0);
+    let hundredths = (u128::from(largest) * 10_000) / u128::from(surface_area);
+    hundredths.min(10_000) as u32
+}
+
+pub(super) fn damage_covers_surface(
+    damage: &[Rect],
+    logical_width: u32,
+    logical_height: u32,
+) -> bool {
+    let width = logical_width.min(i32::MAX as u32) as i32;
+    let height = logical_height.min(i32::MAX as u32) as i32;
+    damage_covers_logical_surface(damage, width, height)
+}
+
+pub(in crate::backend::wayland) fn damage_covers_logical_surface(
+    damage: &[Rect],
+    logical_width: i32,
+    logical_height: i32,
+) -> bool {
+    damage.iter().any(|rect| {
+        rect.x <= 0 && rect.y <= 0 && rect.width >= logical_width && rect.height >= logical_height
+    })
+}
+
+fn clamped_rect_area(rect: Rect, logical_width: u32, logical_height: u32) -> u64 {
+    let max_x = logical_width.min(i32::MAX as u32) as i32;
+    let max_y = logical_height.min(i32::MAX as u32) as i32;
+    let left = rect.x.clamp(0, max_x);
+    let top = rect.y.clamp(0, max_y);
+    let right = rect.x.saturating_add(rect.width).clamp(0, max_x);
+    let bottom = rect.y.saturating_add(rect.height).clamp(0, max_y);
+    if right <= left || bottom <= top {
+        return 0;
+    }
+    (right - left) as u64 * (bottom - top) as u64
+}
+
+fn format_damage_reason(reason: Option<FullDamageReason>) -> &'static str {
+    reason.map_or("none", FullDamageReason::as_str)
+}

--- a/src/backend/wayland/state/perf_modules/render_breakdown.rs
+++ b/src/backend/wayland/state/perf_modules/render_breakdown.rs
@@ -1,0 +1,303 @@
+use std::time::Duration;
+
+use log::info;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum PerfRenderProfileKind {
+    #[default]
+    None,
+    Canvas,
+    Ui,
+    CanvasAndUi,
+}
+
+impl PerfRenderProfileKind {
+    pub(in crate::backend::wayland) fn from_flags(canvas: bool, ui: bool) -> Self {
+        match (canvas, ui) {
+            (false, false) => Self::None,
+            (true, false) => Self::Canvas,
+            (false, true) => Self::Ui,
+            (true, true) => Self::CanvasAndUi,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Canvas => "canvas",
+            Self::Ui => "ui",
+            Self::CanvasAndUi => "canvas_and_ui",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct PerfRenderStageDurations {
+    pub(in crate::backend::wayland) advance_animations: Duration,
+    pub(in crate::backend::wayland) dirty_collect: Duration,
+    pub(in crate::backend::wayland) buffer_acquire: Duration,
+    pub(in crate::backend::wayland) cairo_surface: Duration,
+    pub(in crate::backend::wayland) clear_clip: Duration,
+    pub(in crate::backend::wayland) background: Duration,
+    pub(in crate::backend::wayland) completed_shapes: Duration,
+    pub(in crate::backend::wayland) provisional: Duration,
+    pub(in crate::backend::wayland) ui: Duration,
+    pub(in crate::backend::wayland) render_profile: Duration,
+    pub(in crate::backend::wayland) damage_commit: Duration,
+    pub(in crate::backend::wayland) toolbar: Duration,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct PerfRenderBreakdown {
+    pub(in crate::backend::wayland) stages: PerfRenderStageDurations,
+    pub(in crate::backend::wayland) surface_px: u64,
+    pub(in crate::backend::wayland) shapes_total: usize,
+    pub(in crate::backend::wayland) shapes_tested: usize,
+    pub(in crate::backend::wayland) shapes_rendered: usize,
+    pub(in crate::backend::wayland) provisional_points: usize,
+    pub(in crate::backend::wayland) render_profile: PerfRenderProfileKind,
+    pub(in crate::backend::wayland) canvas_layer_cache_hit: bool,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct PerfRenderBreakdownSummary {
+    pub(super) frames: u64,
+    pub(super) samples: u64,
+    pub(super) dominant_stage: String,
+    pub(super) dominant_stage_avg: Duration,
+    pub(super) stage_avg: PerfRenderStageDurations,
+    pub(super) surface_px_max: u64,
+    pub(super) shapes_total_max: usize,
+    pub(super) shapes_tested_avg: u64,
+    pub(super) shapes_rendered_avg: u64,
+    pub(super) shape_cull_pct: String,
+    pub(super) provisional_points_max: usize,
+    pub(super) render_profile_frames: u64,
+    pub(super) canvas_layer_cache_hits: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct PerfRenderBreakdownAccumulator {
+    samples: u64,
+    stage_totals: PerfRenderStageDurations,
+    surface_px_max: u64,
+    shapes_total_max: usize,
+    shapes_tested_total: u64,
+    shapes_rendered_total: u64,
+    provisional_points_max: usize,
+    render_profile_frames: u64,
+    canvas_layer_cache_hits: u64,
+}
+
+impl PerfRenderBreakdownAccumulator {
+    pub(super) fn record(&mut self, breakdown: &PerfRenderBreakdown) {
+        self.samples += 1;
+        add_stage_totals(&mut self.stage_totals, &breakdown.stages);
+        self.surface_px_max = self.surface_px_max.max(breakdown.surface_px);
+        self.shapes_total_max = self.shapes_total_max.max(breakdown.shapes_total);
+        self.shapes_tested_total = self
+            .shapes_tested_total
+            .saturating_add(breakdown.shapes_tested as u64);
+        self.shapes_rendered_total = self
+            .shapes_rendered_total
+            .saturating_add(breakdown.shapes_rendered as u64);
+        self.provisional_points_max = self
+            .provisional_points_max
+            .max(breakdown.provisional_points);
+        if breakdown.render_profile != PerfRenderProfileKind::None {
+            self.render_profile_frames += 1;
+        }
+        if breakdown.canvas_layer_cache_hit {
+            self.canvas_layer_cache_hits += 1;
+        }
+    }
+
+    pub(super) fn build_summary(&self, frames: u64) -> Option<PerfRenderBreakdownSummary> {
+        if self.samples == 0 {
+            return None;
+        }
+
+        let stage_avg = average_stage_durations(&self.stage_totals, self.samples);
+        let (dominant_stage, dominant_stage_avg) = dominant_render_stage(&stage_avg);
+
+        Some(PerfRenderBreakdownSummary {
+            frames,
+            samples: self.samples,
+            dominant_stage: dominant_stage.to_string(),
+            dominant_stage_avg,
+            stage_avg,
+            surface_px_max: self.surface_px_max,
+            shapes_total_max: self.shapes_total_max,
+            shapes_tested_avg: average_count(self.shapes_tested_total, self.samples),
+            shapes_rendered_avg: average_count(self.shapes_rendered_total, self.samples),
+            shape_cull_pct: shape_cull_pct_from_counts(
+                self.shapes_tested_total,
+                self.shapes_rendered_total,
+            ),
+            provisional_points_max: self.provisional_points_max,
+            render_profile_frames: self.render_profile_frames,
+            canvas_layer_cache_hits: self.canvas_layer_cache_hits,
+        })
+    }
+
+    pub(super) fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+pub(super) fn log_render_stage_frame(frame: u64, render_ms: u64, breakdown: &PerfRenderBreakdown) {
+    let dominant = dominant_render_stage(&breakdown.stages);
+    info!(
+        "perf.render_stage frame={} render_ms={} dominant_stage={} dominant_stage_ms={} advance_animations_ms={} dirty_collect_ms={} buffer_acquire_ms={} cairo_surface_ms={} clear_clip_ms={} background_ms={} completed_shapes_ms={} provisional_ms={} ui_ms={} render_profile_ms={} damage_commit_ms={} toolbar_ms={} surface_px={} shapes_total={} shapes_tested={} shapes_rendered={} shape_cull_pct={} provisional_points={} render_profile_active={} canvas_layer_cache_hit={}",
+        frame,
+        render_ms,
+        dominant.0,
+        format_duration_ms(dominant.1),
+        format_duration_ms(breakdown.stages.advance_animations),
+        format_duration_ms(breakdown.stages.dirty_collect),
+        format_duration_ms(breakdown.stages.buffer_acquire),
+        format_duration_ms(breakdown.stages.cairo_surface),
+        format_duration_ms(breakdown.stages.clear_clip),
+        format_duration_ms(breakdown.stages.background),
+        format_duration_ms(breakdown.stages.completed_shapes),
+        format_duration_ms(breakdown.stages.provisional),
+        format_duration_ms(breakdown.stages.ui),
+        format_duration_ms(breakdown.stages.render_profile),
+        format_duration_ms(breakdown.stages.damage_commit),
+        format_duration_ms(breakdown.stages.toolbar),
+        breakdown.surface_px,
+        breakdown.shapes_total,
+        breakdown.shapes_tested,
+        breakdown.shapes_rendered,
+        shape_cull_pct_from_counts(
+            breakdown.shapes_tested as u64,
+            breakdown.shapes_rendered as u64
+        ),
+        breakdown.provisional_points,
+        breakdown.render_profile.as_str(),
+        breakdown.canvas_layer_cache_hit
+    );
+}
+
+pub(super) fn log_render_stage_summary(summary: &PerfRenderBreakdownSummary, final_summary: bool) {
+    info!(
+        "perf.render_stage_summary frames={} samples={} dominant_stage={} dominant_stage_avg_ms={} advance_animations_avg_ms={} dirty_collect_avg_ms={} buffer_acquire_avg_ms={} cairo_surface_avg_ms={} clear_clip_avg_ms={} background_avg_ms={} completed_shapes_avg_ms={} provisional_avg_ms={} ui_avg_ms={} render_profile_avg_ms={} damage_commit_avg_ms={} toolbar_avg_ms={} surface_px_max={} shapes_total_max={} shapes_tested_avg={} shapes_rendered_avg={} shape_cull_pct={} provisional_points_max={} render_profile_frames={} canvas_layer_cache_hits={} final={}",
+        summary.frames,
+        summary.samples,
+        summary.dominant_stage,
+        format_duration_ms(summary.dominant_stage_avg),
+        format_duration_ms(summary.stage_avg.advance_animations),
+        format_duration_ms(summary.stage_avg.dirty_collect),
+        format_duration_ms(summary.stage_avg.buffer_acquire),
+        format_duration_ms(summary.stage_avg.cairo_surface),
+        format_duration_ms(summary.stage_avg.clear_clip),
+        format_duration_ms(summary.stage_avg.background),
+        format_duration_ms(summary.stage_avg.completed_shapes),
+        format_duration_ms(summary.stage_avg.provisional),
+        format_duration_ms(summary.stage_avg.ui),
+        format_duration_ms(summary.stage_avg.render_profile),
+        format_duration_ms(summary.stage_avg.damage_commit),
+        format_duration_ms(summary.stage_avg.toolbar),
+        summary.surface_px_max,
+        summary.shapes_total_max,
+        summary.shapes_tested_avg,
+        summary.shapes_rendered_avg,
+        summary.shape_cull_pct,
+        summary.provisional_points_max,
+        summary.render_profile_frames,
+        summary.canvas_layer_cache_hits,
+        final_summary
+    );
+}
+
+fn add_stage_totals(total: &mut PerfRenderStageDurations, frame: &PerfRenderStageDurations) {
+    total.advance_animations = total
+        .advance_animations
+        .saturating_add(frame.advance_animations);
+    total.dirty_collect = total.dirty_collect.saturating_add(frame.dirty_collect);
+    total.buffer_acquire = total.buffer_acquire.saturating_add(frame.buffer_acquire);
+    total.cairo_surface = total.cairo_surface.saturating_add(frame.cairo_surface);
+    total.clear_clip = total.clear_clip.saturating_add(frame.clear_clip);
+    total.background = total.background.saturating_add(frame.background);
+    total.completed_shapes = total
+        .completed_shapes
+        .saturating_add(frame.completed_shapes);
+    total.provisional = total.provisional.saturating_add(frame.provisional);
+    total.ui = total.ui.saturating_add(frame.ui);
+    total.render_profile = total.render_profile.saturating_add(frame.render_profile);
+    total.damage_commit = total.damage_commit.saturating_add(frame.damage_commit);
+    total.toolbar = total.toolbar.saturating_add(frame.toolbar);
+}
+
+fn average_stage_durations(
+    total: &PerfRenderStageDurations,
+    samples: u64,
+) -> PerfRenderStageDurations {
+    PerfRenderStageDurations {
+        advance_animations: average_duration(total.advance_animations, samples),
+        dirty_collect: average_duration(total.dirty_collect, samples),
+        buffer_acquire: average_duration(total.buffer_acquire, samples),
+        cairo_surface: average_duration(total.cairo_surface, samples),
+        clear_clip: average_duration(total.clear_clip, samples),
+        background: average_duration(total.background, samples),
+        completed_shapes: average_duration(total.completed_shapes, samples),
+        provisional: average_duration(total.provisional, samples),
+        ui: average_duration(total.ui, samples),
+        render_profile: average_duration(total.render_profile, samples),
+        damage_commit: average_duration(total.damage_commit, samples),
+        toolbar: average_duration(total.toolbar, samples),
+    }
+}
+
+fn average_duration(total: Duration, samples: u64) -> Duration {
+    let nanos = total
+        .as_nanos()
+        .checked_div(u128::from(samples))
+        .unwrap_or(0);
+    Duration::from_nanos(nanos.min(u128::from(u64::MAX)) as u64)
+}
+
+fn average_count(total: u64, samples: u64) -> u64 {
+    total.checked_div(samples).unwrap_or(0)
+}
+
+fn dominant_render_stage(stages: &PerfRenderStageDurations) -> (&'static str, Duration) {
+    [
+        ("advance_animations", stages.advance_animations),
+        ("dirty_collect", stages.dirty_collect),
+        ("buffer_acquire", stages.buffer_acquire),
+        ("cairo_surface", stages.cairo_surface),
+        ("clear_clip", stages.clear_clip),
+        ("background", stages.background),
+        ("completed_shapes", stages.completed_shapes),
+        ("provisional", stages.provisional),
+        ("ui", stages.ui),
+        ("render_profile", stages.render_profile),
+        ("damage_commit", stages.damage_commit),
+        ("toolbar", stages.toolbar),
+    ]
+    .into_iter()
+    .max_by_key(|(_, duration)| *duration)
+    .unwrap_or(("none", Duration::ZERO))
+}
+
+fn shape_cull_pct_from_counts(tested: u64, rendered: u64) -> String {
+    if tested == 0 {
+        "n/a".to_string()
+    } else {
+        let culled = tested.saturating_sub(rendered);
+        format_pct(culled, tested)
+    }
+}
+
+fn format_pct(count: u64, total: u64) -> String {
+    if total == 0 {
+        return "0.00".to_string();
+    }
+    format!("{:.2}", (count as f64 / total as f64) * 100.0)
+}
+
+fn format_duration_ms(duration: Duration) -> String {
+    format!("{:.2}", duration.as_secs_f64() * 1000.0)
+}

--- a/src/backend/wayland/state/perf_modules/render_breakdown.rs
+++ b/src/backend/wayland/state/perf_modules/render_breakdown.rs
@@ -56,7 +56,7 @@ pub(in crate::backend::wayland) struct PerfRenderBreakdown {
     pub(in crate::backend::wayland) shapes_rendered: usize,
     pub(in crate::backend::wayland) provisional_points: usize,
     pub(in crate::backend::wayland) render_profile: PerfRenderProfileKind,
-    pub(in crate::backend::wayland) canvas_layer_cache_hit: bool,
+    pub(in crate::backend::wayland) canvas_layer_cache_used: bool,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -74,7 +74,7 @@ pub(super) struct PerfRenderBreakdownSummary {
     pub(super) shape_cull_pct: String,
     pub(super) provisional_points_max: usize,
     pub(super) render_profile_frames: u64,
-    pub(super) canvas_layer_cache_hits: u64,
+    pub(super) canvas_layer_cache_used_frames: u64,
 }
 
 #[derive(Debug, Default)]
@@ -87,7 +87,7 @@ pub(super) struct PerfRenderBreakdownAccumulator {
     shapes_rendered_total: u64,
     provisional_points_max: usize,
     render_profile_frames: u64,
-    canvas_layer_cache_hits: u64,
+    canvas_layer_cache_used_frames: u64,
 }
 
 impl PerfRenderBreakdownAccumulator {
@@ -108,8 +108,8 @@ impl PerfRenderBreakdownAccumulator {
         if breakdown.render_profile != PerfRenderProfileKind::None {
             self.render_profile_frames += 1;
         }
-        if breakdown.canvas_layer_cache_hit {
-            self.canvas_layer_cache_hits += 1;
+        if breakdown.canvas_layer_cache_used {
+            self.canvas_layer_cache_used_frames += 1;
         }
     }
 
@@ -137,7 +137,7 @@ impl PerfRenderBreakdownAccumulator {
             ),
             provisional_points_max: self.provisional_points_max,
             render_profile_frames: self.render_profile_frames,
-            canvas_layer_cache_hits: self.canvas_layer_cache_hits,
+            canvas_layer_cache_used_frames: self.canvas_layer_cache_used_frames,
         })
     }
 
@@ -149,7 +149,7 @@ impl PerfRenderBreakdownAccumulator {
 pub(super) fn log_render_stage_frame(frame: u64, render_ms: u64, breakdown: &PerfRenderBreakdown) {
     let dominant = dominant_render_stage(&breakdown.stages);
     info!(
-        "perf.render_stage frame={} render_ms={} dominant_stage={} dominant_stage_ms={} advance_animations_ms={} dirty_collect_ms={} buffer_acquire_ms={} cairo_surface_ms={} clear_clip_ms={} background_ms={} completed_shapes_ms={} provisional_ms={} ui_ms={} render_profile_ms={} damage_commit_ms={} toolbar_ms={} surface_px={} shapes_total={} shapes_tested={} shapes_rendered={} shape_cull_pct={} provisional_points={} render_profile_active={} canvas_layer_cache_hit={}",
+        "perf.render_stage frame={} render_ms={} dominant_stage={} dominant_stage_ms={} advance_animations_ms={} dirty_collect_ms={} buffer_acquire_ms={} cairo_surface_ms={} clear_clip_ms={} background_ms={} completed_shapes_ms={} provisional_ms={} ui_ms={} render_profile_ms={} damage_commit_ms={} toolbar_ms={} surface_px={} shapes_total={} shapes_tested={} shapes_rendered={} shape_cull_pct={} provisional_points={} render_profile_active={} canvas_layer_cache_used={}",
         frame,
         render_ms,
         dominant.0,
@@ -176,13 +176,13 @@ pub(super) fn log_render_stage_frame(frame: u64, render_ms: u64, breakdown: &Per
         ),
         breakdown.provisional_points,
         breakdown.render_profile.as_str(),
-        breakdown.canvas_layer_cache_hit
+        breakdown.canvas_layer_cache_used
     );
 }
 
 pub(super) fn log_render_stage_summary(summary: &PerfRenderBreakdownSummary, final_summary: bool) {
     info!(
-        "perf.render_stage_summary frames={} samples={} dominant_stage={} dominant_stage_avg_ms={} advance_animations_avg_ms={} dirty_collect_avg_ms={} buffer_acquire_avg_ms={} cairo_surface_avg_ms={} clear_clip_avg_ms={} background_avg_ms={} completed_shapes_avg_ms={} provisional_avg_ms={} ui_avg_ms={} render_profile_avg_ms={} damage_commit_avg_ms={} toolbar_avg_ms={} surface_px_max={} shapes_total_max={} shapes_tested_avg={} shapes_rendered_avg={} shape_cull_pct={} provisional_points_max={} render_profile_frames={} canvas_layer_cache_hits={} final={}",
+        "perf.render_stage_summary frames={} samples={} dominant_stage={} dominant_stage_avg_ms={} advance_animations_avg_ms={} dirty_collect_avg_ms={} buffer_acquire_avg_ms={} cairo_surface_avg_ms={} clear_clip_avg_ms={} background_avg_ms={} completed_shapes_avg_ms={} provisional_avg_ms={} ui_avg_ms={} render_profile_avg_ms={} damage_commit_avg_ms={} toolbar_avg_ms={} surface_px_max={} shapes_total_max={} shapes_tested_avg={} shapes_rendered_avg={} shape_cull_pct={} provisional_points_max={} render_profile_frames={} canvas_layer_cache_used_frames={} final={}",
         summary.frames,
         summary.samples,
         summary.dominant_stage,
@@ -206,7 +206,7 @@ pub(super) fn log_render_stage_summary(summary: &PerfRenderBreakdownSummary, fin
         summary.shape_cull_pct,
         summary.provisional_points_max,
         summary.render_profile_frames,
-        summary.canvas_layer_cache_hits,
+        summary.canvas_layer_cache_used_frames,
         final_summary
     );
 }

--- a/src/backend/wayland/state/render/canvas/mod.rs
+++ b/src/backend/wayland/state/render/canvas/mod.rs
@@ -70,7 +70,7 @@ impl WaylandState {
             debug!("Rendered committed shapes from layer cache");
             if let Some(perf) = perf.as_mut() {
                 perf.shapes_total = shapes_total;
-                perf.canvas_layer_cache_hit = true;
+                perf.canvas_layer_cache_used = true;
             }
         } else {
             // Render all completed shapes from active frame

--- a/src/backend/wayland/state/render/canvas/mod.rs
+++ b/src/backend/wayland/state/render/canvas/mod.rs
@@ -16,21 +16,37 @@ impl WaylandState {
         phys_height: u32,
         now: Instant,
         damage_world: &[crate::util::Rect],
+        mut perf: Option<&mut PerfRenderBreakdown>,
     ) -> Result<()> {
         let canvas_transform_active = self.canvas_transform_active();
         let (canvas_origin_x, canvas_origin_y) = self.canvas_view_origin();
+        let shapes_total = self.input_state.boards.active_frame().shapes.len();
 
         // For pure pan transforms, serve the board background and committed
         // shapes from the baked layer cache: pan frames force full damage, so
         // this turns an O(shapes) Cairo replay into a single aligned blit.
+        let layer_cache_start = perf.as_ref().map(|_| Instant::now());
         let layer_cache_ready = if self.canvas_layer_cache_usable() {
             self.ensure_canvas_layer_cache(width, height, scale)
         } else {
             self.canvas_layer_cache.clear();
             false
         };
+        if let (Some(perf), Some(layer_cache_start)) = (perf.as_mut(), layer_cache_start) {
+            perf.stages.completed_shapes = perf
+                .stages
+                .completed_shapes
+                .saturating_add(Instant::now().saturating_duration_since(layer_cache_start));
+        }
 
+        let background_start = perf.as_ref().map(|_| Instant::now());
         let eraser_ctx = self.render_canvas_background(ctx, scale, phys_width, phys_height)?;
+        if let (Some(perf), Some(background_start)) = (perf.as_mut(), background_start) {
+            perf.stages.background = perf
+                .stages
+                .background
+                .saturating_add(Instant::now().saturating_duration_since(background_start));
+        }
 
         // Scale subsequent drawing to logical coordinates
         let _ = ctx.save();
@@ -48,16 +64,21 @@ impl WaylandState {
 
         let replay_ctx = eraser_ctx.replay_context();
 
+        let completed_shapes_start = perf.as_ref().map(|_| Instant::now());
         if layer_cache_ready && self.canvas_layer_cache.blit(ctx) {
             // Board background and committed shapes came from the baked layer.
             debug!("Rendered committed shapes from layer cache");
+            if let Some(perf) = perf.as_mut() {
+                perf.shapes_total = shapes_total;
+                perf.canvas_layer_cache_hit = true;
+            }
         } else {
             // Render all completed shapes from active frame
-            debug!(
-                "Rendering {} completed shapes",
-                self.input_state.boards.active_frame().shapes.len()
-            );
+            debug!("Rendering {} completed shapes", shapes_total);
             let shapes = &self.input_state.boards.active_frame().shapes;
+            if let Some(perf) = perf.as_mut() {
+                perf.shapes_total = shapes.len();
+            }
 
             // Manual Culling: Only render shapes that intersect with the damage regions.
             // Cairo's internal clipping is efficient for rasterization, but sending
@@ -120,7 +141,10 @@ impl WaylandState {
                 };
 
                 if let Some(safe_bounds) = safe_bounds {
+                    let mut shapes_tested = 0usize;
+                    let mut shapes_rendered = 0usize;
                     for drawn_shape in shapes {
+                        shapes_tested += 1;
                         // If shape has no bounding box (e.g. empty freehand), skip it.
                         // If it has one, check intersection. Uses the per-shape
                         // memoized bounds to avoid O(points) recomputation per frame.
@@ -139,16 +163,34 @@ impl WaylandState {
 
                             if intersects {
                                 render_drawn_shape(drawn_shape);
+                                shapes_rendered += 1;
                             }
                         }
+                    }
+                    if let Some(perf) = perf.as_mut() {
+                        perf.shapes_tested = shapes_tested;
+                        perf.shapes_rendered = shapes_rendered;
                     }
                 }
             } else {
                 // If we don't have damage bounds, render everything to stay correct.
+                let mut shapes_rendered = 0usize;
                 for drawn_shape in shapes {
                     render_drawn_shape(drawn_shape);
+                    shapes_rendered += 1;
+                }
+                if let Some(perf) = perf.as_mut() {
+                    perf.shapes_tested = shapes.len();
+                    perf.shapes_rendered = shapes_rendered;
                 }
             }
+        }
+        if let (Some(perf), Some(completed_shapes_start)) = (perf.as_mut(), completed_shapes_start)
+        {
+            perf.stages.completed_shapes = perf
+                .stages
+                .completed_shapes
+                .saturating_add(Instant::now().saturating_duration_since(completed_shapes_start));
         }
 
         self.render_selection_overlays(ctx);
@@ -163,6 +205,8 @@ impl WaylandState {
         self.render_eraser_hover_halos(ctx, hover_mx, hover_my);
 
         let provisional = self.input_state.provisional_tool_stroke(mx, my);
+        let provisional_points = provisional_point_count(&provisional);
+        let provisional_start = perf.as_ref().map(|_| Instant::now());
         let rendered_provisional = match provisional {
             crate::input::tool::ProvisionalToolStroke::BlurReplayPreview(params) => {
                 crate::draw::render_blur_rect(ctx, params, &replay_ctx);
@@ -172,6 +216,13 @@ impl WaylandState {
                 .input_state
                 .render_provisional_shape_for_damage(ctx, mx, my, damage_world),
         };
+        if let (Some(perf), Some(provisional_start)) = (perf.as_mut(), provisional_start) {
+            perf.provisional_points = provisional_points;
+            perf.stages.provisional = perf
+                .stages
+                .provisional
+                .saturating_add(Instant::now().saturating_duration_since(provisional_start));
+        }
         if rendered_provisional {
             debug!("Rendered provisional shape");
         }
@@ -191,5 +242,17 @@ impl WaylandState {
         let _ = ctx.restore();
 
         Ok(())
+    }
+}
+
+fn provisional_point_count(stroke: &crate::input::tool::ProvisionalToolStroke<'_>) -> usize {
+    match stroke {
+        crate::input::tool::ProvisionalToolStroke::BorrowedFreehand { points, .. }
+        | crate::input::tool::ProvisionalToolStroke::BorrowedPressureFreehand { points, .. }
+        | crate::input::tool::ProvisionalToolStroke::BorrowedMarker { points, .. }
+        | crate::input::tool::ProvisionalToolStroke::EraserPreview { points, .. } => points.len(),
+        crate::input::tool::ProvisionalToolStroke::Shape(_)
+        | crate::input::tool::ProvisionalToolStroke::BlurReplayPreview(_)
+        | crate::input::tool::ProvisionalToolStroke::None => 0,
     }
 }

--- a/src/backend/wayland/state/render/mod.rs
+++ b/src/backend/wayland/state/render/mod.rs
@@ -23,12 +23,43 @@ impl WaylandState {
         let height = self.surface.height();
         let phys_width = width.saturating_mul(scale as u32);
         let phys_height = height.saturating_mul(scale as u32);
+        let perf_enabled = self.perf_enabled();
+        let mut render_breakdown = perf_enabled.then(|| PerfRenderBreakdown {
+            surface_px: u64::from(phys_width).saturating_mul(u64::from(phys_height)),
+            ..PerfRenderBreakdown::default()
+        });
+        macro_rules! record_stage {
+            ($field:ident, $body:expr) => {{
+                let stage_start = perf_enabled.then(Instant::now);
+                let result = $body;
+                if let (Some(breakdown), Some(stage_start)) =
+                    (render_breakdown.as_mut(), stage_start)
+                {
+                    breakdown.stages.$field = breakdown
+                        .stages
+                        .$field
+                        .saturating_add(Instant::now().saturating_duration_since(stage_start));
+                }
+                result
+            }};
+        }
+
         let now = Instant::now();
-        let highlight_active = self.input_state.advance_click_highlights(now);
-        let preset_feedback_active = self.input_state.advance_preset_feedback(now);
-        let ui_toast_active = self.input_state.advance_ui_toast(now);
-        let blocked_feedback_active = self.input_state.advance_blocked_feedback(now);
-        let text_edit_entry_active = self.input_state.advance_text_edit_entry_feedback(now);
+        let (
+            highlight_active,
+            preset_feedback_active,
+            ui_toast_active,
+            blocked_feedback_active,
+            text_edit_entry_active,
+        ) = record_stage!(advance_animations, {
+            (
+                self.input_state.advance_click_highlights(now),
+                self.input_state.advance_preset_feedback(now),
+                self.input_state.advance_ui_toast(now),
+                self.input_state.advance_blocked_feedback(now),
+                self.input_state.advance_text_edit_entry_feedback(now),
+            )
+        });
         let ui_animation_active = highlight_active
             || preset_feedback_active
             || ui_toast_active
@@ -40,36 +71,44 @@ impl WaylandState {
         // Add new dirty regions from input state to the per-buffer damage tracker.
         // We do this BEFORE acquiring the buffer/damage so the current frame's changes
         // are included in the damage for the current buffer.
-        let input_damage_report = self.input_state.take_dirty_region_report();
-        let input_damage = input_damage_report.regions;
         let logical_width = width.min(i32::MAX as u32) as i32;
         let logical_height = height.min(i32::MAX as u32) as i32;
-        let force_full_damage_reason = self.render_force_full_damage_reason();
-        // Transient UI effects (toasts, feedback flashes) emit targeted damage
-        // instead of forcing full-surface redraws. Collect on every frame so the
-        // previous-bounds tracking stays in sync even when full damage is forced
-        // for other reasons.
-        let ui_effect_damage = self.collect_ui_effect_damage(
-            ui_toast_active,
-            preset_feedback_active,
-            blocked_feedback_active,
-            text_edit_entry_active,
-            width,
-            height,
-        );
-        if let Some(reason) = force_full_damage_reason {
-            // Zoom and board pan use a world transform; full damage avoids
-            // mismatched coordinate spaces.
-            self.buffer_damage.mark_all_full(reason);
-        } else if let Some(reason) = input_full_damage_reason(input_damage_report.full_reason) {
-            self.buffer_damage.mark_all_full(reason);
-        } else {
-            self.buffer_damage.add_regions(input_damage);
-            self.buffer_damage.add_regions(ui_effect_damage);
-        }
+        let mut damage_diagnostics = PerfDamageDiagnostics::default();
+        record_stage!(dirty_collect, {
+            let input_damage_report = self.input_state.take_dirty_region_report();
+            let input_damage = input_damage_report.regions;
+            let input_full_reason = input_full_damage_reason(input_damage_report.full_reason);
+            damage_diagnostics.input_regions = input_damage.len();
+            damage_diagnostics.input_full_reason = input_full_reason;
+            damage_diagnostics.input_covers_surface =
+                damage_covers_logical_surface(&input_damage, logical_width, logical_height);
+            let force_full_damage_reason = self.render_force_full_damage_reason();
+            // Transient UI effects (toasts, feedback flashes) emit targeted damage
+            // instead of forcing full-surface redraws. Collect on every frame so the
+            // previous-bounds tracking stays in sync even when full damage is forced
+            // for other reasons.
+            let ui_effect_damage = self.collect_ui_effect_damage(
+                ui_toast_active,
+                preset_feedback_active,
+                blocked_feedback_active,
+                text_edit_entry_active,
+                width,
+                height,
+            );
+            if let Some(reason) = force_full_damage_reason {
+                // Zoom and board pan use a world transform; full damage avoids
+                // mismatched coordinate spaces.
+                self.buffer_damage.mark_all_full(reason);
+            } else if let Some(reason) = input_full_reason {
+                self.buffer_damage.mark_all_full(reason);
+            } else {
+                self.buffer_damage.add_regions(input_damage);
+                self.buffer_damage.add_regions(ui_effect_damage);
+            }
+        });
 
         // Get a buffer from the pool for rendering
-        let (buffer, canvas_ptr, pool_gen, pool_size) = {
+        let (buffer, canvas_ptr, pool_gen, pool_size) = record_stage!(buffer_acquire, {
             let (pool, generation) = self.surface.ensure_pool(&self.shm, buffer_count)?;
             debug!(
                 "Requesting buffer from pool (gen {}, size {})",
@@ -93,7 +132,7 @@ impl WaylandState {
             let pool_size = pool.len();
             debug!("Buffer acquired from pool (slot ptr: 0x{:x})", key);
             (buf, key, generation, pool_size)
-        };
+        });
 
         // Record pool size after create_buffer to detect growth.
         self.surface.update_pool_size(pool_size);
@@ -109,6 +148,8 @@ impl WaylandState {
             pool_gen,
             pool_size,
         );
+        damage_diagnostics.buffer_regions_before_merge = damage_report.regions_before_merge;
+        damage_diagnostics.buffer_regions_after_merge = damage_report.regions_after_merge;
         let mut logical_damage = damage_report.regions;
         let mut full_damage_reason = damage_report.full_reason;
         if logical_damage.is_empty()
@@ -120,6 +161,8 @@ impl WaylandState {
                 .mark_all_full(FullDamageReason::EmptyDamageFallback);
         }
         let damage_screen = logical_damage;
+        damage_diagnostics.buffer_covers_surface =
+            damage_covers_logical_surface(&damage_screen, logical_width, logical_height);
         let damage_world = if self.canvas_transform_active() {
             let scale = if self.zoom.active {
                 self.zoom.scale.max(f64::MIN_POSITIVE)
@@ -144,6 +187,9 @@ impl WaylandState {
         let active_render_profile = self.input_state.active_render_profile().cloned();
         let remap_canvas = self.input_state.active_canvas_render_profile().is_some();
         let remap_ui = self.input_state.active_ui_render_profile().is_some();
+        if let Some(breakdown) = render_breakdown.as_mut() {
+            breakdown.render_profile = PerfRenderProfileKind::from_flags(remap_canvas, remap_ui);
+        }
         let stride = (phys_width * 4) as i32;
         let canvas_len = phys_height as usize * stride as usize;
 
@@ -156,43 +202,50 @@ impl WaylandState {
         //    ensuring Cairo doesn't access memory after ownership transfers
         // 5. No other references to this memory exist during Cairo's usage
         // 6. The buffer remains valid throughout Cairo's usage (enforced by Rust's borrow checker)
-        let cairo_surface = unsafe {
-            cairo::ImageSurface::create_for_data_unsafe(
-                canvas_ptr as *mut u8,
-                cairo::Format::ARgb32,
-                phys_width as i32,
-                phys_height as i32,
-                (phys_width * 4) as i32,
-            )
-            .context("Failed to create Cairo surface")?
-        };
-
         // Render using Cairo
         let draw_start = std::time::Instant::now();
-        let ctx = cairo::Context::new(&cairo_surface).context("Failed to create Cairo context")?;
+        let (cairo_surface, ctx) = record_stage!(cairo_surface, {
+            let cairo_surface = unsafe {
+                cairo::ImageSurface::create_for_data_unsafe(
+                    canvas_ptr as *mut u8,
+                    cairo::Format::ARgb32,
+                    phys_width as i32,
+                    phys_height as i32,
+                    (phys_width * 4) as i32,
+                )
+                .context("Failed to create Cairo surface")?
+            };
 
-        // Optimization: Clip drawing to the damage regions.
-        // This dramatically reduces CPU fill rate pressure on high-res screens by
-        // avoiding redraws of static content (which is preserved in the back-buffer).
-        // Note: Cairo works in logical coordinates if we scale it, but here we are
-        // pre-scale (identity transform). We must scale the logical damage rects to pixels.
-        if !damage_screen.is_empty() {
-            for rect in &damage_screen {
-                // Scale logical rect to physical pixels
-                let x = rect.x as f64 * scale as f64;
-                let y = rect.y as f64 * scale as f64;
-                let w = rect.width as f64 * scale as f64;
-                let h = rect.height as f64 * scale as f64;
-                ctx.rectangle(x, y, w, h);
+            let ctx =
+                cairo::Context::new(&cairo_surface).context("Failed to create Cairo context")?;
+            (cairo_surface, ctx)
+        });
+
+        record_stage!(clear_clip, {
+            // Optimization: Clip drawing to the damage regions.
+            // This dramatically reduces CPU fill rate pressure on high-res screens by
+            // avoiding redraws of static content (which is preserved in the back-buffer).
+            // Note: Cairo works in logical coordinates if we scale it, but here we are
+            // pre-scale (identity transform). We must scale the logical damage rects to pixels.
+            if !damage_screen.is_empty() {
+                for rect in &damage_screen {
+                    // Scale logical rect to physical pixels
+                    let x = rect.x as f64 * scale as f64;
+                    let y = rect.y as f64 * scale as f64;
+                    let w = rect.width as f64 * scale as f64;
+                    let h = rect.height as f64 * scale as f64;
+                    ctx.rectangle(x, y, w, h);
+                }
+                ctx.clip();
             }
-            ctx.clip();
-        }
 
-        // Clear with fully transparent background (only clears within clip)
-        debug!("Clearing background");
-        ctx.set_operator(cairo::Operator::Clear);
-        ctx.paint().context("Failed to clear background")?;
-        ctx.set_operator(cairo::Operator::Over);
+            // Clear with fully transparent background (only clears within clip)
+            debug!("Clearing background");
+            ctx.set_operator(cairo::Operator::Clear);
+            ctx.paint().context("Failed to clear background")?;
+            ctx.set_operator(cairo::Operator::Over);
+            Ok::<(), anyhow::Error>(())
+        })?;
 
         if render_canvas {
             self.render_canvas_layer(
@@ -204,41 +257,48 @@ impl WaylandState {
                 phys_height,
                 now,
                 &damage_world,
+                render_breakdown.as_mut(),
             )?;
         }
 
         let mut has_ui_baseline = false;
-        if let Some(profile) = active_render_profile.as_ref() {
-            if remap_canvas && !remap_ui {
-                cairo_surface.flush();
-                // SAFETY: `canvas_ptr` points to the SlotPool memory for the buffer created above.
-                // Cairo has flushed all pending writes, so the rendered canvas pixels can be
-                // rewritten before UI is drawn on top.
-                let canvas =
-                    unsafe { std::slice::from_raw_parts_mut(canvas_ptr as *mut u8, canvas_len) };
-                profile.remap_argb8888_regions(
-                    canvas,
-                    phys_width as i32,
-                    phys_height as i32,
-                    stride,
-                    &scaled_damage,
-                );
-                cairo_surface.mark_dirty();
-            } else if !remap_canvas && remap_ui && render_ui {
-                cairo_surface.flush();
-                // SAFETY: `canvas_ptr` points to the SlotPool memory for the buffer created above.
-                // Cairo has flushed all pending writes, so we can snapshot the canvas-only pixels in
-                // a reusable scratch buffer before drawing UI and later remap only bytes changed by
-                // the UI pass.
-                let canvas =
-                    unsafe { std::slice::from_raw_parts_mut(canvas_ptr as *mut u8, canvas_len) };
-                self.data.render_profile_ui_baseline.resize(canvas_len, 0);
-                self.data.render_profile_ui_baseline.copy_from_slice(canvas);
-                has_ui_baseline = true;
+        record_stage!(render_profile, {
+            if let Some(profile) = active_render_profile.as_ref() {
+                if remap_canvas && !remap_ui {
+                    cairo_surface.flush();
+                    // SAFETY: `canvas_ptr` points to the SlotPool memory for the buffer created above.
+                    // Cairo has flushed all pending writes, so the rendered canvas pixels can be
+                    // rewritten before UI is drawn on top.
+                    let canvas = unsafe {
+                        std::slice::from_raw_parts_mut(canvas_ptr as *mut u8, canvas_len)
+                    };
+                    profile.remap_argb8888_regions(
+                        canvas,
+                        phys_width as i32,
+                        phys_height as i32,
+                        stride,
+                        &scaled_damage,
+                    );
+                    cairo_surface.mark_dirty();
+                } else if !remap_canvas && remap_ui && render_ui {
+                    cairo_surface.flush();
+                    // SAFETY: `canvas_ptr` points to the SlotPool memory for the buffer created above.
+                    // Cairo has flushed all pending writes, so we can snapshot the canvas-only pixels in
+                    // a reusable scratch buffer before drawing UI and later remap only bytes changed by
+                    // the UI pass.
+                    let canvas = unsafe {
+                        std::slice::from_raw_parts_mut(canvas_ptr as *mut u8, canvas_len)
+                    };
+                    self.data.render_profile_ui_baseline.resize(canvas_len, 0);
+                    self.data.render_profile_ui_baseline.copy_from_slice(canvas);
+                    has_ui_baseline = true;
+                }
             }
-        }
+        });
 
-        self.render_ui_layer(&ctx, width, height, scale, render_ui);
+        record_stage!(ui, {
+            self.render_ui_layer(&ctx, width, height, scale, render_ui);
+        });
 
         // Flush Cairo
         debug!("Flushing Cairo surface");
@@ -246,91 +306,104 @@ impl WaylandState {
         drop(ctx);
         drop(cairo_surface);
 
-        if let Some(profile) = active_render_profile.as_ref() {
-            // SAFETY: `canvas_ptr` points to the SlotPool memory for the buffer created above.
-            // Cairo has been flushed and dropped, and the buffer has not been attached yet, so this
-            // is the only active mutable access to the rendered pixel bytes.
-            let canvas =
-                unsafe { std::slice::from_raw_parts_mut(canvas_ptr as *mut u8, canvas_len) };
-            if remap_canvas && remap_ui {
-                profile.remap_argb8888_regions(
-                    canvas,
-                    phys_width as i32,
-                    phys_height as i32,
-                    stride,
-                    &scaled_damage,
-                );
-            } else if !remap_canvas && remap_ui && has_ui_baseline {
-                profile.remap_argb8888_regions_changed_from(
-                    canvas,
-                    &self.data.render_profile_ui_baseline,
-                    phys_width as i32,
-                    phys_height as i32,
-                    stride,
-                    &scaled_damage,
-                );
+        record_stage!(render_profile, {
+            if let Some(profile) = active_render_profile.as_ref() {
+                // SAFETY: `canvas_ptr` points to the SlotPool memory for the buffer created above.
+                // Cairo has been flushed and dropped, and the buffer has not been attached yet, so this
+                // is the only active mutable access to the rendered pixel bytes.
+                let canvas =
+                    unsafe { std::slice::from_raw_parts_mut(canvas_ptr as *mut u8, canvas_len) };
+                if remap_canvas && remap_ui {
+                    profile.remap_argb8888_regions(
+                        canvas,
+                        phys_width as i32,
+                        phys_height as i32,
+                        stride,
+                        &scaled_damage,
+                    );
+                } else if !remap_canvas && remap_ui && has_ui_baseline {
+                    profile.remap_argb8888_regions_changed_from(
+                        canvas,
+                        &self.data.render_profile_ui_baseline,
+                        phys_width as i32,
+                        phys_height as i32,
+                        stride,
+                        &scaled_damage,
+                    );
+                }
             }
-        }
+        });
 
         let draw_duration = draw_start.elapsed();
         if draw_duration > std::time::Duration::from_millis(2) {
             debug!("Cairo draw took {:?}", draw_duration);
         }
 
-        // Attach buffer and commit
-        debug!("Attaching buffer and committing surface");
-        let wl_surface = self
-            .surface
-            .wl_surface()
-            .cloned()
-            .context("Surface not created")?;
-        wl_surface.set_buffer_scale(scale);
-        wl_surface.attach(Some(buffer.wl_buffer()), 0, 0);
+        record_stage!(damage_commit, {
+            // Attach buffer and commit
+            debug!("Attaching buffer and committing surface");
+            let wl_surface = self
+                .surface
+                .wl_surface()
+                .cloned()
+                .context("Surface not created")?;
+            wl_surface.set_buffer_scale(scale);
+            wl_surface.attach(Some(buffer.wl_buffer()), 0, 0);
 
-        // Damage logic moved to top of function (add_regions and take_buffer_damage).
-        // We now use the computed screen-space damage for clipping and compositor hints.
+            // Damage logic moved to top of function (add_regions and take_buffer_damage).
+            // We now use the computed screen-space damage for clipping and compositor hints.
 
-        if debug_damage_logging_enabled() {
-            debug!(
-                "Damage (scaled): count={}, {}",
-                scaled_damage.len(),
-                damage_summary(&scaled_damage)
+            if debug_damage_logging_enabled() {
+                debug!(
+                    "Damage (scaled): count={}, {}",
+                    scaled_damage.len(),
+                    damage_summary(&scaled_damage)
+                );
+            }
+
+            // Apply per-buffer damage regions for correct incremental rendering.
+            // Each buffer tracks damage since it was last displayed, avoiding stale pixels.
+            for region in &scaled_damage {
+                wl_surface.damage_buffer(region.x, region.y, region.width, region.height);
+            }
+
+            let force_frame_callback = self.frozen.preflight_pending()
+                || self.zoom.preflight_pending()
+                || self.capture.preflight_needs_frame_callback();
+            if self.config.performance.enable_vsync {
+                debug!("Requesting frame callback (vsync enabled)");
+                wl_surface.frame(qh, wl_surface.clone());
+            } else if force_frame_callback {
+                debug!("Requesting frame callback (preflight)");
+                wl_surface.frame(qh, wl_surface.clone());
+                self.surface.set_frame_callback_pending(true);
+            } else {
+                debug!("Skipping frame callback (vsync disabled - allows back-to-back renders)");
+            }
+
+            self.commit_perf_frame(
+                PerfFrameDamageContext {
+                    damage_screen: &damage_screen,
+                    logical_width: width,
+                    logical_height: height,
+                    damage_rects: scaled_damage.len(),
+                    force_full_reason: full_damage_reason,
+                    diagnostics: damage_diagnostics,
+                },
+                Instant::now(),
             );
-        }
-
-        // Apply per-buffer damage regions for correct incremental rendering.
-        // Each buffer tracks damage since it was last displayed, avoiding stale pixels.
-        for region in &scaled_damage {
-            wl_surface.damage_buffer(region.x, region.y, region.width, region.height);
-        }
-
-        let force_frame_callback = self.frozen.preflight_pending()
-            || self.zoom.preflight_pending()
-            || self.capture.preflight_needs_frame_callback();
-        if self.config.performance.enable_vsync {
-            debug!("Requesting frame callback (vsync enabled)");
-            wl_surface.frame(qh, wl_surface.clone());
-        } else if force_frame_callback {
-            debug!("Requesting frame callback (preflight)");
-            wl_surface.frame(qh, wl_surface.clone());
-            self.surface.set_frame_callback_pending(true);
-        } else {
-            debug!("Skipping frame callback (vsync disabled - allows back-to-back renders)");
-        }
-
-        self.commit_perf_frame(
-            &damage_screen,
-            width,
-            height,
-            scaled_damage.len(),
-            full_damage_reason,
-            Instant::now(),
-        );
-        wl_surface.commit();
+            wl_surface.commit();
+            Ok::<(), anyhow::Error>(())
+        })?;
         debug!("=== RENDER COMPLETE ===");
 
         // Render toolbar overlays if visible, only when state/hover changed.
-        self.render_layer_toolbars_if_needed();
+        record_stage!(toolbar, {
+            self.render_layer_toolbars_if_needed();
+        });
+        if let Some(breakdown) = render_breakdown {
+            self.record_perf_render_breakdown(breakdown);
+        }
 
         if self.capture_suppressed() {
             self.capture.mark_preflight_rendered();
@@ -353,5 +426,8 @@ impl WaylandState {
 fn input_full_damage_reason(
     reason: Option<crate::draw::DirtyFullReason>,
 ) -> Option<FullDamageReason> {
-    reason.map(|crate::draw::DirtyFullReason::CanvasClear| FullDamageReason::CanvasClear)
+    reason.map(|reason| match reason {
+        crate::draw::DirtyFullReason::CanvasClear => FullDamageReason::CanvasClear,
+        crate::draw::DirtyFullReason::FirstRunOnboarding => FullDamageReason::FirstRunOnboarding,
+    })
 }

--- a/src/draw/dirty.rs
+++ b/src/draw/dirty.rs
@@ -8,6 +8,7 @@ use crate::util::Rect;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DirtyFullReason {
     CanvasClear,
+    FirstRunOnboarding,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/input/state/core/base/mod.rs
+++ b/src/input/state/core/base/mod.rs
@@ -15,7 +15,8 @@ pub use types::{
 pub(crate) use types::{
     BlockedActionFeedback, BoardPickerClickState, ClipboardFingerprint, ClipboardPasteRequest,
     DelayedHistory, HistoryMode, PasteAnchor, PendingBackendAction, PendingBoardDelete,
-    PendingClipboardFallback, PendingPageDelete, PendingSelectionClipboardPublish,
-    PolygonClickState, PresetFeedbackState, SelectionPublishState, TextClickState,
-    TextEditEntryFeedback, ToastAction, UiToastState, WayscriberClipboardSelection,
+    PendingClipboardFallback, PendingOnboardingUsage, PendingPageDelete,
+    PendingSelectionClipboardPublish, PolygonClickState, PresetFeedbackState,
+    SelectionPublishState, TextClickState, TextEditEntryFeedback, ToastAction, UiToastState,
+    WayscriberClipboardSelection,
 };

--- a/src/input/state/core/mod.rs
+++ b/src/input/state/core/mod.rs
@@ -29,7 +29,8 @@ pub use base::{
 pub(crate) use base::{BoardPickerClickState, PolygonClickState, TextClickState};
 pub(crate) use base::{
     ClipboardFingerprint, ClipboardPasteRequest, PasteAnchor, PendingBackendAction,
-    PendingSelectionClipboardPublish, SelectionPublishState, WayscriberClipboardSelection,
+    PendingOnboardingUsage, PendingSelectionClipboardPublish, SelectionPublishState,
+    WayscriberClipboardSelection,
 };
 pub use board_picker::{BoardPickerCursorHint, BoardPickerLayout};
 pub use color_picker_popup::{

--- a/src/input/state/core/utility/interaction.rs
+++ b/src/input/state/core/utility/interaction.rs
@@ -151,9 +151,6 @@ impl InputState {
             return;
         }
 
-        // First-run onboarding card can live outside the stroke bounds. Force a
-        // full repaint so the step transition appears immediately.
-        self.dirty_tracker.mark_full();
         self.pending_onboarding_usage.first_stroke_done = true;
     }
 

--- a/src/input/state/mod.rs
+++ b/src/input/state/mod.rs
@@ -35,7 +35,8 @@ pub(crate) use core::{
 #[allow(unused_imports)]
 pub(crate) use core::{
     ClipboardFingerprint, ClipboardPasteRequest, PasteAnchor, PendingBackendAction,
-    PendingSelectionClipboardPublish, SelectionPublishState, WayscriberClipboardSelection,
+    PendingOnboardingUsage, PendingSelectionClipboardPublish, SelectionPublishState,
+    WayscriberClipboardSelection,
 };
 pub use highlight::ClickHighlightSettings;
 

--- a/src/input/state/tests/drawing.rs
+++ b/src/input/state/tests/drawing.rs
@@ -314,6 +314,32 @@ fn append_path_long_diagonal_release_splits_finished_path_damage() {
 }
 
 #[test]
+fn first_stroke_onboarding_signal_keeps_release_damage_bounded() {
+    let mut state = create_test_input_state();
+    assert!(state.set_tool_override(Some(Tool::Pen)));
+    state.update_screen_dimensions(1000, 1000);
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_press(MouseButton::Left, 10, 10);
+    let _ = state.take_dirty_regions();
+    state.on_mouse_motion(900, 900);
+    let _ = state.take_dirty_regions();
+
+    state.on_mouse_release(MouseButton::Left, 900, 900);
+    let first_dirty = state.take_dirty_region_report();
+
+    assert!(state.pending_onboarding_usage.first_stroke_done);
+    assert_eq!(first_dirty.full_reason, None);
+    assert!(
+        first_dirty.regions.iter().all(|rect| {
+            !(rect.x <= 0 && rect.y <= 0 && rect.width >= 1000 && rect.height >= 1000)
+        }),
+        "input onboarding usage should not force full-surface release damage; dirty={:?}",
+        first_dirty.regions
+    );
+}
+
+#[test]
 fn pressure_preview_release_cleans_wide_preview_when_final_freehand_narrows() {
     let mut state = create_test_input_state();
     assert!(state.set_tool_override(Some(Tool::Pen)));


### PR DESCRIPTION
Body:

## Summary
- Add `WAYSCRIBER_PERF_LOG` render-stage diagnostics for frame timing, damage provenance, merge counts, shape culling, render-profile activity, and canvas-layer cache use
- Avoid forcing full-surface damage after first-stroke onboarding bookkeeping when onboarding is already complete
- Split render perf breakdown and damage diagnostics into focused modules