### PR TITLE
Unify toolbar icons across built-in and GTK frontends

### DIFF
--- a/src/backend/wayland/toolbar/render/side_palette/header.rs
+++ b/src/backend/wayland/toolbar/render/side_palette/header.rs
@@ -102,7 +102,7 @@ pub(super) fn draw_header(layout: &mut SidePaletteLayout) -> f64 {
     let close_hover = hover
         .map(|(hx, hy)| point_in_rect(hx, hy, close_x, btn_y, btn_size, btn_size))
         .unwrap_or(false);
-    draw_minimize_button(ctx, close_x, btn_y, btn_size, close_hover);
+    draw_side_minimize_button(ctx, close_x, btn_y, btn_size, close_hover);
     hits.push(HitRegion {
         focus_id: None,
         rect: (close_x, btn_y, btn_size, btn_size),

--- a/src/backend/wayland/toolbar/render/widgets/buttons.rs
+++ b/src/backend/wayland/toolbar/render/widgets/buttons.rs
@@ -4,8 +4,7 @@ use super::constants::{
     COLOR_BUTTON_HOVER, COLOR_CLOSE_DEFAULT, COLOR_CLOSE_HOVER, COLOR_FOCUS_RING, COLOR_PIN_ACTIVE,
     COLOR_PIN_DEFAULT, COLOR_PIN_HOVER, COLOR_SEGMENT_ACTIVE, COLOR_SEGMENT_BG,
     COLOR_SEGMENT_DIVIDER, COLOR_SEGMENT_HOVER, COLOR_SEGMENT_TEXT_ACTIVE,
-    COLOR_SEGMENT_TEXT_INACTIVE, COLOR_TEXT_PRIMARY, LINE_WIDTH_THICK, RADIUS_LG, RADIUS_STD,
-    SPACING_XS, set_color,
+    COLOR_SEGMENT_TEXT_INACTIVE, COLOR_TEXT_PRIMARY, RADIUS_LG, RADIUS_STD, set_color,
 };
 use super::draw_round_rect;
 use crate::ui_text::{UiTextStyle, text_layout};
@@ -32,34 +31,60 @@ pub(in crate::backend::wayland::toolbar::render) fn draw_drag_handle(
         let _ = ctx.stroke();
     }
 
-    ctx.set_line_width(1.1);
     let bar_alpha = if hover { 1.0 } else { 0.85 };
     ctx.set_source_rgba(1.0, 1.0, 1.0, bar_alpha);
-    let bar_w = w * 0.55;
-    let bar_h = SPACING_XS;
-    let bar_gap = SPACING_XS;
-    let bar_x = x + (w - bar_w) / 2.0;
-    let mut bar_y = drag_handle_bar_start_y(y, h, bar_h, bar_gap);
-    for _ in 0..3 {
-        draw_round_rect(ctx, bar_x, bar_y, bar_w, bar_h, 1.0);
-        let _ = ctx.fill();
-        bar_y += bar_h + bar_gap;
-    }
+    let icon_size = w.min(h);
+    crate::toolbar_icons::draw_icon_drag(
+        ctx,
+        x + (w - icon_size) / 2.0,
+        y + (h - icon_size) / 2.0,
+        icon_size,
+    );
 }
 
-fn drag_handle_bar_start_y(y: f64, h: f64, bar_h: f64, bar_gap: f64) -> f64 {
-    let stack_h = 3.0 * bar_h + 2.0 * bar_gap;
-    y + (h - stack_h) / 2.0
-}
-
-/// Minimize chrome button: a dash, not an X — the bar collapses to an
-/// edge restore tab instead of disappearing.
+/// Minimize the horizontal top bar into its edge restore tab.
 pub(in crate::backend::wayland::toolbar::render) fn draw_minimize_button(
     ctx: &cairo::Context,
     x: f64,
     y: f64,
     size: f64,
     hover: bool,
+) {
+    draw_collapse_button(
+        ctx,
+        x,
+        y,
+        size,
+        hover,
+        crate::toolbar_icons::draw_icon_minimize,
+    );
+}
+
+/// Minimize the vertical side palette into its edge restore tab.
+pub(in crate::backend::wayland::toolbar::render) fn draw_side_minimize_button(
+    ctx: &cairo::Context,
+    x: f64,
+    y: f64,
+    size: f64,
+    hover: bool,
+) {
+    draw_collapse_button(
+        ctx,
+        x,
+        y,
+        size,
+        hover,
+        crate::toolbar_icons::draw_icon_side_minimize,
+    );
+}
+
+fn draw_collapse_button(
+    ctx: &cairo::Context,
+    x: f64,
+    y: f64,
+    size: f64,
+    hover: bool,
+    glyph: fn(&cairo::Context, f64, f64, f64),
 ) {
     let r = size / 2.0;
     let cx = x + r;
@@ -77,11 +102,13 @@ pub(in crate::backend::wayland::toolbar::render) fn draw_minimize_button(
     let _ = ctx.fill();
 
     set_color(ctx, COLOR_TEXT_PRIMARY);
-    ctx.set_line_width(LINE_WIDTH_THICK);
-    let inset = size * 0.28;
-    ctx.move_to(x + inset, cy);
-    ctx.line_to(x + size - inset, cy);
-    let _ = ctx.stroke();
+    let icon_size = size * 0.6;
+    glyph(
+        ctx,
+        x + (size - icon_size) / 2.0,
+        y + (size - icon_size) / 2.0,
+        icon_size,
+    );
 }
 
 pub(in crate::backend::wayland::toolbar::render) fn draw_pin_button(
@@ -115,43 +142,15 @@ pub(in crate::backend::wayland::toolbar::render) fn draw_pin_button(
     ctx.arc(cx, cy, r, 0.0, PI * 2.0);
     let _ = ctx.fill();
 
-    let pin_size = size * 0.5;
-    draw_pushpin(ctx, cx, cy, pin_size, pinned);
-}
-
-/// Draw a pushpin glyph centered at (cx, cy). The control means
-/// "keep this toolbar open at startup", so the glyph is a thumbtack —
-/// filled when pinned, outline when not.
-fn draw_pushpin(ctx: &cairo::Context, cx: f64, cy: f64, size: f64, filled: bool) {
-    let s = size;
-
-    ctx.new_path();
-    // Head: flat cap at the top
-    ctx.move_to(cx - s * 0.45, cy - s * 0.85);
-    ctx.line_to(cx + s * 0.45, cy - s * 0.85);
-    ctx.line_to(cx + s * 0.3, cy - s * 0.55);
-    // Neck down to the flange
-    ctx.line_to(cx + s * 0.3, cy - s * 0.15);
-    // Flange: wider base plate
-    ctx.line_to(cx + s * 0.6, cy + s * 0.15);
-    ctx.line_to(cx - s * 0.6, cy + s * 0.15);
-    ctx.line_to(cx - s * 0.3, cy - s * 0.15);
-    ctx.line_to(cx - s * 0.3, cy - s * 0.55);
-    ctx.close_path();
-
     set_color(ctx, COLOR_TEXT_PRIMARY);
-    if filled {
-        let _ = ctx.fill();
+    let icon_size = size * 0.62;
+    let icon_x = x + (size - icon_size) / 2.0;
+    let icon_y = y + (size - icon_size) / 2.0;
+    if pinned {
+        crate::toolbar_icons::draw_icon_pin(ctx, icon_x, icon_y, icon_size);
     } else {
-        ctx.set_line_width(1.3);
-        let _ = ctx.stroke();
+        crate::toolbar_icons::draw_icon_unpin(ctx, icon_x, icon_y, icon_size);
     }
-
-    // Needle below the flange
-    ctx.set_line_width(if filled { 1.6 } else { 1.3 });
-    ctx.move_to(cx, cy + s * 0.15);
-    ctx.line_to(cx, cy + s * 0.85);
-    let _ = ctx.stroke();
 }
 
 pub(in crate::backend::wayland::toolbar::render) fn draw_button(
@@ -352,24 +351,5 @@ pub(in crate::backend::wayland::toolbar::render) fn draw_segmented_control(
         let tx = label_x + (segment_w - ext.width()) / 2.0 - ext.x_bearing();
         let ty = y + (h - ext.height()) / 2.0 - ext.y_bearing();
         layout.show_at_baseline(ctx, tx, ty);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn drag_handle_bars_center_full_stack_in_button() {
-        let y = 12.0;
-        let h = 18.0;
-        let bar_h = 2.0;
-        let bar_gap = 2.0;
-
-        let start_y = drag_handle_bar_start_y(y, h, bar_h, bar_gap);
-        let stack_h = 3.0 * bar_h + 2.0 * bar_gap;
-
-        assert_eq!(start_y, 16.0);
-        assert_eq!(start_y + stack_h / 2.0, y + h / 2.0);
     }
 }

--- a/src/backend/wayland/toolbar/render/widgets/mod.rs
+++ b/src/backend/wayland/toolbar/render/widgets/mod.rs
@@ -11,7 +11,7 @@ mod tooltip;
 pub(super) use background::{draw_group_card, draw_panel_background, draw_popover_panel};
 pub(super) use buttons::{
     draw_button, draw_destructive_button, draw_disabled_button, draw_drag_handle,
-    draw_minimize_button, draw_pin_button, draw_segmented_control,
+    draw_minimize_button, draw_pin_button, draw_segmented_control, draw_side_minimize_button,
 };
 pub(super) use checkbox::{draw_checkbox, draw_mini_checkbox};
 pub(super) use color::{draw_color_indicator, draw_hue_bar, draw_sat_val_area, draw_swatch};

--- a/src/backend/wayland/toolbar/view/top/build.rs
+++ b/src/backend/wayland/toolbar/view/top/build.rs
@@ -109,13 +109,12 @@ pub(super) fn build_top_view_planned(
         tool_drawn = true;
     }
 
-    // --- Shapes picker (face = last-used shape, caret grid below) ----------
+    // --- Shapes picker (family icon, caret grid below) ----------------------
     let mut picker_anchor: Option<(f64, f64, f64, f64)> = None;
     if model::top_shape_picker_visible(snapshot) {
         if previous_group == Some(model::TopToolGroup::Pens) {
             push_divider(&mut tree, &mut x, "tools");
         }
-        let icon_tool = current_shape_tool.unwrap_or_else(model::default_shape_tool);
         let picker_active = snapshot.shape_picker_open || current_shape_tool.is_some();
         let interact = Interaction::click(
             ToolbarEvent::ToggleShapePicker(!snapshot.shape_picker_open),
@@ -123,7 +122,7 @@ pub(super) fn build_top_view_planned(
         );
         let kind = if use_icons {
             WidgetKind::IconButton {
-                glyph: semantic_icon_fn(model::semantic_icon_for_tool(icon_tool)),
+                glyph: IconFn(toolbar_icons::draw_icon_shape_picker),
                 icon_size: ToolbarLayoutSpec::TOP_ICON_SIZE,
                 style: ButtonStyle::active(picker_active),
             }
@@ -644,7 +643,7 @@ fn build_top_minimized_tab(width: f64, height: f64) -> WidgetTree {
         "top.chrome.restore",
         (0.0, 0.0, width, height),
         WidgetKind::IconButton {
-            glyph: IconFn(toolbar_icons::draw_icon_chevron_down),
+            glyph: IconFn(toolbar_icons::draw_icon_restore),
             icon_size: (height * 0.75).min(18.0),
             style: ButtonStyle::plain(),
         },

--- a/src/toolbar_gtk/icons.rs
+++ b/src/toolbar_gtk/icons.rs
@@ -41,8 +41,8 @@ pub(super) fn tool_icon_painter(tool: Tool) -> IconPainter {
     }
 }
 
-/// Handle to an icon widget whose painter can be swapped (the shapes
-/// picker face shows the last-used shape).
+/// Handle to an icon widget whose painter can be swapped when live toolbar
+/// state changes the represented action (for example pin/unpin).
 #[derive(Clone)]
 pub(super) struct IconWidget {
     pub(super) area: gtk4::DrawingArea,

--- a/src/toolbar_gtk/view/side_bar.rs
+++ b/src/toolbar_gtk/view/side_bar.rs
@@ -292,7 +292,7 @@ impl SideBar {
         let band = gtk4::Box::new(gtk4::Orientation::Horizontal, px(6.0));
         band.add_css_class("header-band");
 
-        let grip = IconWidget::new(toolbar_icons::draw_icon_grip_bars, 18.0 * scale);
+        let grip = IconWidget::new(toolbar_icons::draw_icon_drag, 18.0 * scale);
         grip.area.set_can_target(true);
         grip.area.add_css_class("drag-handle");
         grip.area.set_tooltip_text(Some("Drag toolbar"));
@@ -457,9 +457,9 @@ impl SideBar {
         button.add_css_class("chrome");
         let icon = IconWidget::new(
             if snapshot.side_pinned {
-                toolbar_icons::draw_icon_pin_filled
+                toolbar_icons::draw_icon_pin
             } else {
-                toolbar_icons::draw_icon_pin_outline
+                toolbar_icons::draw_icon_unpin
             },
             size * 0.62,
         );
@@ -474,9 +474,9 @@ impl SideBar {
         self.chrome_updaters.push(Box::new(move |snapshot| {
             pinned.set(snapshot.side_pinned);
             icon.set_painter(if snapshot.side_pinned {
-                toolbar_icons::draw_icon_pin_filled
+                toolbar_icons::draw_icon_pin
             } else {
-                toolbar_icons::draw_icon_pin_outline
+                toolbar_icons::draw_icon_unpin
             });
             if snapshot.side_pinned {
                 handle.add_css_class("pinned");
@@ -494,7 +494,7 @@ impl SideBar {
         button.add_css_class("chrome");
         button.add_css_class("minimize");
         button.set_tooltip_text(Some("Minimize (leaves a restore tab)"));
-        let icon = IconWidget::new(toolbar_icons::draw_icon_dash, size * 0.6);
+        let icon = IconWidget::new(toolbar_icons::draw_icon_side_minimize, size * 0.6);
         button.set_child(Some(&icon.area));
         let sender = self.feedback.clone();
         button.connect_clicked(move |_| {

--- a/src/toolbar_gtk/view/top_bar.rs
+++ b/src/toolbar_gtk/view/top_bar.rs
@@ -370,7 +370,7 @@ impl TopBar {
         restore.add_css_class("chrome");
         restore.set_tooltip_text(Some("Show toolbar"));
         let icon = IconWidget::new(
-            toolbar_icons::draw_icon_chevron_down,
+            toolbar_icons::draw_icon_restore,
             (MINIMIZED_SIZE.1 * 0.75 * scale).min(18.0 * scale),
         );
         restore.set_child(Some(&icon.area));
@@ -436,7 +436,7 @@ impl TopBar {
 
         // --- Drag grip -----------------------------------------------------
         if model::toolbar_item_visible(snapshot, crate::config::toolbar_item_ids::TOP_CHROME_DRAG) {
-            let grip = IconWidget::new(toolbar_icons::draw_icon_grip_bars, sz(HANDLE_SIZE));
+            let grip = IconWidget::new(toolbar_icons::draw_icon_drag, sz(HANDLE_SIZE));
             grip.area.set_can_target(true);
             grip.area.add_css_class("drag-handle");
             grip.area.set_tooltip_text(Some("Drag toolbar"));
@@ -755,31 +755,23 @@ impl TopBar {
         button
     }
 
-    /// Shapes picker button: face shows the last-used shape; the popover
-    /// carries the grid and per-tool option rows.
+    /// Shapes picker button: the family icon opens the grid and per-tool
+    /// option rows; individual shapes keep their own icons inside the popover.
     fn shapes_picker_button(
         &mut self,
-        snapshot: &ToolbarSnapshot,
+        _snapshot: &ToolbarSnapshot,
         button_size: (f64, f64),
         icon_size: f64,
         use_icons: bool,
     ) -> gtk4::Button {
-        let face_tool = model::current_shape_tool(snapshot.active_tool, snapshot.tool_override)
-            .unwrap_or_else(model::default_shape_tool);
         let button = if use_icons {
-            let icon = icon_button(
-                tool_icon_painter(face_tool),
+            icon_button(
+                toolbar_icons::draw_icon_shape_picker,
                 button_size,
                 icon_size,
                 "Shapes",
-            );
-            let icon_handle = icon.icon.clone();
-            self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-                let face = model::current_shape_tool(snapshot.active_tool, snapshot.tool_override)
-                    .unwrap_or_else(model::default_shape_tool);
-                icon_handle.set_painter(tool_icon_painter(face));
-            }));
-            icon.button
+            )
+            .button
         } else {
             text_button("Shapes", button_size, "Shapes")
         };
@@ -944,9 +936,9 @@ impl TopBar {
         button.add_css_class("chrome");
         let icon = IconWidget::new(
             if snapshot.top_pinned {
-                toolbar_icons::draw_icon_pin_filled
+                toolbar_icons::draw_icon_pin
             } else {
-                toolbar_icons::draw_icon_pin_outline
+                toolbar_icons::draw_icon_unpin
             },
             size * 0.62,
         );
@@ -961,9 +953,9 @@ impl TopBar {
         self.updaters.borrow_mut().push(Box::new(move |snapshot| {
             pinned.set(snapshot.top_pinned);
             icon.set_painter(if snapshot.top_pinned {
-                toolbar_icons::draw_icon_pin_filled
+                toolbar_icons::draw_icon_pin
             } else {
-                toolbar_icons::draw_icon_pin_outline
+                toolbar_icons::draw_icon_unpin
             });
             if snapshot.top_pinned {
                 handle.add_css_class("pinned");
@@ -1025,7 +1017,7 @@ impl TopBar {
         button.add_css_class("chrome");
         button.add_css_class("minimize");
         button.set_tooltip_text(Some("Minimize (leaves a restore tab)"));
-        let icon = IconWidget::new(toolbar_icons::draw_icon_dash, size * 0.6);
+        let icon = IconWidget::new(toolbar_icons::draw_icon_minimize, size * 0.6);
         button.set_child(Some(&icon.area));
         let sender = self.feedback.clone();
         button.connect_clicked(move |_| {

--- a/src/toolbar_gtk/widgets.rs
+++ b/src/toolbar_gtk/widgets.rs
@@ -161,7 +161,6 @@ pub(super) fn install_shortcut_focus_policy(window: &gtk4::Window) {
 
 pub(super) struct IconButton {
     pub(super) button: gtk4::Button,
-    pub(super) icon: IconWidget,
 }
 
 pub(super) fn icon_button(
@@ -174,7 +173,7 @@ pub(super) fn icon_button(
     let icon = IconWidget::new(painter, icon_size);
     button.set_child(Some(&icon.area));
     button.set_tooltip_text(Some(tooltip));
-    IconButton { button, icon }
+    IconButton { button }
 }
 
 pub(super) fn text_button(label: &str, button_size: (f64, f64), tooltip: &str) -> gtk4::Button {

--- a/src/toolbar_icons/actions.rs
+++ b/src/toolbar_icons/actions.rs
@@ -3,30 +3,7 @@ use std::f64::consts::PI;
 
 /// Draw a clear/trash icon
 pub fn draw_icon_clear(ctx: &Context, x: f64, y: f64, size: f64) {
-    let s = size;
-    let stroke = (s * 0.1).max(1.5);
-    ctx.set_line_width(stroke);
-    ctx.set_line_cap(cairo::LineCap::Round);
-    ctx.set_line_join(cairo::LineJoin::Round);
-
-    // Trash can body
-    ctx.move_to(x + s * 0.25, y + s * 0.35);
-    ctx.line_to(x + s * 0.3, y + s * 0.8);
-    ctx.line_to(x + s * 0.7, y + s * 0.8);
-    ctx.line_to(x + s * 0.75, y + s * 0.35);
-    let _ = ctx.stroke();
-
-    // Lid
-    ctx.move_to(x + s * 0.2, y + s * 0.35);
-    ctx.line_to(x + s * 0.8, y + s * 0.35);
-    let _ = ctx.stroke();
-
-    // Handle
-    ctx.move_to(x + s * 0.4, y + s * 0.35);
-    ctx.line_to(x + s * 0.4, y + s * 0.25);
-    ctx.line_to(x + s * 0.6, y + s * 0.25);
-    ctx.line_to(x + s * 0.6, y + s * 0.35);
-    let _ = ctx.stroke();
+    super::svg::render_clear_canvas(ctx, x, y, size);
 }
 
 /// Draw a freeze/pause icon
@@ -250,25 +227,7 @@ pub fn draw_icon_copy(ctx: &Context, x: f64, y: f64, size: f64) {
 
 /// Draw a screenshot/camera icon.
 pub fn draw_icon_screenshot(ctx: &Context, x: f64, y: f64, size: f64) {
-    let s = size;
-    let stroke = (s * 0.09).max(1.5);
-    ctx.set_line_width(stroke);
-    ctx.set_line_join(cairo::LineJoin::Round);
-    ctx.set_line_cap(cairo::LineCap::Round);
-
-    ctx.rectangle(x + s * 0.18, y + s * 0.32, s * 0.64, s * 0.46);
-    let _ = ctx.stroke();
-
-    ctx.move_to(x + s * 0.34, y + s * 0.32);
-    ctx.line_to(x + s * 0.4, y + s * 0.22);
-    ctx.line_to(x + s * 0.6, y + s * 0.22);
-    ctx.line_to(x + s * 0.66, y + s * 0.32);
-    let _ = ctx.stroke();
-
-    ctx.arc(x + s * 0.5, y + s * 0.56, s * 0.13, 0.0, PI * 2.0);
-    let _ = ctx.stroke();
-    ctx.arc(x + s * 0.72, y + s * 0.4, s * 0.035, 0.0, PI * 2.0);
-    let _ = ctx.fill();
+    super::svg::render_screenshot(ctx, x, y, size);
 }
 
 /// Draw a visibility/eye icon.
@@ -335,6 +294,7 @@ pub fn draw_icon_chevron_right(ctx: &Context, x: f64, y: f64, size: f64) {
 }
 
 /// Draw a downward chevron icon (expand below).
+#[allow(dead_code)] // used by toolbar-gtk section controls when that feature is enabled
 pub fn draw_icon_chevron_down(ctx: &Context, x: f64, y: f64, size: f64) {
     let s = size;
     let stroke = (s * 0.12).max(1.5);

--- a/src/toolbar_icons/controls.rs
+++ b/src/toolbar_icons/controls.rs
@@ -30,17 +30,7 @@ pub fn draw_icon_plus(ctx: &Context, x: f64, y: f64, size: f64) {
 
 /// Draw a "more" (three dots) icon
 pub fn draw_icon_more(ctx: &Context, x: f64, y: f64, size: f64) {
-    let s = size;
-    let r = (s * 0.09).max(1.5);
-    let cy = y + s * 0.5;
-    let start_x = x + s * 0.25;
-    let gap = s * 0.25;
-
-    for i in 0..3 {
-        let cx = start_x + gap * i as f64;
-        ctx.arc(cx, cy, r, 0.0, PI * 2.0);
-        let _ = ctx.fill();
-    }
+    super::svg::render_more(ctx, x, y, size);
 }
 
 /// Draw an information icon.
@@ -146,71 +136,64 @@ pub fn draw_icon_board(ctx: &Context, x: f64, y: f64, size: f64) {
 /// handles. Uses the context's current source color.
 #[allow(dead_code)] // referenced by the toolbar-gtk frontend only
 pub fn draw_icon_grip_bars(ctx: &Context, x: f64, y: f64, size: f64) {
-    let bar_w = size * 0.55;
-    let bar_h = (size * 0.11).max(1.5);
-    let bar_gap = bar_h;
-    let stack_h = 3.0 * bar_h + 2.0 * bar_gap;
-    let bar_x = x + (size - bar_w) / 2.0;
-    let mut bar_y = y + (size - stack_h) / 2.0;
-    for _ in 0..3 {
-        ctx.rectangle(bar_x, bar_y, bar_w, bar_h);
-        let _ = ctx.fill();
-        bar_y += bar_h + bar_gap;
-    }
+    draw_icon_drag(ctx, x, y, size);
+}
+
+/// Draw the toolbar drag handle.
+pub fn draw_icon_drag(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_drag(ctx, x, y, size);
 }
 
 /// Draw a minimize dash (not an X: the bar collapses to a restore tab).
 #[allow(dead_code)] // referenced by the toolbar-gtk frontend only
 pub fn draw_icon_dash(ctx: &Context, x: f64, y: f64, size: f64) {
-    ctx.set_line_width((size * 0.12).max(1.6));
-    ctx.set_line_cap(cairo::LineCap::Round);
-    let inset = size * 0.24;
-    let cy = y + size / 2.0;
-    ctx.move_to(x + inset, cy);
-    ctx.line_to(x + size - inset, cy);
-    let _ = ctx.stroke();
+    draw_icon_minimize(ctx, x, y, size);
 }
 
 /// Draw a pushpin glyph ("keep open at startup"): outline when unpinned,
 /// filled when pinned. Geometry mirrors the built-in pin chrome button.
 #[allow(dead_code)] // referenced by the toolbar-gtk frontend only
 pub fn draw_icon_pushpin(ctx: &Context, x: f64, y: f64, size: f64, filled: bool) {
-    let s = size / 2.0;
-    let cx = x + s;
-    let cy = y + s;
-
-    ctx.new_path();
-    ctx.move_to(cx - s * 0.45, cy - s * 0.85);
-    ctx.line_to(cx + s * 0.45, cy - s * 0.85);
-    ctx.line_to(cx + s * 0.3, cy - s * 0.55);
-    ctx.line_to(cx + s * 0.3, cy - s * 0.15);
-    ctx.line_to(cx + s * 0.6, cy + s * 0.15);
-    ctx.line_to(cx - s * 0.6, cy + s * 0.15);
-    ctx.line_to(cx - s * 0.3, cy - s * 0.15);
-    ctx.line_to(cx - s * 0.3, cy - s * 0.55);
-    ctx.close_path();
     if filled {
-        let _ = ctx.fill();
+        draw_icon_pin(ctx, x, y, size);
     } else {
-        ctx.set_line_width(1.3);
-        let _ = ctx.stroke();
+        draw_icon_unpin(ctx, x, y, size);
     }
-
-    ctx.set_line_width(if filled { 1.6 } else { 1.3 });
-    ctx.set_line_cap(cairo::LineCap::Round);
-    ctx.move_to(cx, cy + s * 0.15);
-    ctx.line_to(cx, cy + s * 0.85);
-    let _ = ctx.stroke();
 }
 
 /// Outline pushpin with the 4-arg painter shape used by icon widgets.
 #[allow(dead_code)] // referenced by the toolbar-gtk frontend only
 pub fn draw_icon_pin_outline(ctx: &Context, x: f64, y: f64, size: f64) {
-    draw_icon_pushpin(ctx, x, y, size, false);
+    draw_icon_unpin(ctx, x, y, size);
 }
 
 /// Filled pushpin with the 4-arg painter shape used by icon widgets.
 #[allow(dead_code)] // referenced by the toolbar-gtk frontend only
 pub fn draw_icon_pin_filled(ctx: &Context, x: f64, y: f64, size: f64) {
-    draw_icon_pushpin(ctx, x, y, size, true);
+    draw_icon_pin(ctx, x, y, size);
+}
+
+pub fn draw_icon_pin(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_pin(ctx, x, y, size);
+}
+
+pub fn draw_icon_unpin(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_unpin(ctx, x, y, size);
+}
+
+pub fn draw_icon_minimize(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_minimize(ctx, x, y, size);
+}
+
+pub fn draw_icon_side_minimize(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_side_minimize(ctx, x, y, size);
+}
+
+pub fn draw_icon_restore(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_restore(ctx, x, y, size);
+}
+
+#[allow(dead_code)] // part of the complete icon family; no close action today
+pub fn draw_icon_close(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_close(ctx, x, y, size);
 }

--- a/src/toolbar_icons/history/arrows.rs
+++ b/src/toolbar_icons/history/arrows.rs
@@ -1,35 +1,6 @@
 use cairo::Context;
 use std::f64::consts::PI;
 
-/// Common helper to draw a single curved arrow pointing left.
-/// Set `offset_y` when you want a subtle vertical shift (not used here, but kept
-/// for compatibility with older call sites).
-pub(super) fn draw_curved_arrow(ctx: &Context, x: f64, y: f64, size: f64, offset_y: bool) {
-    let s = size;
-    let stroke = (s * 0.12).max(1.5);
-    ctx.set_line_width(stroke);
-    ctx.set_line_cap(cairo::LineCap::Round);
-    ctx.set_line_join(cairo::LineJoin::Round);
-
-    let cx = x + s * 0.5;
-    let cy = y + s * 0.5 + if offset_y { s * 0.02 } else { 0.0 };
-    let r = s * 0.38;
-
-    // Sweep around most of the circle, leaving a small gap on the left where the head sits.
-    let start_angle = -PI * 0.9;
-    let end_angle = PI * 0.9;
-
-    ctx.save().ok();
-    // Slight clockwise tilt to match the rest of the toolbar
-    ctx.translate(cx, cy);
-    ctx.rotate(-10f64.to_radians());
-    ctx.translate(-cx, -cy);
-
-    draw_arc_with_head(ctx, cx, cy, r, start_angle, end_angle, s * 0.18);
-
-    ctx.restore().ok();
-}
-
 /// Helper to draw the "undo all / redo all" double curved arrow.
 ///
 /// Front arrow = same geometry as the single undo/redo.

--- a/src/toolbar_icons/history/mod.rs
+++ b/src/toolbar_icons/history/mod.rs
@@ -6,15 +6,12 @@ use cairo::Context;
 
 /// Draw an undo icon (curved arrow left)
 pub fn draw_icon_undo(ctx: &Context, x: f64, y: f64, size: f64) {
-    arrows::draw_curved_arrow(ctx, x, y, size, false);
+    super::svg::render_undo(ctx, x, y, size);
 }
 
 /// Draw a redo icon (curved arrow right)
 pub fn draw_icon_redo(ctx: &Context, x: f64, y: f64, size: f64) {
-    // Mirror the undo arrow for perfect symmetry
-    with_horizontal_mirror(ctx, x, y, size, |ctx| {
-        arrows::draw_curved_arrow(ctx, 0.0, 0.0, size, false);
-    });
+    super::svg::render_redo(ctx, x, y, size);
 }
 
 /// Draw an undo all icon (double curved arrow left)

--- a/src/toolbar_icons/svg.rs
+++ b/src/toolbar_icons/svg.rs
@@ -1,7 +1,9 @@
-//! Tool icon drawing via local Cairo paths.
+//! Wayscriber Core toolbar icons.
 //!
-//! These icons intentionally mirror the small Lucide-style assets used by the
-//! toolbar without depending on a full SVG parser and rasterizer.
+//! Original MIT-licensed 24×24 geometry. The caller owns foreground color,
+//! alpha, clipping, hover/active backgrounds, and disabled-state opacity.
+//! Every public renderer accepts the same `(ctx, x, y, size)` contract used by
+//! Wayscriber's existing Cairo toolbar icon entry points.
 
 use cairo::Context;
 use std::f64::consts::PI;
@@ -9,14 +11,12 @@ use std::f64::consts::PI;
 type IconDraw = fn(&Context);
 
 fn render_icon(ctx: &Context, x: f64, y: f64, size: f64, draw: IconDraw) {
-    if size <= 0.0 {
+    if !size.is_finite() || size <= 0.0 {
         return;
     }
-
     let _ = ctx.save();
     ctx.translate(x, y);
-    let scale = size / 24.0;
-    ctx.scale(scale, scale);
+    ctx.scale(size / 24.0, size / 24.0);
     ctx.set_line_width(2.0);
     ctx.set_line_cap(cairo::LineCap::Round);
     ctx.set_line_join(cairo::LineJoin::Round);
@@ -24,12 +24,24 @@ fn render_icon(ctx: &Context, x: f64, y: f64, size: f64, draw: IconDraw) {
     let _ = ctx.restore();
 }
 
+#[inline]
 fn stroke(ctx: &Context) {
     let _ = ctx.stroke();
 }
 
+#[inline]
 fn fill(ctx: &Context) {
     let _ = ctx.fill();
+}
+
+fn circle(ctx: &Context, cx: f64, cy: f64, radius: f64) {
+    ctx.new_path();
+    ctx.arc(cx, cy, radius, 0.0, PI * 2.0);
+}
+
+fn dot(ctx: &Context, cx: f64, cy: f64, radius: f64) {
+    circle(ctx, cx, cy, radius);
+    fill(ctx);
 }
 
 fn rounded_rect(ctx: &Context, x: f64, y: f64, width: f64, height: f64, radius: f64) {
@@ -44,298 +56,599 @@ fn rounded_rect(ctx: &Context, x: f64, y: f64, width: f64, height: f64, radius: 
         PI / 2.0,
     );
     ctx.arc(x + radius, y + height - radius, radius, PI / 2.0, PI);
-    ctx.arc(x + radius, y + radius, radius, PI, 3.0 * PI / 2.0);
+    ctx.arc(x + radius, y + radius, radius, PI, PI * 1.5);
     ctx.close_path();
 }
 
-fn circle(ctx: &Context, x: f64, y: f64, radius: f64) {
+fn ellipse(ctx: &Context, cx: f64, cy: f64, rx: f64, ry: f64) {
+    // Four cubic Beziers; avoids relying on a scaled CTM after path creation.
+    const K: f64 = 0.552_284_749_830_793_6;
     ctx.new_path();
-    ctx.arc(x, y, radius, 0.0, PI * 2.0);
+    ctx.move_to(cx + rx, cy);
+    ctx.curve_to(cx + rx, cy + K * ry, cx + K * rx, cy + ry, cx, cy + ry);
+    ctx.curve_to(cx - K * rx, cy + ry, cx - rx, cy + K * ry, cx - rx, cy);
+    ctx.curve_to(cx - rx, cy - K * ry, cx - K * rx, cy - ry, cx, cy - ry);
+    ctx.curve_to(cx + K * rx, cy - ry, cx + rx, cy - K * ry, cx + rx, cy);
+    ctx.close_path();
+}
+
+// ---- Primary tools -------------------------------------------------------------
+
+fn draw_drag(ctx: &Context) {
+    for (x, y) in [
+        (9.0, 6.0),
+        (15.0, 6.0),
+        (9.0, 12.0),
+        (15.0, 12.0),
+        (9.0, 18.0),
+        (15.0, 18.0),
+    ] {
+        dot(ctx, x, y, 1.25);
+    }
 }
 
 fn draw_select(ctx: &Context) {
-    ctx.move_to(12.6, 12.6);
-    ctx.line_to(19.0, 19.0);
+    ctx.new_path();
+    ctx.move_to(5.0, 3.5);
+    ctx.line_to(17.8, 12.2);
+    ctx.line_to(11.9, 13.6);
+    ctx.line_to(9.2, 19.2);
+    ctx.close_path();
     stroke(ctx);
 
-    ctx.move_to(3.7, 3.0);
-    ctx.line_to(10.2, 19.0);
-    ctx.line_to(12.0, 13.5);
-    ctx.line_to(19.6, 10.5);
-    ctx.close_path();
+    ctx.move_to(12.1, 13.6);
+    ctx.line_to(17.1, 18.6);
     stroke(ctx);
 }
 
 fn draw_pen(ctx: &Context) {
-    ctx.move_to(15.7, 21.3);
-    ctx.line_to(12.7, 18.3);
-    ctx.line_to(18.3, 12.7);
-    ctx.line_to(21.3, 15.7);
+    ctx.new_path();
+    ctx.move_to(6.4, 16.5);
+    ctx.line_to(15.7, 7.2);
+    ctx.curve_to(16.55, 6.35, 17.95, 6.35, 18.8, 7.2);
+    ctx.curve_to(19.65, 8.05, 19.65, 9.45, 18.8, 10.3);
+    ctx.line_to(9.5, 19.6);
+    ctx.line_to(5.4, 20.5);
     ctx.close_path();
     stroke(ctx);
 
-    ctx.move_to(18.0, 13.0);
-    ctx.line_to(16.6, 6.1);
-    ctx.line_to(2.3, 2.3);
-    ctx.line_to(6.1, 16.6);
-    ctx.line_to(13.0, 18.0);
+    ctx.move_to(14.7, 8.3);
+    ctx.line_to(17.7, 11.3);
     stroke(ctx);
 
-    ctx.move_to(2.3, 2.3);
-    ctx.line_to(9.6, 9.6);
+    // Fine pressure stroke: semantic cue distinguishing Pen from Marker.
+    ctx.move_to(3.5, 21.0);
+    ctx.curve_to(5.8, 19.8, 8.2, 19.8, 10.5, 21.0);
+    stroke(ctx);
+}
+
+fn draw_marker(ctx: &Context) {
+    ctx.new_path();
+    ctx.move_to(8.0, 3.0);
+    ctx.line_to(16.0, 3.0);
+    ctx.line_to(16.0, 12.0);
+    ctx.line_to(12.0, 17.0);
+    ctx.line_to(8.0, 12.0);
+    ctx.close_path();
     stroke(ctx);
 
-    circle(ctx, 11.0, 11.0, 2.0);
+    ctx.move_to(8.0, 8.0);
+    ctx.line_to(16.0, 8.0);
+    stroke(ctx);
+    ctx.move_to(9.5, 14.5);
+    ctx.line_to(14.5, 14.5);
+    stroke(ctx);
+
+    // Deliberate optical exception: a broad, uniform marker swatch.
+    ctx.set_line_width(3.0);
+    ctx.move_to(5.0, 21.0);
+    ctx.line_to(19.0, 21.0);
+    stroke(ctx);
+    ctx.set_line_width(2.0);
+}
+
+fn draw_step_marker(ctx: &Context) {
+    circle(ctx, 10.5, 11.5, 7.0);
+    stroke(ctx);
+
+    // Callout leader tail; this is what prevents a numbered-list reading.
+    ctx.move_to(15.7, 16.2);
+    ctx.line_to(18.5, 19.0);
+    ctx.line_to(17.5, 14.7);
+    stroke(ctx);
+
+    // Vector-built numeral 1; no font dependency.
+    ctx.move_to(9.2, 9.3);
+    ctx.line_to(11.0, 8.2);
+    ctx.line_to(11.0, 15.3);
+    stroke(ctx);
+    ctx.move_to(9.4, 15.3);
+    ctx.line_to(12.6, 15.3);
+    stroke(ctx);
+}
+
+fn draw_eraser(ctx: &Context) {
+    ctx.new_path();
+    ctx.move_to(4.1, 14.9);
+    ctx.line_to(12.5, 6.5);
+    ctx.curve_to(13.28, 5.72, 14.52, 5.72, 15.3, 6.5);
+    ctx.line_to(19.5, 10.7);
+    ctx.curve_to(20.28, 11.48, 20.28, 12.72, 19.5, 13.5);
+    ctx.line_to(13.0, 20.0);
+    ctx.line_to(8.9, 20.0);
+    ctx.close_path();
+    stroke(ctx);
+
+    ctx.move_to(7.5, 11.5);
+    ctx.line_to(14.4, 18.4);
+    stroke(ctx);
+    ctx.move_to(13.0, 20.0);
+    ctx.line_to(20.0, 20.0);
     stroke(ctx);
 }
 
 fn draw_line(ctx: &Context) {
-    ctx.move_to(5.0, 12.0);
-    ctx.line_to(19.0, 12.0);
+    ctx.move_to(5.0, 18.5);
+    ctx.line_to(19.0, 5.5);
     stroke(ctx);
-}
-
-fn draw_rect(ctx: &Context) {
-    rounded_rect(ctx, 2.0, 6.0, 20.0, 12.0, 2.0);
-    stroke(ctx);
-}
-
-fn draw_circle(ctx: &Context) {
-    circle(ctx, 12.0, 12.0, 10.0);
-    stroke(ctx);
+    dot(ctx, 5.0, 18.5, 1.25);
+    dot(ctx, 19.0, 5.5, 1.25);
 }
 
 fn draw_arrow(ctx: &Context) {
-    ctx.move_to(7.0, 7.0);
-    ctx.line_to(17.0, 7.0);
-    ctx.line_to(17.0, 17.0);
+    ctx.move_to(5.0, 5.5);
+    ctx.line_to(19.0, 18.5);
+    stroke(ctx);
+    ctx.move_to(13.0, 18.5);
+    ctx.line_to(19.0, 18.5);
+    ctx.line_to(19.0, 12.5);
+    stroke(ctx);
+}
+
+fn draw_shape_picker(ctx: &Context) {
+    rounded_rect(ctx, 4.0, 4.0, 7.0, 7.0, 1.5);
+    stroke(ctx);
+    circle(ctx, 8.0, 17.0, 3.0);
+    stroke(ctx);
+    ctx.move_to(15.5, 11.0);
+    ctx.line_to(20.0, 19.0);
+    ctx.line_to(11.0, 19.0);
+    ctx.close_path();
+    stroke(ctx);
+}
+
+fn draw_text(ctx: &Context) {
+    ctx.move_to(5.0, 5.0);
+    ctx.line_to(19.0, 5.0);
+    stroke(ctx);
+    ctx.move_to(12.0, 5.0);
+    ctx.line_to(12.0, 19.0);
+    stroke(ctx);
+    ctx.move_to(9.0, 19.0);
+    ctx.line_to(15.0, 19.0);
+    stroke(ctx);
+}
+
+fn draw_sticky_note(ctx: &Context) {
+    ctx.new_path();
+    ctx.move_to(6.0, 3.0);
+    ctx.line_to(18.0, 3.0);
+    ctx.curve_to(19.66, 3.0, 21.0, 4.34, 21.0, 6.0);
+    ctx.line_to(21.0, 16.0);
+    ctx.line_to(16.0, 21.0);
+    ctx.line_to(6.0, 21.0);
+    ctx.curve_to(4.34, 21.0, 3.0, 19.66, 3.0, 18.0);
+    ctx.line_to(3.0, 6.0);
+    ctx.curve_to(3.0, 4.34, 4.34, 3.0, 6.0, 3.0);
+    ctx.close_path();
     stroke(ctx);
 
-    ctx.move_to(7.0, 17.0);
-    ctx.line_to(17.0, 7.0);
+    ctx.move_to(16.0, 21.0);
+    ctx.line_to(16.0, 16.0);
+    ctx.line_to(21.0, 16.0);
+    stroke(ctx);
+    ctx.move_to(8.0, 8.0);
+    ctx.line_to(15.0, 8.0);
+    stroke(ctx);
+    ctx.move_to(8.0, 12.0);
+    ctx.line_to(13.0, 12.0);
+    stroke(ctx);
+}
+
+// ---- Annotation utilities ------------------------------------------------------
+
+fn draw_screenshot(ctx: &Context) {
+    for (x1, y1, x2, y2, x3, y3) in [
+        (4.0, 9.0, 4.0, 5.0, 8.0, 5.0),
+        (16.0, 5.0, 20.0, 5.0, 20.0, 9.0),
+        (20.0, 15.0, 20.0, 19.0, 16.0, 19.0),
+        (8.0, 19.0, 4.0, 19.0, 4.0, 15.0),
+    ] {
+        ctx.move_to(x1, y1);
+        ctx.line_to(x2, y2);
+        ctx.line_to(x3, y3);
+        stroke(ctx);
+    }
+    circle(ctx, 12.0, 12.0, 3.25);
+    stroke(ctx);
+}
+
+fn draw_highlight(ctx: &Context) {
+    circle(ctx, 12.0, 12.0, 3.25);
+    stroke(ctx);
+    circle(ctx, 12.0, 12.0, 7.5);
+    stroke(ctx);
+    dot(ctx, 12.0, 12.0, 1.0);
+}
+
+fn draw_undo(ctx: &Context) {
+    ctx.move_to(8.5, 7.0);
+    ctx.line_to(4.5, 11.0);
+    ctx.line_to(8.5, 15.0);
+    stroke(ctx);
+    ctx.move_to(4.5, 11.0);
+    ctx.line_to(13.0, 11.0);
+    ctx.curve_to(16.31, 11.0, 19.0, 13.69, 19.0, 17.0);
+    stroke(ctx);
+}
+
+fn draw_redo(ctx: &Context) {
+    ctx.move_to(15.5, 7.0);
+    ctx.line_to(19.5, 11.0);
+    ctx.line_to(15.5, 15.0);
+    stroke(ctx);
+    ctx.move_to(19.5, 11.0);
+    ctx.line_to(11.0, 11.0);
+    ctx.curve_to(7.69, 11.0, 5.0, 13.69, 5.0, 17.0);
+    stroke(ctx);
+}
+
+fn draw_clear_canvas(ctx: &Context) {
+    ctx.move_to(4.0, 6.0);
+    ctx.line_to(20.0, 6.0);
+    stroke(ctx);
+    ctx.move_to(9.0, 6.0);
+    ctx.line_to(9.0, 4.0);
+    ctx.line_to(15.0, 4.0);
+    ctx.line_to(15.0, 6.0);
+    stroke(ctx);
+    ctx.move_to(6.5, 6.0);
+    ctx.line_to(7.3, 20.0);
+    ctx.line_to(16.7, 20.0);
+    ctx.line_to(17.5, 6.0);
+    stroke(ctx);
+    ctx.move_to(10.0, 10.0);
+    ctx.line_to(10.0, 16.0);
+    stroke(ctx);
+    ctx.move_to(14.0, 10.0);
+    ctx.line_to(14.0, 16.0);
+    stroke(ctx);
+}
+
+// ---- Toolbar chrome ------------------------------------------------------------
+
+fn draw_overflow(ctx: &Context) {
+    for x in [6.0, 12.0, 18.0] {
+        dot(ctx, x, 12.0, 1.3);
+    }
+}
+
+fn draw_pin(ctx: &Context) {
+    ctx.new_path();
+    ctx.move_to(8.0, 4.0);
+    ctx.line_to(16.0, 4.0);
+    ctx.line_to(14.6, 9.0);
+    ctx.line_to(17.0, 11.5);
+    ctx.line_to(17.0, 14.0);
+    ctx.line_to(7.0, 14.0);
+    ctx.line_to(7.0, 11.5);
+    ctx.line_to(9.4, 9.0);
+    ctx.close_path();
+    stroke(ctx);
+    ctx.move_to(12.0, 14.0);
+    ctx.line_to(12.0, 21.0);
+    stroke(ctx);
+}
+
+fn draw_unpin(ctx: &Context) {
+    ctx.new_path();
+    ctx.move_to(8.7, 4.0);
+    ctx.line_to(16.0, 4.0);
+    ctx.line_to(14.6, 9.0);
+    ctx.line_to(17.0, 11.5);
+    ctx.line_to(17.0, 14.0);
+    ctx.line_to(14.0, 14.0);
+    stroke(ctx);
+    ctx.move_to(10.3, 14.0);
+    ctx.line_to(7.0, 14.0);
+    ctx.line_to(7.0, 11.5);
+    ctx.line_to(8.5, 9.9);
+    stroke(ctx);
+    ctx.move_to(12.0, 14.0);
+    ctx.line_to(12.0, 21.0);
+    stroke(ctx);
+    ctx.move_to(4.0, 4.0);
+    ctx.line_to(20.0, 20.0);
+    stroke(ctx);
+}
+
+fn draw_minimize(ctx: &Context) {
+    ctx.move_to(5.0, 5.0);
+    ctx.line_to(5.0, 8.0);
+    ctx.line_to(19.0, 8.0);
+    ctx.line_to(19.0, 5.0);
+    stroke(ctx);
+    ctx.move_to(8.5, 15.5);
+    ctx.line_to(12.0, 12.0);
+    ctx.line_to(15.5, 15.5);
+    stroke(ctx);
+}
+
+fn draw_side_minimize(ctx: &Context) {
+    ctx.move_to(5.0, 5.0);
+    ctx.line_to(8.0, 5.0);
+    ctx.line_to(8.0, 19.0);
+    ctx.line_to(5.0, 19.0);
+    stroke(ctx);
+    ctx.move_to(15.5, 8.5);
+    ctx.line_to(12.0, 12.0);
+    ctx.line_to(15.5, 15.5);
+    stroke(ctx);
+}
+
+fn draw_restore(ctx: &Context) {
+    ctx.move_to(5.0, 5.0);
+    ctx.line_to(5.0, 8.0);
+    ctx.line_to(19.0, 8.0);
+    ctx.line_to(19.0, 5.0);
+    stroke(ctx);
+    ctx.move_to(8.5, 11.5);
+    ctx.line_to(12.0, 15.0);
+    ctx.line_to(15.5, 11.5);
+    stroke(ctx);
+}
+
+#[allow(dead_code)] // complete family entry point; no close action today
+fn draw_close(ctx: &Context) {
+    ctx.move_to(6.0, 6.0);
+    ctx.line_to(18.0, 18.0);
+    stroke(ctx);
+    ctx.move_to(18.0, 6.0);
+    ctx.line_to(6.0, 18.0);
+    stroke(ctx);
+}
+
+// ---- Shape palette -------------------------------------------------------------
+
+fn draw_rectangle(ctx: &Context) {
+    rounded_rect(ctx, 4.0, 6.0, 16.0, 12.0, 2.0);
+    stroke(ctx);
+}
+
+fn draw_ellipse(ctx: &Context) {
+    ellipse(ctx, 12.0, 12.0, 8.0, 6.0);
     stroke(ctx);
 }
 
 fn draw_blur(ctx: &Context) {
     rounded_rect(ctx, 4.0, 4.0, 16.0, 16.0, 3.0);
     stroke(ctx);
-
-    for (x, y, radius) in [
-        (9.0, 9.0, 1.2),
-        (15.0, 9.0, 1.2),
-        (12.0, 12.0, 1.6),
-        (9.0, 15.0, 1.2),
-        (15.0, 15.0, 1.2),
+    for (x, y, r) in [
+        (8.0, 8.0, 1.0),
+        (13.0, 8.0, 1.0),
+        (16.5, 11.5, 1.0),
+        (11.0, 12.0, 1.4),
+        (7.5, 15.5, 1.0),
+        (14.0, 16.0, 1.0),
     ] {
-        circle(ctx, x, y, radius);
-        fill(ctx);
+        dot(ctx, x, y, r);
     }
 }
 
-fn draw_eraser(ctx: &Context) {
-    ctx.move_to(21.0, 21.0);
-    ctx.line_to(8.0, 21.0);
-    ctx.line_to(2.6, 15.6);
-    ctx.line_to(13.3, 4.9);
-    ctx.line_to(20.7, 12.3);
-    ctx.line_to(12.8, 21.0);
-    stroke(ctx);
-
-    ctx.move_to(5.1, 11.1);
-    ctx.line_to(13.9, 19.9);
-    stroke(ctx);
-}
-
-fn draw_text(ctx: &Context) {
+fn draw_triangle(ctx: &Context) {
     ctx.move_to(12.0, 4.0);
-    ctx.line_to(12.0, 20.0);
+    ctx.line_to(20.0, 19.0);
+    ctx.line_to(4.0, 19.0);
+    ctx.close_path();
     stroke(ctx);
+}
 
-    ctx.move_to(4.0, 7.0);
-    ctx.line_to(4.0, 5.0);
+fn draw_parallelogram(ctx: &Context) {
+    ctx.move_to(8.0, 5.0);
     ctx.line_to(20.0, 5.0);
-    ctx.line_to(20.0, 7.0);
-    stroke(ctx);
-
-    ctx.move_to(9.0, 20.0);
-    ctx.line_to(15.0, 20.0);
+    ctx.line_to(16.0, 19.0);
+    ctx.line_to(4.0, 19.0);
+    ctx.close_path();
     stroke(ctx);
 }
 
-fn draw_note(ctx: &Context) {
-    ctx.move_to(21.0, 9.0);
-    ctx.line_to(21.0, 19.0);
-    ctx.line_to(19.0, 21.0);
-    ctx.line_to(5.0, 21.0);
-    ctx.line_to(3.0, 19.0);
-    ctx.line_to(3.0, 5.0);
-    ctx.line_to(5.0, 3.0);
-    ctx.line_to(15.0, 3.0);
-    ctx.line_to(21.0, 9.0);
+fn draw_rhombus(ctx: &Context) {
+    ctx.move_to(12.0, 3.0);
+    ctx.line_to(21.0, 12.0);
+    ctx.line_to(12.0, 21.0);
+    ctx.line_to(3.0, 12.0);
+    ctx.close_path();
     stroke(ctx);
+}
 
-    ctx.move_to(15.0, 3.0);
-    ctx.line_to(15.0, 8.0);
+fn draw_regular_polygon(ctx: &Context) {
+    ctx.move_to(12.0, 3.5);
+    ctx.line_to(20.2, 9.5);
+    ctx.line_to(17.1, 19.1);
+    ctx.line_to(6.9, 19.1);
+    ctx.line_to(3.8, 9.5);
+    ctx.close_path();
+    stroke(ctx);
+}
+
+fn draw_freeform_polygon(ctx: &Context) {
+    let points = [
+        (4.5, 15.5),
+        (7.5, 5.5),
+        (15.5, 7.5),
+        (19.5, 18.5),
+        (9.5, 20.0),
+    ];
+    ctx.move_to(points[0].0, points[0].1);
+    for &(x, y) in &points[1..] {
+        ctx.line_to(x, y);
+    }
+    ctx.close_path();
+    stroke(ctx);
+    for (x, y) in points {
+        dot(ctx, x, y, 1.15);
+    }
+}
+
+#[allow(dead_code)] // complete family entry point; not wired to an option yet
+fn draw_fill(ctx: &Context) {
+    ctx.move_to(5.0, 12.0);
+    ctx.line_to(12.0, 5.0);
+    ctx.line_to(19.0, 12.0);
+    ctx.line_to(12.0, 19.0);
+    ctx.close_path();
+    stroke(ctx);
+    ctx.move_to(12.0, 5.0);
     ctx.line_to(16.0, 9.0);
-    ctx.line_to(21.0, 9.0);
+    stroke(ctx);
+
+    ctx.new_path();
+    ctx.move_to(20.0, 15.0);
+    ctx.curve_to(21.2, 16.5, 22.0, 17.7, 22.0, 18.8);
+    ctx.curve_to(22.0, 19.9, 21.1, 20.8, 20.0, 20.8);
+    ctx.curve_to(18.9, 20.8, 18.0, 19.9, 18.0, 18.8);
+    ctx.curve_to(18.0, 17.7, 18.8, 16.5, 20.0, 15.0);
+    ctx.close_path();
     stroke(ctx);
 }
 
-fn draw_highlight(ctx: &Context) {
+#[allow(dead_code)] // complete family entry point; not wired to an option yet
+fn draw_highlight_ring(ctx: &Context) {
+    circle(ctx, 12.0, 12.0, 6.0);
+    stroke(ctx);
     for (x1, y1, x2, y2) in [
-        (14.0, 4.1, 12.0, 6.0),
-        (5.1, 8.0, 2.2, 7.2),
-        (6.0, 12.0, 4.1, 14.0),
-        (7.2, 2.2, 8.0, 5.1),
+        (12.0, 3.0, 12.0, 5.0),
+        (12.0, 19.0, 12.0, 21.0),
+        (3.0, 12.0, 5.0, 12.0),
+        (19.0, 12.0, 21.0, 12.0),
     ] {
         ctx.move_to(x1, y1);
         ctx.line_to(x2, y2);
         stroke(ctx);
     }
-
-    ctx.move_to(9.0, 9.7);
-    ctx.line_to(20.7, 14.0);
-    ctx.line_to(16.3, 15.5);
-    ctx.line_to(14.5, 20.7);
-    ctx.close_path();
-    stroke(ctx);
 }
 
-fn draw_marker(ctx: &Context) {
-    ctx.move_to(9.0, 11.0);
-    ctx.line_to(3.0, 17.0);
-    ctx.line_to(3.0, 20.0);
-    ctx.line_to(12.0, 20.0);
-    ctx.line_to(15.0, 17.0);
-    stroke(ctx);
+// ---- Public render entry points ------------------------------------------------
 
-    ctx.move_to(22.0, 12.0);
-    ctx.line_to(17.4, 16.6);
-    ctx.line_to(14.6, 16.6);
-    ctx.line_to(9.4, 11.4);
-    ctx.line_to(9.4, 8.6);
-    ctx.line_to(14.0, 4.0);
-    stroke(ctx);
+macro_rules! renderers {
+    ($(($public:ident, $draw:ident)),+ $(,)?) => {
+        $(
+            #[inline]
+            #[allow(dead_code)]
+            pub fn $public(ctx: &Context, x: f64, y: f64, size: f64) {
+                render_icon(ctx, x, y, size, $draw);
+            }
+        )+
+    };
 }
 
-fn draw_step_marker(ctx: &Context) {
-    for y in [5.0, 12.0, 19.0] {
-        ctx.move_to(11.0, y);
-        ctx.line_to(21.0, y);
-        stroke(ctx);
-    }
-
-    ctx.move_to(4.0, 4.0);
-    ctx.line_to(5.0, 4.0);
-    ctx.line_to(5.0, 9.0);
-    stroke(ctx);
-
-    ctx.move_to(4.0, 9.0);
-    ctx.line_to(6.0, 9.0);
-    stroke(ctx);
-
-    ctx.move_to(3.4, 15.5);
-    ctx.curve_to(4.0, 14.5, 6.5, 14.7, 6.5, 16.5);
-    ctx.curve_to(6.5, 18.1, 3.9, 19.0, 3.4, 20.0);
-    ctx.line_to(6.5, 20.0);
-    stroke(ctx);
-}
-
-pub fn render_select(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_select);
-}
-
-pub fn render_pen(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_pen);
-}
-
-pub fn render_line(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_line);
-}
-
-pub fn render_rect(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_rect);
-}
-
-pub fn render_circle(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_circle);
-}
-
-pub fn render_arrow(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_arrow);
-}
-
-pub fn render_blur(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_blur);
-}
-
-pub fn render_eraser(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_eraser);
-}
-
-pub fn render_text(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_text);
-}
-
-pub fn render_note(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_note);
-}
-
-pub fn render_highlight(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_highlight);
-}
-
-pub fn render_marker(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_marker);
-}
-
-pub fn render_step_marker(ctx: &Context, x: f64, y: f64, size: f64) {
-    render_icon(ctx, x, y, size, draw_step_marker);
-}
+renderers!(
+    (render_drag, draw_drag),
+    (render_select, draw_select),
+    (render_pen, draw_pen),
+    (render_marker, draw_marker),
+    (render_step_marker, draw_step_marker),
+    (render_eraser, draw_eraser),
+    (render_line, draw_line),
+    (render_arrow, draw_arrow),
+    (render_shape_picker, draw_shape_picker),
+    (render_text, draw_text),
+    (render_note, draw_sticky_note),
+    (render_screenshot, draw_screenshot),
+    (render_highlight, draw_highlight),
+    (render_undo, draw_undo),
+    (render_redo, draw_redo),
+    (render_clear_canvas, draw_clear_canvas),
+    (render_more, draw_overflow),
+    (render_pin, draw_pin),
+    (render_unpin, draw_unpin),
+    (render_minimize, draw_minimize),
+    (render_side_minimize, draw_side_minimize),
+    (render_restore, draw_restore),
+    (render_close, draw_close),
+    (render_rect, draw_rectangle),
+    (render_circle, draw_ellipse),
+    (render_blur, draw_blur),
+    (render_triangle, draw_triangle),
+    (render_parallelogram, draw_parallelogram),
+    (render_rhombus, draw_rhombus),
+    (render_polygon, draw_regular_polygon),
+    (render_freeform_polygon, draw_freeform_polygon),
+    (render_fill, draw_fill),
+    (render_highlight_ring, draw_highlight_ring),
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use cairo::{Format, ImageSurface};
 
-    type IconRenderFn = fn(&Context, f64, f64, f64);
+    type IconRender = fn(&Context, f64, f64, f64);
 
-    fn assert_icon_renders(name: &str, draw: IconRenderFn) {
-        let surface = ImageSurface::create(Format::ARgb32, 24, 24).expect("surface");
-        let ctx = Context::new(&surface).expect("context");
-        ctx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
-        draw(&ctx, 0.0, 0.0, 24.0);
-        surface.flush();
-
-        let mut has_ink = false;
-        surface
-            .with_data(|pixels| {
-                has_ink = pixels.chunks_exact(4).any(|pixel| pixel[3] != 0);
-            })
-            .expect("surface data");
-        assert!(has_ink, "{name} icon rendered an empty surface");
-    }
+    const SIZES: [i32; 5] = [18, 20, 22, 24, 28];
+    const ICONS: [(&str, IconRender); 33] = [
+        ("drag", render_drag),
+        ("select", render_select),
+        ("pen", render_pen),
+        ("marker", render_marker),
+        ("step_marker", render_step_marker),
+        ("eraser", render_eraser),
+        ("line", render_line),
+        ("arrow", render_arrow),
+        ("shape_picker", render_shape_picker),
+        ("text", render_text),
+        ("sticky_note", render_note),
+        ("screenshot", render_screenshot),
+        ("highlight", render_highlight),
+        ("undo", render_undo),
+        ("redo", render_redo),
+        ("clear_canvas", render_clear_canvas),
+        ("overflow", render_more),
+        ("pin", render_pin),
+        ("unpin", render_unpin),
+        ("minimize", render_minimize),
+        ("side_minimize", render_side_minimize),
+        ("restore", render_restore),
+        ("close", render_close),
+        ("rectangle", render_rect),
+        ("ellipse", render_circle),
+        ("blur", render_blur),
+        ("triangle", render_triangle),
+        ("parallelogram", render_parallelogram),
+        ("rhombus", render_rhombus),
+        ("regular_polygon", render_polygon),
+        ("freeform_polygon", render_freeform_polygon),
+        ("fill", render_fill),
+        ("highlight_ring", render_highlight_ring),
+    ];
 
     #[test]
-    fn tool_icons_render_non_empty_alpha() {
-        let icons: [(&str, IconRenderFn); 13] = [
-            ("select", render_select),
-            ("pen", render_pen),
-            ("line", render_line),
-            ("rect", render_rect),
-            ("circle", render_circle),
-            ("arrow", render_arrow),
-            ("blur", render_blur),
-            ("eraser", render_eraser),
-            ("text", render_text),
-            ("note", render_note),
-            ("highlight", render_highlight),
-            ("marker", render_marker),
-            ("step_marker", render_step_marker),
-        ];
-
-        for (name, draw) in icons {
-            assert_icon_renders(name, draw);
+    fn all_icons_render_non_empty_at_required_sizes() {
+        for (name, draw) in ICONS {
+            for size in SIZES {
+                let surface = ImageSurface::create(Format::ARgb32, size, size).expect("surface");
+                let ctx = Context::new(&surface).expect("context");
+                ctx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
+                draw(&ctx, 0.0, 0.0, f64::from(size));
+                surface.flush();
+                let mut has_alpha = false;
+                surface
+                    .with_data(|pixels| {
+                        has_alpha = pixels.chunks_exact(4).any(|pixel| pixel[3] != 0);
+                    })
+                    .expect("surface data");
+                assert!(has_alpha, "{name} rendered empty at {size}px");
+            }
         }
     }
 }

--- a/src/toolbar_icons/tools.rs
+++ b/src/toolbar_icons/tools.rs
@@ -1,143 +1,94 @@
+//! Drop-in replacement for `src/toolbar_icons/tools.rs` wrappers.
+//! Geometry and current-source inheritance live in `super::svg`.
+
 use cairo::Context;
 
-/// Draw a cursor/select icon (arrow pointer)
 pub fn draw_icon_select(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_select(ctx, x, y, size);
 }
 
-/// Draw a pen/freehand icon (nib with a short stroke)
 pub fn draw_icon_pen(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_pen(ctx, x, y, size);
 }
 
-/// Draw a line tool icon
 pub fn draw_icon_line(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_line(ctx, x, y, size);
 }
 
-/// Draw a rectangle tool icon
 pub fn draw_icon_rect(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_rect(ctx, x, y, size);
 }
 
-/// Draw a circle/ellipse tool icon
 pub fn draw_icon_circle(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_circle(ctx, x, y, size);
 }
 
-/// Draw a triangle tool icon.
 pub fn draw_icon_triangle(ctx: &Context, x: f64, y: f64, size: f64) {
-    draw_polygon_icon(ctx, x, y, size, &[0.5, 0.12, 0.86, 0.84, 0.14, 0.84]);
+    super::svg::render_triangle(ctx, x, y, size);
 }
 
-/// Draw a parallelogram tool icon.
 pub fn draw_icon_parallelogram(ctx: &Context, x: f64, y: f64, size: f64) {
-    draw_polygon_icon(
-        ctx,
-        x,
-        y,
-        size,
-        &[0.32, 0.16, 0.88, 0.16, 0.68, 0.84, 0.12, 0.84],
-    );
+    super::svg::render_parallelogram(ctx, x, y, size);
 }
 
-/// Draw a rhombus tool icon.
 pub fn draw_icon_rhombus(ctx: &Context, x: f64, y: f64, size: f64) {
-    draw_polygon_icon(ctx, x, y, size, &[0.5, 0.08, 0.9, 0.5, 0.5, 0.92, 0.1, 0.5]);
+    super::svg::render_rhombus(ctx, x, y, size);
 }
 
-/// Draw a regular polygon picker/tool icon.
 pub fn draw_icon_polygon(ctx: &Context, x: f64, y: f64, size: f64) {
-    draw_regular_polygon_icon(ctx, x, y, size, 5);
+    super::svg::render_polygon(ctx, x, y, size);
 }
 
-/// Draw a freeform polygon tool icon.
 pub fn draw_icon_freeform_polygon(ctx: &Context, x: f64, y: f64, size: f64) {
-    let points = &[0.18, 0.64, 0.34, 0.18, 0.72, 0.28, 0.84, 0.76, 0.46, 0.88];
-    draw_polygon_icon(ctx, x, y, size, points);
-    for pair in points.chunks_exact(2) {
-        ctx.arc(
-            x + pair[0] * size,
-            y + pair[1] * size,
-            (size * 0.055).max(1.2),
-            0.0,
-            std::f64::consts::TAU,
-        );
-        let _ = ctx.fill();
-    }
+    super::svg::render_freeform_polygon(ctx, x, y, size);
 }
 
-/// Draw an arrow tool icon
 pub fn draw_icon_arrow(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_arrow(ctx, x, y, size);
 }
 
-/// Draw a blur tool icon
 pub fn draw_icon_blur(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_blur(ctx, x, y, size);
 }
 
-/// Draw an eraser tool icon
-#[allow(dead_code)]
 pub fn draw_icon_eraser(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_eraser(ctx, x, y, size);
 }
 
-/// Draw a text tool icon (letter T)
 pub fn draw_icon_text(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_text(ctx, x, y, size);
 }
 
-/// Draw a sticky note icon (square with folded corner)
 pub fn draw_icon_note(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_note(ctx, x, y, size);
 }
 
-/// Draw a highlighter tool icon (cursor with click ripple effect)
-#[allow(dead_code)]
 pub fn draw_icon_highlight(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_highlight(ctx, x, y, size);
 }
 
-/// Draw a marker/highlighter icon
 pub fn draw_icon_marker(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_marker(ctx, x, y, size);
 }
 
-/// Draw a step marker icon (numbered list)
 pub fn draw_icon_step_marker(ctx: &Context, x: f64, y: f64, size: f64) {
     super::svg::render_step_marker(ctx, x, y, size);
 }
 
-fn draw_polygon_icon(ctx: &Context, x: f64, y: f64, size: f64, normalized_points: &[f64]) {
-    let mut pairs = normalized_points.chunks_exact(2);
-    let Some(first) = pairs.next() else {
-        return;
-    };
-    // Inherit the caller's source color (hover/disabled states) like every
-    // other icon; only line style is scoped here.
-    let _ = ctx.save();
-    ctx.set_line_width((size * 0.11).clamp(1.5, 2.4));
-    ctx.set_line_join(cairo::LineJoin::Round);
-    ctx.set_line_cap(cairo::LineCap::Round);
-    ctx.move_to(x + first[0] * size, y + first[1] * size);
-    for pair in pairs {
-        ctx.line_to(x + pair[0] * size, y + pair[1] * size);
-    }
-    ctx.close_path();
-    let _ = ctx.stroke();
-    let _ = ctx.restore();
+/// Draw the shape-palette opener. This represents the family of shapes rather
+/// than any one currently selected shape tool.
+pub fn draw_icon_shape_picker(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_shape_picker(ctx, x, y, size);
 }
 
-fn draw_regular_polygon_icon(ctx: &Context, x: f64, y: f64, size: f64, sides: u8) {
-    let center = (x + size * 0.5, y + size * 0.5);
-    let radius = size * 0.38;
-    let mut points = Vec::with_capacity(sides as usize * 2);
-    for index in 0..sides {
-        let angle = -std::f64::consts::FRAC_PI_2
-            + std::f64::consts::TAU * f64::from(index) / f64::from(sides);
-        points.push((center.0 + angle.cos() * radius - x) / size);
-        points.push((center.1 + angle.sin() * radius - y) / size);
-    }
-    draw_polygon_icon(ctx, x, y, size, &points);
+/// Draw the fill affordance used by shape options.
+#[allow(dead_code)] // reserved for the shape-options toolbar surface
+pub fn draw_icon_fill(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_fill(ctx, x, y, size);
+}
+
+/// Draw a highlight/ring affordance for option surfaces.
+#[allow(dead_code)] // reserved for the highlight-options toolbar surface
+pub fn draw_icon_highlight_ring(ctx: &Context, x: f64, y: f64, size: f64) {
+    super::svg::render_highlight_ring(ctx, x, y, size);
 }


### PR DESCRIPTION
## Summary

- Replace the mixed toolbar icon implementations with a cohesive 24×24 procedural Cairo icon family.
- Share the same icon entry points across the built-in and GTK toolbar frontends.
- Refresh tool, shape, action, history, drag, pin, overflow, minimize, and restore icons.
- Give the shape picker a dedicated family icon instead of displaying the last-used shape.
- Use directionally appropriate collapse icons for the horizontal top toolbar and vertical side toolbar.

## Rendering

- Preserve the caller’s foreground color and opacity for hover, active, disabled, and destructive states.
- Keep icons vector-scaled without introducing runtime SVG assets or SVG-rendering dependencies.
- Render the built-in drag glyph at the same intended size as the GTK version.

## Validation

- Added rendering coverage for all icon entry points at 18, 20, 22, 24, and 28 pixels.
- Verified minimized top and side toolbar behavior.
- Passed the complete `./tools/lint-and-test.sh` suite with all features and without default features.