### PR TITLE
perf(wayland): offload session persistence from the event loop

### DIFF
--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -11,7 +11,7 @@ use super::tray::process_tray_action;
 mod capture;
 mod dispatch;
 mod render;
-mod session_save;
+pub(in crate::backend::wayland) mod session_save;
 
 const TRAY_ACTION_POLL_TIMEOUT: Duration = Duration::from_millis(50);
 
@@ -138,6 +138,12 @@ pub(super) fn run_event_loop(
             warn!("Event queue error: {}", e);
             loop_error = Some(e);
             break;
+        }
+
+        if !state.input_state.should_exit {
+            state.reconcile_live_source_interaction_if_idle(
+                "post-dispatch interaction reconciliation",
+            );
         }
 
         // The timeout above is also a fallback for action signals that arrive before

--- a/src/backend/wayland/backend/event_loop/session_save.rs
+++ b/src/backend/wayland/backend/event_loop/session_save.rs
@@ -1,31 +1,133 @@
 use super::super::super::state::WaylandState;
 use crate::{
-    backend::wayland::session::{self as runtime_session, SessionState},
+    backend::wayland::session::{
+        self as runtime_session, PersistenceCompletion, PersistenceOperation, PersistenceOutcome,
+        SaveCompletion, SaveStrategy, SessionState, SubmitFailure,
+    },
     session,
     session::SaveSnapshotReport,
 };
 use std::time::{Duration, Instant};
 
 const AUTOSAVE_ACTIVE_INTERACTION_DEFER_MS: u64 = 500;
+const PERSISTENCE_COMPLETION_POLL_MS: u64 = 25;
 
 mod notifications;
 
 pub(super) use notifications::notify_session_failure;
 #[cfg(test)]
+use notifications::record_autosave_success;
+#[cfg(test)]
 use notifications::{
     SessionSaveNotification, pending_save_notifications, session_save_notification_text,
 };
 use notifications::{
-    notify_session_save_report, record_autosave_failure, record_autosave_success,
-    show_session_failure_toast,
+    notify_session_save_report, record_autosave_failure, show_session_failure_toast,
 };
 
-pub(super) fn persist_session(state: &WaylandState) -> Result<(), anyhow::Error> {
-    let Some(options) = state.session_options() else {
+pub(super) fn persist_session(state: &mut WaylandState) -> Result<(), anyhow::Error> {
+    if let Some(pending) = state.session.cancel_pending_output_transition() {
+        log::info!(
+            "Canceling staged output transition to {:?} during shutdown; persisting active epoch {}",
+            pending.physical_output_identity,
+            state.session.target_epoch()
+        );
+    }
+    let save_result = persist_final_session(state);
+    let worker_failed = !state.persistence.is_healthy();
+    let shutdown_result = state.persistence.shutdown(state.session.target_epoch());
+    if save_result.is_err() && worker_failed && state.persistence.is_stopped() {
+        log::warn!(
+            "Persistence worker failed before the final save; attempting joined event-thread fallback"
+        );
+        match persist_final_session_direct(state) {
+            Ok(()) => {
+                if let Err(shutdown) = shutdown_result {
+                    log::warn!(
+                        "Persistence worker shutdown failed before successful direct fallback: {shutdown:#}"
+                    );
+                }
+                return Ok(());
+            }
+            Err(fallback) => {
+                let original = save_result.expect_err("fallback requires failed worker save");
+                return Err(anyhow::anyhow!(
+                    "worker final save failed: {original:#}; joined direct fallback also failed: {fallback:#}"
+                ));
+            }
+        }
+    }
+    match (save_result, shutdown_result) {
+        (Err(save), Err(shutdown)) => Err(anyhow::anyhow!(
+            "final session save failed: {save:#}; persistence worker shutdown also failed: {shutdown:#}"
+        )),
+        (Err(save), Ok(())) => Err(save),
+        (Ok(()), Err(shutdown)) => Err(shutdown),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn persist_final_session_direct(state: &mut WaylandState) -> Result<(), anyhow::Error> {
+    observe_input_dirty(state, Instant::now());
+    let Some(options) = state.session_options().cloned() else {
         return Ok(());
     };
+    if should_skip_disabled_final_save(&options) {
+        return Ok(());
+    }
+    if should_skip_protected_session_save(state, &options) {
+        return Ok(());
+    }
+    let snapshot = session::snapshot_from_input(&state.input_state, &options);
+    let has_board_data = snapshot
+        .as_ref()
+        .is_some_and(session::SessionSnapshot::has_board_data);
+    if runtime_session::should_skip_unloaded_contentless_save(
+        state.session.has_loaded_board_data(),
+        state.session.is_dirty(),
+        state.input_state.is_session_dirty(),
+        has_board_data,
+        runtime_session::has_session_artifact(&options),
+    ) {
+        return Ok(());
+    }
+    let snapshot = snapshot_or_empty(state, &options, snapshot)?;
+    let snapshot_board_data = snapshot.has_board_data();
+    let report = session::save_snapshot_with_report_and_clear_boundary(
+        &snapshot,
+        &options,
+        state.session.has_loaded_board_data(),
+    )?;
+    let Some(report) = report else {
+        return Err(anyhow::anyhow!(
+            "joined direct fallback produced no committed session write"
+        ));
+    };
+    let committed_board_data =
+        !matches!(report.outcome, session::SaveSnapshotOutcome::ClearedEmpty)
+            && snapshot_board_data;
+    log_session_save_result(SessionSaveReason::Shutdown, Some(&report), Duration::ZERO);
+    state
+        .session
+        .mark_saved(Instant::now(), committed_board_data);
+    Ok(())
+}
 
-    if should_skip_protected_session_save(state, options) {
+fn persist_final_session(state: &mut WaylandState) -> Result<(), anyhow::Error> {
+    let barrier_result = persistence_barrier(state);
+    if let Some(err) = final_save_barrier_policy(barrier_result, state.persistence.is_healthy())? {
+        log::warn!(
+            "Autosave failed while preparing the final session save; retrying the current live state with the normal save strategy: {err:#}"
+        );
+    }
+    let Some(options) = state.session_options().cloned() else {
+        return Ok(());
+    };
+    if should_skip_disabled_final_save(&options) {
+        return Ok(());
+    }
+
+    if should_skip_protected_session_save(state, &options) {
         return Ok(());
     }
 
@@ -36,39 +138,103 @@ pub(super) fn persist_session(state: &WaylandState) -> Result<(), anyhow::Error>
         options.session_file_path().display()
     );
     let snapshot_started = Instant::now();
-    let snapshot = session::snapshot_from_input(&state.input_state, options);
+    let snapshot = session::snapshot_from_input(&state.input_state, &options);
     log_snapshot_capture(
         SessionSaveReason::Shutdown,
-        options,
+        &options,
         snapshot.as_ref(),
         snapshot_started.elapsed(),
     );
-    if should_skip_unloaded_contentless_save(state, options, snapshot.as_ref()) {
+    if should_skip_unloaded_contentless_save(state, &options, snapshot.as_ref())? {
         return Ok(());
     }
-    let save = save_snapshot_or_clear(state, options, snapshot, SessionSaveReason::Shutdown)?;
+    let snapshot = snapshot_or_empty(state, &options, snapshot)?;
+    let outcome = run_persistence_operation(
+        state,
+        PersistenceOperation::Save {
+            snapshot,
+            options,
+            strategy: SaveStrategy::Normal,
+            contentless_clear_boundary: state.session.has_loaded_board_data(),
+        },
+    )?;
+    let PersistenceOutcome::Save(save) = outcome else {
+        return Err(anyhow::anyhow!("unexpected final-save worker outcome"));
+    };
+    if !save.committed() {
+        return Err(anyhow::anyhow!(
+            "final session save produced no committed write"
+        ));
+    }
     log_session_save_result(
         SessionSaveReason::Shutdown,
         save.report.as_ref(),
         started.elapsed(),
     );
+    notify_session_save_report(state, save.report.as_ref());
+    state
+        .session
+        .mark_saved(Instant::now(), save.committed_board_data);
     Ok(())
 }
 
 pub(super) fn autosave_timeout(state: &WaylandState, now: Instant) -> Option<Duration> {
-    let options = state.session_options()?;
-    state.session.autosave_timeout(now, options)
+    let autosave = scheduled_autosave_timeout(
+        &state.session,
+        state.session_options(),
+        state.persistence.is_healthy(),
+        now,
+    );
+    let completion = state
+        .persistence
+        .is_active()
+        .then_some(Duration::from_millis(PERSISTENCE_COMPLETION_POLL_MS));
+    let output_transition = state
+        .persistence
+        .is_healthy()
+        .then(|| state.session.output_transition_timeout(now))
+        .flatten();
+    min_optional_timeout(
+        min_optional_timeout(autosave, completion),
+        output_transition,
+    )
+}
+
+fn scheduled_autosave_timeout(
+    session: &SessionState,
+    options: Option<&session::SessionOptions>,
+    worker_healthy: bool,
+    now: Instant,
+) -> Option<Duration> {
+    if !worker_healthy {
+        return None;
+    }
+    options.and_then(|options| session.autosave_timeout(now, options))
 }
 
 pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<(), anyhow::Error> {
+    drain_persistence_completion(state)?;
+    observe_input_dirty(state, now);
+
+    if !state.persistence.is_healthy() {
+        return Ok(());
+    }
+
+    if state.retry_pending_output_transition_if_due(now)? {
+        return Ok(());
+    }
+
+    if state
+        .reconcile_live_source_interaction_if_idle("post-interaction persistence reconciliation")
+    {
+        return Ok(());
+    }
+
     let Some(options) = state.session_options().cloned() else {
         return Ok(());
     };
 
-    let input_dirty = state.input_state.take_session_dirty();
-    state.session.record_input_dirty(now, input_dirty);
-
-    if should_defer_autosave_for_interaction(state)
+    if should_defer_for_interaction(state)
         && defer_pending_autosave_for_interaction(&mut state.session, now, &options)
     {
         return Ok(());
@@ -88,23 +254,42 @@ pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<
         snapshot_started.elapsed(),
     );
 
-    match save_snapshot_or_clear(state, &options, snapshot, SessionSaveReason::Autosave) {
-        Ok(save) => {
-            log_session_save_result(
-                SessionSaveReason::Autosave,
-                save.report.as_ref(),
-                started.elapsed(),
-            );
-            notify_session_save_report(state, save.report.as_ref());
-            record_autosave_success(
-                &mut state.session,
-                now,
-                save.report.is_some(),
-                save.saved_board_data,
+    if should_skip_protected_session_save(state, &options) {
+        return Ok(());
+    }
+    let snapshot = snapshot_or_empty(state, &options, snapshot)?;
+    let operation = PersistenceOperation::Save {
+        snapshot,
+        options: options.clone(),
+        strategy: SaveStrategy::Autosave,
+        contentless_clear_boundary: state.session.has_loaded_board_data(),
+    };
+    let dirty_window = state.session.prepare_autosave_submission()?;
+    match state
+        .persistence
+        .try_submit(state.session.target_epoch(), operation)
+    {
+        Ok(request_id) => {
+            state
+                .session
+                .commit_autosave_submission(request_id, dirty_window);
+            log::debug!(
+                "Submitted autosave request {:?} for generation {} in {:?}",
+                request_id,
+                state.session.edit_generation(),
+                started.elapsed()
             );
         }
-        Err(err) => {
-            if record_autosave_failure(&mut state.session, now, &options) {
+        Err(SubmitFailure { error, operation }) => {
+            let err = anyhow::anyhow!("failed to submit autosave: {error}");
+            let drop_started = Instant::now();
+            drop(operation);
+            log::warn!(
+                "Dropped rejected autosave request payload on the event-loop thread in {:?}",
+                drop_started.elapsed()
+            );
+            let failed_at = Instant::now();
+            if record_autosave_failure(&mut state.session, failed_at, &options) {
                 show_session_failure_toast(state);
                 notify_session_failure(state, &err);
             }
@@ -114,99 +299,199 @@ pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<
     Ok(())
 }
 
-fn save_snapshot_or_clear(
+fn final_save_barrier_policy(
+    barrier_result: Result<(), anyhow::Error>,
+    worker_healthy: bool,
+) -> Result<Option<anyhow::Error>, anyhow::Error> {
+    match barrier_result {
+        Ok(()) => Ok(None),
+        Err(err) if worker_healthy => Ok(Some(err)),
+        Err(err) => Err(err),
+    }
+}
+
+fn snapshot_or_empty(
     state: &WaylandState,
     options: &session::SessionOptions,
     snapshot: Option<session::SessionSnapshot>,
-    reason: SessionSaveReason,
-) -> Result<SessionSaveAttempt, anyhow::Error> {
-    if should_skip_protected_session_save(state, options) {
-        return Ok(SessionSaveAttempt::skipped());
-    }
-
-    if should_skip_unloaded_contentless_save(state, options, snapshot.as_ref()) {
-        return Ok(SessionSaveAttempt::skipped());
-    }
-
+) -> Result<session::SessionSnapshot, anyhow::Error> {
     if let Some(snapshot) = snapshot {
-        let saved_board_data = snapshot.has_board_data();
-        let report = save_snapshot_with_reason(
-            &snapshot,
-            options,
-            reason,
-            state.session.has_loaded_board_data(),
-        )?;
-        return Ok(SessionSaveAttempt {
-            saved_board_data: report.is_some() && saved_board_data,
-            report,
-        });
+        return Ok(snapshot);
     }
 
     if !persistence_enabled(options) {
-        return Ok(SessionSaveAttempt::skipped());
+        return Err(anyhow::anyhow!(
+            "session has pending persistence work but all persistence is disabled"
+        ));
     }
 
-    let empty_snapshot = session::SessionSnapshot {
+    Ok(session::SessionSnapshot {
         active_board_id: state.input_state.board_id().to_string(),
         boards: Vec::new(),
         tool_state: None,
-    };
-    let report = save_snapshot_with_reason(
-        &empty_snapshot,
-        options,
-        reason,
-        state.session.has_loaded_board_data(),
-    )?;
-    Ok(SessionSaveAttempt {
-        report,
-        saved_board_data: false,
     })
 }
 
-#[derive(Debug)]
-struct SessionSaveAttempt {
-    report: Option<SaveSnapshotReport>,
-    saved_board_data: bool,
+pub(in crate::backend::wayland) fn observe_input_dirty(state: &mut WaylandState, now: Instant) {
+    let input_dirty = state.input_state.take_session_dirty();
+    state.session.record_input_dirty(now, input_dirty);
 }
 
-impl SessionSaveAttempt {
-    fn skipped() -> Self {
-        Self {
-            report: None,
-            saved_board_data: false,
+pub(in crate::backend::wayland) fn persistence_barrier(
+    state: &mut WaylandState,
+) -> Result<(), anyhow::Error> {
+    observe_input_dirty(state, Instant::now());
+    if state.persistence.is_active() {
+        let completion = match state.persistence.wait_for_completion() {
+            Ok(Some(completion)) => completion,
+            Ok(None) => {
+                return Err(anyhow::anyhow!(
+                    "active persistence request had no completion"
+                ));
+            }
+            Err(err) => {
+                handle_persistence_transport_failure(state, Instant::now(), &err);
+                return Err(err);
+            }
+        };
+        apply_persistence_completion(state, completion)?;
+    }
+    if !state.persistence.is_healthy() {
+        return Err(anyhow::anyhow!("session persistence worker is unhealthy"));
+    }
+    Ok(())
+}
+
+pub(in crate::backend::wayland) fn run_persistence_operation(
+    state: &mut WaylandState,
+    operation: PersistenceOperation,
+) -> Result<PersistenceOutcome, anyhow::Error> {
+    persistence_barrier(state)?;
+    state
+        .persistence
+        .run(state.session.target_epoch(), operation)
+}
+
+pub(in crate::backend::wayland) fn drain_persistence_completion(
+    state: &mut WaylandState,
+) -> Result<(), anyhow::Error> {
+    let completion = match state.persistence.try_receive() {
+        Ok(completion) => completion,
+        Err(err) => {
+            handle_persistence_transport_failure(state, Instant::now(), &err);
+            return Err(err);
         }
+    };
+    if let Some(completion) = completion {
+        apply_persistence_completion(state, completion)?;
+    }
+    Ok(())
+}
+
+fn apply_persistence_completion(
+    state: &mut WaylandState,
+    completion: PersistenceCompletion,
+) -> Result<(), anyhow::Error> {
+    observe_input_dirty(state, Instant::now());
+    let id = completion.id;
+    let save_result: Result<SaveCompletion, anyhow::Error> = match completion.result {
+        Ok(PersistenceOutcome::Save(save)) => Ok(save),
+        Ok(other) => Err(anyhow::anyhow!(
+            "unexpected asynchronous persistence outcome: {other:?}"
+        )),
+        Err(err) => Err(err),
+    };
+    let completed_at = Instant::now();
+    let committed = state
+        .session
+        .complete_autosave(id, completed_at, &save_result)?;
+    match save_result {
+        Ok(save) if committed => {
+            log_session_save_result(
+                SessionSaveReason::Autosave,
+                save.report.as_ref(),
+                completion.execution_time,
+            );
+            notify_session_save_report(state, save.report.as_ref());
+        }
+        Ok(_) => {
+            let err = anyhow::anyhow!("autosave worker completed without writing session data");
+            handle_autosave_failure(state, completed_at, &err);
+            return Err(err);
+        }
+        Err(err) => {
+            handle_autosave_failure(state, completed_at, &err);
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+fn handle_autosave_failure(state: &mut WaylandState, now: Instant, err: &anyhow::Error) {
+    let Some(options) = state.session_options().cloned() else {
+        return;
+    };
+    if record_autosave_failure(&mut state.session, now, &options) {
+        show_session_failure_toast(state);
+        notify_session_failure(state, err);
     }
 }
 
-fn save_snapshot_with_reason(
-    snapshot: &session::SessionSnapshot,
-    options: &session::SessionOptions,
-    reason: SessionSaveReason,
-    contentless_clear_boundary: bool,
-) -> Result<Option<SaveSnapshotReport>, anyhow::Error> {
-    match reason {
-        SessionSaveReason::Autosave => {
-            session::save_snapshot_autosave_with_report_and_clear_boundary(
-                snapshot,
-                options,
-                contentless_clear_boundary,
-            )
-        }
-        SessionSaveReason::Shutdown => session::save_snapshot_with_report_and_clear_boundary(
-            snapshot,
-            options,
-            contentless_clear_boundary,
-        ),
+fn handle_persistence_transport_failure(
+    state: &mut WaylandState,
+    now: Instant,
+    err: &anyhow::Error,
+) {
+    let options = state.session_options().cloned();
+    if restore_autosave_after_transport_failure(&mut state.session, options.as_ref(), now) {
+        show_session_failure_toast(state);
+        notify_session_failure(state, err);
     }
 }
 
-fn should_defer_autosave_for_interaction(state: &WaylandState) -> bool {
-    state.input_state.has_active_pointer_interaction()
-        || state.toolbar_dragging()
-        || state.is_move_dragging()
-        || state.board_panning_active()
-        || state.zoom_panning_active()
-        || stylus_tip_down(state)
+fn restore_autosave_after_transport_failure(
+    session: &mut SessionState,
+    options: Option<&session::SessionOptions>,
+    now: Instant,
+) -> bool {
+    if !session.restore_in_flight_autosave() {
+        return false;
+    }
+    options.is_some_and(|options| record_autosave_failure(session, now, options))
+}
+
+pub(in crate::backend::wayland) fn should_defer_for_interaction(state: &WaylandState) -> bool {
+    persistence_interaction_active(
+        state.input_state.has_active_pointer_interaction(),
+        state.toolbar_dragging(),
+        state.is_move_dragging(),
+        state.board_panning_active(),
+        state.zoom_panning_active(),
+        stylus_tip_down(state),
+    )
+}
+
+fn persistence_interaction_active(
+    pointer: bool,
+    toolbar_drag: bool,
+    move_drag: bool,
+    board_pan: bool,
+    zoom_pan: bool,
+    stylus_tip: bool,
+) -> bool {
+    pointer || toolbar_drag || move_drag || board_pan || zoom_pan || stylus_tip
+}
+
+pub(in crate::backend::wayland) fn interaction_defer_interval() -> Duration {
+    Duration::from_millis(AUTOSAVE_ACTIVE_INTERACTION_DEFER_MS)
+}
+
+fn min_optional_timeout(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
 }
 
 fn defer_pending_autosave_for_interaction(
@@ -252,55 +537,13 @@ impl SessionSaveReason {
     }
 }
 
-#[derive(Debug, Default)]
-struct SnapshotSummary {
-    boards: usize,
-    pages: usize,
-    shapes: usize,
-    undo_entries: usize,
-    redo_entries: usize,
-    visible_image_shapes: usize,
-    visible_image_bytes: usize,
-    max_history_depth: usize,
-    tool_state: bool,
-}
-
-impl SnapshotSummary {
-    fn from_snapshot(snapshot: &session::SessionSnapshot) -> Self {
-        let mut summary = Self {
-            tool_state: snapshot.tool_state.is_some(),
-            ..Self::default()
-        };
-        for board in &snapshot.boards {
-            summary.boards += 1;
-            summary.pages += board.pages.pages.len();
-            for frame in &board.pages.pages {
-                let undo = frame.undo_stack_len();
-                let redo = frame.redo_stack_len();
-                summary.shapes += frame.shapes.len();
-                summary.undo_entries += undo;
-                summary.redo_entries += redo;
-                summary.max_history_depth = summary.max_history_depth.max(undo.max(redo));
-                for drawn in &frame.shapes {
-                    if let crate::draw::Shape::Image { data, .. } = &drawn.shape {
-                        summary.visible_image_shapes += 1;
-                        summary.visible_image_bytes =
-                            summary.visible_image_bytes.saturating_add(data.bytes.len());
-                    }
-                }
-            }
-        }
-        summary
-    }
-}
-
 fn log_snapshot_capture(
     reason: SessionSaveReason,
     options: &session::SessionOptions,
     snapshot: Option<&session::SessionSnapshot>,
     elapsed: Duration,
 ) {
-    let Some(snapshot) = snapshot else {
+    let Some(_snapshot) = snapshot else {
         log::info!(
             "Captured {} session snapshot for {} in {:?}: no persistable data",
             reason.label(),
@@ -310,21 +553,11 @@ fn log_snapshot_capture(
         return;
     };
 
-    let summary = SnapshotSummary::from_snapshot(snapshot);
     log::info!(
-        "Captured {} session snapshot for {} in {:?}: boards={}, pages={}, shapes={}, undo_entries={}, redo_entries={}, max_history_depth={}, visible_images={} ({} bytes), tool_state={}",
+        "Captured {} session snapshot for {} in {:?}; diagnostics and payload preparation will run on the persistence worker",
         reason.label(),
         options.session_file_path().display(),
-        elapsed,
-        summary.boards,
-        summary.pages,
-        summary.shapes,
-        summary.undo_entries,
-        summary.redo_entries,
-        summary.max_history_depth,
-        summary.visible_image_shapes,
-        summary.visible_image_bytes,
-        summary.tool_state
+        elapsed
     );
 }
 
@@ -358,6 +591,16 @@ fn persistence_enabled(options: &session::SessionOptions) -> bool {
     options.any_enabled() || options.restore_tool_state || options.persist_history
 }
 
+fn should_skip_disabled_final_save(options: &session::SessionOptions) -> bool {
+    let skip = !persistence_enabled(options);
+    if skip {
+        log::info!(
+            "Skipping final session save because all session persistence options are disabled"
+        );
+    }
+    skip
+}
+
 fn should_skip_protected_session_save(
     state: &WaylandState,
     options: &session::SessionOptions,
@@ -376,16 +619,35 @@ fn should_skip_protected_session_save(
 }
 
 fn should_skip_unloaded_contentless_save(
-    state: &WaylandState,
+    state: &mut WaylandState,
     options: &session::SessionOptions,
     snapshot: Option<&session::SessionSnapshot>,
-) -> bool {
+) -> Result<bool, anyhow::Error> {
+    let has_board_data = snapshot.is_some_and(session::SessionSnapshot::has_board_data);
+    if has_board_data
+        || state.session.has_loaded_board_data()
+        || state.session.is_dirty()
+        || state.input_state.is_session_dirty()
+    {
+        return Ok(false);
+    }
+    let outcome = run_persistence_operation(
+        state,
+        PersistenceOperation::HasArtifacts {
+            options: options.clone(),
+        },
+    )?;
+    let PersistenceOutcome::HasArtifacts(has_artifacts) = outcome else {
+        return Err(anyhow::anyhow!(
+            "unexpected session artifact inspection outcome"
+        ));
+    };
     let skip = runtime_session::should_skip_unloaded_contentless_save(
         state.session.has_loaded_board_data(),
         state.session.is_dirty(),
         state.input_state.is_session_dirty(),
-        snapshot.is_some_and(session::SessionSnapshot::has_board_data),
-        runtime_session::has_session_artifact(options),
+        has_board_data,
+        has_artifacts,
     );
     if skip {
         log::warn!(
@@ -393,7 +655,7 @@ fn should_skip_unloaded_contentless_save(
             options.session_file_path().display()
         );
     }
-    skip
+    Ok(skip)
 }
 
 #[cfg(test)]

--- a/src/backend/wayland/backend/event_loop/session_save.rs
+++ b/src/backend/wayland/backend/event_loop/session_save.rs
@@ -22,7 +22,8 @@ use notifications::{
     SessionSaveNotification, pending_save_notifications, session_save_notification_text,
 };
 use notifications::{
-    notify_session_save_report, record_autosave_failure, show_session_failure_toast,
+    notify_persistence_worker_failure, notify_session_save_report, record_autosave_failure,
+    show_persistence_worker_failure_toast, show_session_failure_toast,
 };
 
 pub(super) fn persist_session(state: &mut WaylandState) -> Result<(), anyhow::Error> {
@@ -289,7 +290,9 @@ pub(super) fn autosave_if_due(state: &mut WaylandState, now: Instant) -> Result<
                 drop_started.elapsed()
             );
             let failed_at = Instant::now();
-            if record_autosave_failure(&mut state.session, failed_at, &options) {
+            if !state.persistence.is_healthy() {
+                handle_persistence_transport_failure(state, failed_at, &err);
+            } else if record_autosave_failure(&mut state.session, failed_at, &options) {
                 show_session_failure_toast(state);
                 notify_session_failure(state, &err);
             }
@@ -367,9 +370,15 @@ pub(in crate::backend::wayland) fn run_persistence_operation(
     operation: PersistenceOperation,
 ) -> Result<PersistenceOutcome, anyhow::Error> {
     persistence_barrier(state)?;
-    state
+    let result = state
         .persistence
-        .run(state.session.target_epoch(), operation)
+        .run(state.session.target_epoch(), operation);
+    if let Err(err) = &result
+        && !state.persistence.is_healthy()
+    {
+        handle_persistence_transport_failure(state, Instant::now(), err);
+    }
+    result
 }
 
 pub(in crate::backend::wayland) fn drain_persistence_completion(
@@ -443,21 +452,25 @@ fn handle_persistence_transport_failure(
     err: &anyhow::Error,
 ) {
     let options = state.session_options().cloned();
-    if restore_autosave_after_transport_failure(&mut state.session, options.as_ref(), now) {
-        show_session_failure_toast(state);
-        notify_session_failure(state, err);
+    if record_persistence_transport_failure(&mut state.session, options.as_ref(), now) {
+        show_persistence_worker_failure_toast(state);
+        notify_persistence_worker_failure(state, err);
     }
 }
 
-fn restore_autosave_after_transport_failure(
+fn record_persistence_transport_failure(
     session: &mut SessionState,
     options: Option<&session::SessionOptions>,
     now: Instant,
 ) -> bool {
-    if !session.restore_in_flight_autosave() {
+    let restored_autosave = session.restore_in_flight_autosave();
+    let Some(options) = options else {
         return false;
+    };
+    if restored_autosave {
+        let _ = record_autosave_failure(session, now, options);
     }
-    options.is_some_and(|options| record_autosave_failure(session, now, options))
+    session.mark_worker_failure_notified()
 }
 
 pub(in crate::backend::wayland) fn should_defer_for_interaction(state: &WaylandState) -> bool {

--- a/src/backend/wayland/backend/event_loop/session_save/notifications.rs
+++ b/src/backend/wayland/backend/event_loop/session_save/notifications.rs
@@ -165,10 +165,32 @@ pub(in crate::backend::wayland::backend::event_loop) fn notify_session_failure(
     );
 }
 
+pub(super) fn notify_persistence_worker_failure(state: &WaylandState, err: &anyhow::Error) {
+    notification::send_notification_with_timeout_async(
+        &state.tokio_handle,
+        "Session Persistence Stopped".to_string(),
+        format!(
+            "Automatic session persistence stopped because its background worker failed. Wayscriber will retry the final save during shutdown. Details: {err}"
+        ),
+        Some("dialog-error".to_string()),
+        SESSION_SAVE_NOTIFICATION_TIMEOUT_MS,
+    );
+}
+
 pub(super) fn show_session_failure_toast(state: &mut WaylandState) {
     state.input_state.set_ui_toast_with_action_and_duration(
         UiToastKind::Warning,
         "Session save failed; drawings may not restore. Check max_file_size_mb.",
+        "Settings",
+        Action::OpenConfigurator,
+        SESSION_SAVE_WARNING_TOAST_MS,
+    );
+}
+
+pub(super) fn show_persistence_worker_failure_toast(state: &mut WaylandState) {
+    state.input_state.set_ui_toast_with_action_and_duration(
+        UiToastKind::Warning,
+        "Automatic session persistence stopped; final save will be retried on exit.",
         "Settings",
         Action::OpenConfigurator,
         SESSION_SAVE_WARNING_TOAST_MS,

--- a/src/backend/wayland/backend/event_loop/session_save/notifications.rs
+++ b/src/backend/wayland/backend/event_loop/session_save/notifications.rs
@@ -129,6 +129,7 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
+#[cfg(test)]
 pub(super) fn record_autosave_success(
     session_state: &mut SessionState,
     now: Instant,

--- a/src/backend/wayland/backend/event_loop/session_save/tests.rs
+++ b/src/backend/wayland/backend/event_loop/session_save/tests.rs
@@ -1,6 +1,101 @@
 use super::*;
+use crate::backend::wayland::session::{PersistenceController, PersistenceOperation};
 use crate::session::SaveSnapshotOutcome;
 use std::path::PathBuf;
+
+#[test]
+fn final_save_retries_after_failed_autosave_while_worker_is_healthy() {
+    let error = anyhow::anyhow!("autosave failed");
+    let recovered = final_save_barrier_policy(Err(error), true)
+        .expect("healthy worker should remain available for the final save");
+    assert!(recovered.is_some());
+}
+
+#[test]
+fn final_save_does_not_retry_through_an_unhealthy_worker() {
+    let error = anyhow::anyhow!("worker disconnected");
+    let propagated = final_save_barrier_policy(Err(error), false)
+        .expect_err("unhealthy worker must enter shutdown fallback handling");
+    assert!(propagated.to_string().contains("worker disconnected"));
+}
+
+#[test]
+fn pointer_and_stylus_both_gate_persistence_transitions() {
+    assert!(persistence_interaction_active(
+        true, false, false, false, false, false
+    ));
+    assert!(persistence_interaction_active(
+        false, false, false, false, false, true
+    ));
+    assert!(!persistence_interaction_active(
+        false, false, false, false, false, false
+    ));
+}
+
+#[test]
+fn unhealthy_worker_removes_dirty_session_from_automatic_schedule() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display-1");
+    options.persist_transparent = true;
+    options.autosave_enabled = true;
+    options.autosave_idle = Duration::from_millis(1);
+    options.autosave_interval = Duration::from_millis(1);
+    let now = Instant::now();
+    let mut state = SessionState::new(Some(options.clone()));
+    state.record_input_dirty(now, true);
+    let due = now + Duration::from_millis(2);
+
+    assert_eq!(
+        scheduled_autosave_timeout(&state, Some(&options), false, due),
+        None
+    );
+    assert_eq!(
+        scheduled_autosave_timeout(&state, Some(&options), true, due),
+        Some(Duration::ZERO)
+    );
+}
+
+#[test]
+fn accepted_autosave_worker_panic_restores_dirty_and_requests_one_notification() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "disconnect-test");
+    options.persist_transparent = true;
+    options.autosave_enabled = true;
+    options.autosave_idle = Duration::from_millis(1);
+    options.autosave_interval = Duration::from_millis(1);
+    options.autosave_failure_backoff = Duration::from_millis(50);
+    let started = Instant::now();
+    let mut session = SessionState::new(Some(options.clone()));
+    session.record_input_dirty(started, true);
+    let dirty_window = session.prepare_autosave_submission().unwrap();
+    let mut controller = PersistenceController::start().unwrap();
+    let request_id = controller
+        .try_submit(0, PersistenceOperation::PanicForTest)
+        .unwrap();
+    session.commit_autosave_submission(request_id, dirty_window);
+
+    let err = controller
+        .wait_for_completion()
+        .expect_err("worker panic must disconnect the completion channel");
+    assert!(err.to_string().contains("disconnected"));
+    assert!(!controller.is_healthy());
+
+    let failure_at = Instant::now();
+    let notification_requests = [
+        restore_autosave_after_transport_failure(&mut session, Some(&options), failure_at),
+        restore_autosave_after_transport_failure(&mut session, Some(&options), failure_at),
+    ]
+    .into_iter()
+    .filter(|requested| *requested)
+    .count();
+    assert_eq!(notification_requests, 1);
+    assert!(session.is_dirty());
+    assert_eq!(
+        scheduled_autosave_timeout(&session, Some(&options), false, failure_at),
+        None
+    );
+
+    assert!(controller.shutdown(0).is_err());
+    assert!(controller.is_stopped());
+}
 
 #[test]
 fn persistence_enabled_respects_any_enabled_boards() {
@@ -34,6 +129,18 @@ fn persistence_enabled_is_false_when_nothing_is_enabled() {
     options.restore_tool_state = false;
 
     assert!(!persistence_enabled(&options));
+}
+
+#[test]
+fn final_save_skips_fully_disabled_persistence() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "display-1");
+    options.persist_transparent = false;
+    options.persist_whiteboard = false;
+    options.persist_blackboard = false;
+    options.persist_history = false;
+    options.restore_tool_state = false;
+
+    assert!(should_skip_disabled_final_save(&options));
 }
 
 #[test]

--- a/src/backend/wayland/backend/event_loop/session_save/tests.rs
+++ b/src/backend/wayland/backend/event_loop/session_save/tests.rs
@@ -80,8 +80,8 @@ fn accepted_autosave_worker_panic_restores_dirty_and_requests_one_notification()
 
     let failure_at = Instant::now();
     let notification_requests = [
-        restore_autosave_after_transport_failure(&mut session, Some(&options), failure_at),
-        restore_autosave_after_transport_failure(&mut session, Some(&options), failure_at),
+        record_persistence_transport_failure(&mut session, Some(&options), failure_at),
+        record_persistence_transport_failure(&mut session, Some(&options), failure_at),
     ]
     .into_iter()
     .filter(|requested| *requested)
@@ -95,6 +95,26 @@ fn accepted_autosave_worker_panic_restores_dirty_and_requests_one_notification()
 
     assert!(controller.shutdown(0).is_err());
     assert!(controller.is_stopped());
+}
+
+#[test]
+fn synchronous_worker_loss_without_autosave_ticket_requests_one_notification() {
+    let mut options = session::SessionOptions::new(PathBuf::from("/tmp"), "sync-disconnect");
+    options.persist_transparent = true;
+    let mut session = SessionState::new(Some(options.clone()));
+    let failure_at = Instant::now();
+
+    assert!(record_persistence_transport_failure(
+        &mut session,
+        Some(&options),
+        failure_at,
+    ));
+    assert!(!record_persistence_transport_failure(
+        &mut session,
+        Some(&options),
+        failure_at,
+    ));
+    assert!(!session.is_dirty());
 }
 
 #[test]

--- a/src/backend/wayland/backend/mod.rs
+++ b/src/backend/wayland/backend/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::backend::ExitAfterCaptureMode;
 
-mod event_loop;
+pub(in crate::backend::wayland) mod event_loop;
 mod helpers;
 mod run;
 mod setup;

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -40,6 +40,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
     let config_dir = Config::config_directory_from_source(&source)?;
     let session_options =
         session::build_session_options(&config, &config_dir, backend.named_session_file.clone());
+    let persistence = crate::backend::wayland::session::PersistenceController::start()?;
     let output_prefs = output::resolve(&config);
 
     #[cfg(tablet)]
@@ -124,6 +125,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
         onboarding,
         capture_manager,
         session_options,
+        persistence,
         tokio_handle,
         exit_after_capture_mode,
         frozen_enabled: frozen_supported,

--- a/src/backend/wayland/handlers/compositor.rs
+++ b/src/backend/wayland/handlers/compositor.rs
@@ -8,7 +8,6 @@ use wayland_client::{
 };
 
 use super::super::state::{FullDamageReason, WaylandState};
-use crate::session;
 
 impl CompositorHandler for WaylandState {
     fn scale_factor_changed(
@@ -119,11 +118,7 @@ impl CompositorHandler for WaylandState {
         debug!("Surface entered output");
 
         let previous_output = self.surface.current_output();
-        let had_confirmed_surface_enter = self.has_seen_surface_enter();
         let output_changed = previous_output.as_ref() != Some(output);
-        if output_changed && previous_output.is_some() && had_confirmed_surface_enter {
-            self.persist_session_for_output(previous_output.as_ref(), "surface output change");
-        }
         self.surface.set_current_output(output.clone());
         self.set_has_seen_surface_enter(true);
         if output_changed {
@@ -188,50 +183,8 @@ impl CompositorHandler for WaylandState {
         }
 
         let identity = self.output_identity_for(output);
-
-        let mut load_result = None;
-        let already_loaded = self.session.is_loaded();
-        let mut load_requested = false;
-        if let Some(options) = self.session_options_mut() {
-            let changed = options.set_output_identity(identity.as_deref());
-
-            if changed && let Some(id) = options.output_identity() {
-                info!(
-                    "Persisting session using monitor identity '{}' (session file: {}).",
-                    id,
-                    options.session_file_path().display()
-                );
-            }
-
-            if changed || !already_loaded {
-                info!(
-                    "Loading session snapshot from {} (per_output={}, output_identity={:?})",
-                    options.session_file_path().display(),
-                    options.per_output,
-                    options.output_identity()
-                );
-                load_result = Some(session::load_snapshot_with_outcome(options));
-                load_requested = true;
-            }
-        }
-
-        if let Some(result) = load_result {
-            let mut loaded_board_data = false;
-            match result {
-                Ok(outcome) => {
-                    loaded_board_data = outcome.has_board_data();
-                    self.handle_session_load_outcome(outcome, "output load");
-                }
-                Err(err) => {
-                    warn!("Failed to load session state: {}", err);
-                }
-            }
-
-            if load_requested {
-                self.session.mark_loaded(loaded_board_data);
-                self.input_state.needs_redraw = true;
-            }
-        }
+        self.begin_session_output_transition(identity, "surface output change");
+        self.input_state.needs_redraw = true;
     }
 
     fn surface_leave(

--- a/src/backend/wayland/handlers/layer.rs
+++ b/src/backend/wayland/handlers/layer.rs
@@ -1,5 +1,5 @@
 // Responds to layer-shell configure/close events, keeping dimensions in sync with the compositor.
-use log::{debug, info, warn};
+use log::{debug, info};
 use smithay_client_toolkit::shell::{
     WaylandSurface,
     wlr_layer::{LayerShellHandler, LayerSurface, LayerSurfaceConfigure},
@@ -7,7 +7,6 @@ use smithay_client_toolkit::shell::{
 use wayland_client::{Connection, Proxy, QueueHandle};
 
 use super::super::state::{FullDamageReason, WaylandState};
-use crate::session;
 
 impl LayerShellHandler for WaylandState {
     fn closed(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, layer: &LayerSurface) {
@@ -113,31 +112,7 @@ impl LayerShellHandler for WaylandState {
         self.sync_toolbar_visibility(qh);
 
         // Fallback: on xdg-only environments we might never get surface_enter before configure.
-        // Try to load a session snapshot once even without output identity; compositor handler
-        // will still reload with a concrete identity if it arrives later.
-        if !self.session.is_loaded()
-            && let Some(options) = self.session_options_mut()
-        {
-            let load_result = session::load_snapshot_with_outcome(options);
-            let mut load_succeeded = false;
-            let mut loaded_board_data = false;
-            match load_result {
-                Ok(outcome) => {
-                    load_succeeded = true;
-                    loaded_board_data = outcome.has_board_data();
-                    self.handle_session_load_outcome(outcome, "fallback load");
-                }
-                Err(err) => {
-                    warn!("Fallback session load failed: {}", err);
-                }
-            }
-            // Mark loaded to avoid reapplying on every configure when load succeeded; compositor
-            // enter still reloads when a concrete output identity arrives because that changes
-            // the identity and triggers a fresh load.
-            if load_succeeded {
-                self.session.mark_loaded(loaded_board_data);
-            }
-            self.input_state.needs_redraw = true;
-        }
+        // Enter the same epoch-bound, interaction-safe transition path used by surface_enter.
+        self.begin_configure_fallback_session_transition("layer configure fallback");
     }
 }

--- a/src/backend/wayland/handlers/xdg.rs
+++ b/src/backend/wayland/handlers/xdg.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 use wayland_client::{Connection, QueueHandle};
 
 use super::super::state::{FullDamageReason, WaylandState};
-use crate::session;
 
 impl WindowHandler for WaylandState {
     fn request_close(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _window: &Window) {
@@ -157,30 +156,9 @@ impl WindowHandler for WaylandState {
         // Surface is now sized; re-apply toolbar offsets so margins reflect configured bounds.
         self.sync_toolbar_visibility(qh);
 
-        // Fallback: xdg may not emit surface_enter before configure; attempt a session load once.
-        if !self.session.is_loaded()
-            && let Some(options) = self.session_options_mut()
-        {
-            let load_result = session::load_snapshot_with_outcome(options);
-            let mut load_succeeded = false;
-            let mut loaded_board_data = false;
-            match load_result {
-                Ok(outcome) => {
-                    load_succeeded = true;
-                    loaded_board_data = outcome.has_board_data();
-                    self.handle_session_load_outcome(outcome, "fallback load");
-                }
-                Err(err) => {
-                    warn!("Fallback session load failed: {}", err);
-                }
-            }
-            // Mark loaded to avoid repeated loads when load succeeded; compositor enter still
-            // reloads when it sets a new output identity.
-            if load_succeeded {
-                self.session.mark_loaded(loaded_board_data);
-            }
-            self.input_state.needs_redraw = true;
-        }
+        // Fallback: xdg may not emit surface_enter before configure. Use the same epoch-bound,
+        // interaction-safe transition path as surface_enter instead of loading directly.
+        self.begin_configure_fallback_session_transition("xdg configure fallback");
     }
 }
 

--- a/src/backend/wayland/session.rs
+++ b/src/backend/wayland/session.rs
@@ -50,6 +50,7 @@ pub struct SessionState {
     pending_output_transition: Option<PendingOutputTransition>,
     live_source_resolution_pending: bool,
     notified_failure: bool,
+    notified_worker_failure: bool,
     notified_near_limit_paths: HashSet<PathBuf>,
     notified_trimmed_history: bool,
     notified_visible_only: bool,
@@ -76,6 +77,7 @@ impl SessionState {
             pending_output_transition: None,
             live_source_resolution_pending: false,
             notified_failure: false,
+            notified_worker_failure: false,
             notified_near_limit_paths: HashSet::new(),
             notified_trimmed_history: false,
             notified_visible_only: false,
@@ -221,6 +223,15 @@ impl SessionState {
             false
         } else {
             self.notified_failure = true;
+            true
+        }
+    }
+
+    pub(in crate::backend::wayland) fn mark_worker_failure_notified(&mut self) -> bool {
+        if self.notified_worker_failure {
+            false
+        } else {
+            self.notified_worker_failure = true;
             true
         }
     }

--- a/src/backend/wayland/session.rs
+++ b/src/backend/wayland/session.rs
@@ -11,17 +11,44 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+#[derive(Debug, Clone, Copy)]
+pub(in crate::backend::wayland) struct DirtyWindow {
+    generation: u64,
+    dirty_since: Instant,
+    last_dirty_at: Instant,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InFlightAutosave {
+    request_id: RequestId,
+    window: DirtyWindow,
+}
+
+#[derive(Debug, Clone)]
+pub(in crate::backend::wayland) struct PendingOutputTransition {
+    pub(in crate::backend::wayland) source_epoch: u64,
+    pub(in crate::backend::wayland) staged_options: SessionOptions,
+    pub(in crate::backend::wayland) physical_output_identity: Option<String>,
+    pub(in crate::backend::wayland) retry_at: Instant,
+    pub(in crate::backend::wayland) failure_notified: bool,
+}
+
 /// Tracks session persistence state and bookkeeping for per-output snapshots.
 pub struct SessionState {
     options: Option<SessionOptions>,
     loaded: bool,
     loaded_board_data: bool,
+    target_epoch: u64,
+    edit_generation: u64,
     dirty: bool,
     dirty_since: Option<Instant>,
     last_dirty_at: Option<Instant>,
     last_save_at: Option<Instant>,
     autosave_retry_at: Option<Instant>,
     autosave_deferred_until: Option<Instant>,
+    in_flight_autosave: Option<InFlightAutosave>,
+    pending_output_transition: Option<PendingOutputTransition>,
+    live_source_resolution_pending: bool,
     notified_failure: bool,
     notified_near_limit_paths: HashSet<PathBuf>,
     notified_trimmed_history: bool,
@@ -37,12 +64,17 @@ impl SessionState {
             options,
             loaded: false,
             loaded_board_data: false,
+            target_epoch: 0,
+            edit_generation: 0,
             dirty: false,
             dirty_since: None,
             last_dirty_at: None,
             last_save_at: None,
             autosave_retry_at: None,
             autosave_deferred_until: None,
+            in_flight_autosave: None,
+            pending_output_transition: None,
+            live_source_resolution_pending: false,
             notified_failure: false,
             notified_near_limit_paths: HashSet::new(),
             notified_trimmed_history: false,
@@ -58,19 +90,22 @@ impl SessionState {
     }
 
     /// Returns mutable access to the session options, if present.
+    #[allow(dead_code)]
     pub fn options_mut(&mut self) -> Option<&mut SessionOptions> {
         self.options.as_mut()
     }
 
-    /// Returns true if a session snapshot has already been loaded this run.
+    /// Returns true if the active logical session source has been resolved this run.
     pub fn is_loaded(&self) -> bool {
         self.loaded
     }
 
     /// Marks the session as loaded and records whether board data is now on disk.
+    #[allow(dead_code)]
     pub fn mark_loaded(&mut self, loaded_board_data: bool) {
         self.loaded = true;
         self.loaded_board_data = loaded_board_data;
+        self.live_source_resolution_pending = false;
     }
 
     pub fn has_loaded_board_data(&self) -> bool {
@@ -78,13 +113,26 @@ impl SessionState {
     }
 
     pub fn is_dirty(&self) -> bool {
-        self.dirty
+        self.dirty || self.in_flight_autosave.is_some()
+    }
+
+    pub(in crate::backend::wayland) fn target_epoch(&self) -> u64 {
+        self.target_epoch
+    }
+
+    pub(in crate::backend::wayland) fn edit_generation(&self) -> u64 {
+        self.edit_generation
     }
 
     pub fn record_input_dirty(&mut self, now: Instant, input_dirty: bool) {
         if !input_dirty {
             return;
         }
+        if self.live_source_resolution_pending {
+            self.loaded = true;
+            self.live_source_resolution_pending = false;
+        }
+        self.edit_generation = self.edit_generation.wrapping_add(1);
         if !self.dirty {
             self.dirty_since = Some(now);
         }
@@ -93,6 +141,7 @@ impl SessionState {
     }
 
     pub fn mark_saved(&mut self, now: Instant, saved_board_data: bool) {
+        self.in_flight_autosave = None;
         self.dirty = false;
         self.dirty_since = None;
         self.last_dirty_at = None;
@@ -104,14 +153,21 @@ impl SessionState {
     }
 
     pub fn mark_clean_after_load(&mut self) {
+        self.in_flight_autosave = None;
         self.dirty = false;
         self.dirty_since = None;
         self.last_dirty_at = None;
         self.autosave_retry_at = None;
         self.autosave_deferred_until = None;
+        self.live_source_resolution_pending = false;
     }
 
-    fn commit_runtime_open(&mut self, options: SessionOptions, loaded_board_data: bool) {
+    pub(in crate::backend::wayland) fn commit_runtime_open(
+        &mut self,
+        options: SessionOptions,
+        loaded_board_data: bool,
+    ) {
+        self.advance_target_epoch();
         self.options = Some(options);
         self.loaded = true;
         self.loaded_board_data = loaded_board_data;
@@ -121,15 +177,17 @@ impl SessionState {
         self.last_save_at = None;
         self.autosave_retry_at = None;
         self.autosave_deferred_until = None;
+        self.in_flight_autosave = None;
         self.notified_failure = false;
     }
 
-    fn commit_runtime_save_as(
+    pub(in crate::backend::wayland) fn commit_runtime_save_as(
         &mut self,
         options: SessionOptions,
         now: Instant,
         saved_board_data: bool,
     ) {
+        self.advance_target_epoch();
         self.options = Some(options);
         self.loaded = true;
         self.loaded_board_data = saved_board_data;
@@ -139,10 +197,11 @@ impl SessionState {
         self.last_save_at = Some(now);
         self.autosave_retry_at = None;
         self.autosave_deferred_until = None;
+        self.in_flight_autosave = None;
         self.notified_failure = false;
     }
 
-    fn commit_runtime_clear(&mut self, now: Instant) {
+    pub(in crate::backend::wayland) fn commit_runtime_clear(&mut self, now: Instant) {
         self.loaded = true;
         self.loaded_board_data = false;
         self.dirty = false;
@@ -151,6 +210,8 @@ impl SessionState {
         self.last_save_at = Some(now);
         self.autosave_retry_at = None;
         self.autosave_deferred_until = None;
+        self.in_flight_autosave = None;
+        self.live_source_resolution_pending = false;
         self.notified_failure = false;
     }
 
@@ -207,7 +268,7 @@ impl SessionState {
     }
 
     pub fn autosave_due(&self, now: Instant, options: &SessionOptions) -> bool {
-        if !autosave_active(options) || !self.dirty {
+        if !autosave_active(options) || !self.dirty || self.in_flight_autosave.is_some() {
             return false;
         }
         if let Some(retry_at) = self.autosave_retry_at
@@ -234,7 +295,7 @@ impl SessionState {
     }
 
     pub fn autosave_timeout(&self, now: Instant, options: &SessionOptions) -> Option<Duration> {
-        if !autosave_active(options) || !self.dirty {
+        if !autosave_active(options) || !self.dirty || self.in_flight_autosave.is_some() {
             return None;
         }
         let last_dirty_at = self.last_dirty_at?;
@@ -259,6 +320,234 @@ impl SessionState {
         }
         Some(next_time.saturating_duration_since(now))
     }
+
+    pub(in crate::backend::wayland) fn prepare_autosave_submission(&self) -> Result<DirtyWindow> {
+        if self.in_flight_autosave.is_some() {
+            return Err(anyhow!("an autosave ticket is already in flight"));
+        }
+        let (Some(dirty_since), Some(last_dirty_at)) = (self.dirty_since, self.last_dirty_at)
+        else {
+            return Err(anyhow!(
+                "cannot submit autosave without a pending dirty window"
+            ));
+        };
+        Ok(DirtyWindow {
+            generation: self.edit_generation,
+            dirty_since,
+            last_dirty_at,
+        })
+    }
+
+    pub(in crate::backend::wayland) fn commit_autosave_submission(
+        &mut self,
+        request_id: RequestId,
+        window: DirtyWindow,
+    ) {
+        debug_assert!(self.in_flight_autosave.is_none());
+        self.in_flight_autosave = Some(InFlightAutosave { request_id, window });
+        self.dirty = false;
+        self.dirty_since = None;
+        self.last_dirty_at = None;
+        self.autosave_deferred_until = None;
+    }
+
+    pub(in crate::backend::wayland) fn complete_autosave(
+        &mut self,
+        request_id: RequestId,
+        now: Instant,
+        result: &Result<persistence::SaveCompletion>,
+    ) -> Result<bool> {
+        let Some(ticket) = self.in_flight_autosave.take() else {
+            return Err(anyhow!(
+                "autosave completion arrived without an in-flight ticket"
+            ));
+        };
+        if ticket.request_id != request_id || request_id.target_epoch != self.target_epoch {
+            self.merge_dirty_window(ticket.window);
+            return Err(anyhow!(
+                "autosave completion does not own the active ticket/target epoch"
+            ));
+        }
+        match result {
+            Ok(save) if save.committed() => {
+                self.last_save_at = Some(now);
+                self.autosave_retry_at = None;
+                self.notified_failure = false;
+                self.loaded_board_data = save.committed_board_data;
+                Ok(true)
+            }
+            Ok(_) | Err(_) => {
+                self.merge_dirty_window(ticket.window);
+                Ok(false)
+            }
+        }
+    }
+
+    pub(in crate::backend::wayland) fn restore_in_flight_autosave(&mut self) -> bool {
+        if let Some(ticket) = self.in_flight_autosave.take() {
+            self.merge_dirty_window(ticket.window);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn merge_dirty_window(&mut self, window: DirtyWindow) {
+        self.dirty = true;
+        self.edit_generation = self.edit_generation.max(window.generation);
+        self.dirty_since = Some(self.dirty_since.map_or(window.dirty_since, |current| {
+            current.min(window.dirty_since)
+        }));
+        self.last_dirty_at = Some(self.last_dirty_at.map_or(window.last_dirty_at, |current| {
+            current.max(window.last_dirty_at)
+        }));
+    }
+
+    pub(in crate::backend::wayland) fn stage_output_transition(
+        &mut self,
+        staged_options: SessionOptions,
+        physical_output_identity: Option<String>,
+        retry_at: Instant,
+    ) {
+        let failure_notified = self
+            .pending_output_transition
+            .as_ref()
+            .is_some_and(|pending| {
+                pending.source_epoch == self.target_epoch
+                    && pending.physical_output_identity == physical_output_identity
+            });
+        self.pending_output_transition = Some(PendingOutputTransition {
+            source_epoch: self.target_epoch,
+            staged_options,
+            physical_output_identity,
+            retry_at,
+            failure_notified,
+        });
+    }
+
+    pub(in crate::backend::wayland) fn pending_output_transition(
+        &self,
+    ) -> Option<&PendingOutputTransition> {
+        self.pending_output_transition.as_ref()
+    }
+
+    pub(in crate::backend::wayland) fn take_pending_output_transition(
+        &mut self,
+    ) -> Option<PendingOutputTransition> {
+        self.pending_output_transition.take()
+    }
+
+    pub(in crate::backend::wayland) fn cancel_pending_output_transition(
+        &mut self,
+    ) -> Option<PendingOutputTransition> {
+        self.pending_output_transition.take()
+    }
+
+    pub(in crate::backend::wayland) fn has_pending_live_source_resolution(&self) -> bool {
+        self.live_source_resolution_pending
+    }
+
+    /// Cancels a superseded destination while retaining dirty live source data.
+    ///
+    /// A dirty source becomes authoritative for this run so a later configure
+    /// fallback cannot reload over it. A clean unloaded source remains pending
+    /// until the controller can perform its initial load. The dirty window and
+    /// target epoch remain unchanged.
+    pub(in crate::backend::wayland) fn cancel_output_transition_for_live_source(
+        &mut self,
+        input_dirty: bool,
+    ) -> Option<PendingOutputTransition> {
+        let pending = self.pending_output_transition.take();
+        if pending.is_some() {
+            if self.is_dirty() || input_dirty {
+                self.loaded = true;
+                self.live_source_resolution_pending = false;
+            } else {
+                self.live_source_resolution_pending = !self.loaded;
+            }
+        }
+        pending
+    }
+
+    /// Resolves provisional protection after an output transition was canceled.
+    ///
+    /// Returns true while an interaction still blocks resolution. A committed
+    /// mutation makes the live source authoritative; a clean idle source remains
+    /// unloaded so the controller can perform the configured initial load.
+    pub(in crate::backend::wayland) fn resolve_live_source_resolution(
+        &mut self,
+        input_dirty: bool,
+        interaction_active: bool,
+    ) -> bool {
+        if !self.live_source_resolution_pending {
+            return false;
+        }
+        if self.is_dirty() || input_dirty {
+            self.loaded = true;
+            self.live_source_resolution_pending = false;
+            return false;
+        }
+        if interaction_active {
+            return true;
+        }
+        self.live_source_resolution_pending = false;
+        false
+    }
+
+    pub(in crate::backend::wayland) fn output_transition_timeout(
+        &self,
+        now: Instant,
+    ) -> Option<Duration> {
+        self.pending_output_transition
+            .as_ref()
+            .map(|transition| transition.retry_at.saturating_duration_since(now))
+    }
+
+    pub(in crate::backend::wayland) fn defer_output_transition(
+        &mut self,
+        now: Instant,
+        delay: Duration,
+    ) {
+        if let Some(transition) = self.pending_output_transition.as_mut() {
+            transition.retry_at = now + delay;
+        }
+    }
+
+    pub(in crate::backend::wayland) fn mark_output_transition_notified(&mut self) -> bool {
+        let Some(transition) = self.pending_output_transition.as_mut() else {
+            return false;
+        };
+        if transition.failure_notified {
+            false
+        } else {
+            transition.failure_notified = true;
+            true
+        }
+    }
+
+    pub(in crate::backend::wayland) fn commit_output_options(
+        &mut self,
+        options: SessionOptions,
+        loaded_board_data: bool,
+    ) {
+        self.advance_target_epoch();
+        self.options = Some(options);
+        self.loaded = true;
+        self.loaded_board_data = loaded_board_data;
+        self.mark_clean_after_load();
+    }
+
+    fn advance_target_epoch(&mut self) {
+        self.target_epoch = self.target_epoch.wrapping_add(1);
+        self.live_source_resolution_pending = false;
+        if self
+            .pending_output_transition
+            .as_ref()
+            .is_some_and(|pending| pending.source_epoch != self.target_epoch)
+        {
+            self.pending_output_transition = None;
+        }
+    }
 }
 
 fn autosave_active(options: &SessionOptions) -> bool {
@@ -266,13 +555,22 @@ fn autosave_active(options: &SessionOptions) -> bool {
         && (options.any_enabled() || options.restore_tool_state || options.persist_history)
 }
 
+mod persistence;
 mod runtime;
+
+pub(in crate::backend::wayland) use persistence::{
+    PersistenceCompletion, PersistenceController, PersistenceOperation, PersistenceOutcome,
+    RequestId, SaveCompletion, SaveStrategy, SubmitFailure,
+};
 
 pub(in crate::backend::wayland) use runtime::{
     RuntimeClearSessionReport, RuntimeClearToolStateReport, RuntimeOpenSessionReport,
-    RuntimeSaveAsSessionReport, clear_current_session_runtime, clear_saved_tool_state_runtime,
-    open_named_session_runtime, save_named_session_as_requires_overwrite,
-    save_named_session_as_runtime,
+    RuntimeSaveAsSessionReport,
+};
+#[cfg(test)]
+pub(super) use runtime::{
+    clear_current_session_runtime, clear_saved_tool_state_runtime, open_named_session_runtime,
+    save_named_session_as_requires_overwrite, save_named_session_as_runtime,
 };
 pub(super) use runtime::{has_session_artifact, should_skip_unloaded_contentless_save};
 

--- a/src/backend/wayland/session/persistence.rs
+++ b/src/backend/wayland/session/persistence.rs
@@ -1,0 +1,923 @@
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::session::{
+    self, ClearToolStateOutcome, LoadSnapshotOutcome, SaveAsOverwrite, SaveSnapshotOutcome,
+    SaveSnapshotReport, SessionInspection, SessionOptions, SessionSnapshot,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct RequestId {
+    pub(in crate::backend::wayland) target_epoch: u64,
+    pub(in crate::backend::wayland) sequence: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum SaveStrategy {
+    Autosave,
+    Normal,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) enum PersistenceOperation {
+    Save {
+        snapshot: SessionSnapshot,
+        options: SessionOptions,
+        strategy: SaveStrategy,
+        contentless_clear_boundary: bool,
+    },
+    SaveAs {
+        snapshot: SessionSnapshot,
+        options: SessionOptions,
+        overwrite: SaveAsOverwrite,
+    },
+    LoadConfigured {
+        options: SessionOptions,
+    },
+    LoadNamedCandidate {
+        options: SessionOptions,
+    },
+    Inspect {
+        options: SessionOptions,
+    },
+    SaveAsOverwritePreflight {
+        current_path: PathBuf,
+        options: SessionOptions,
+    },
+    ValidateNamedOpen {
+        path: PathBuf,
+    },
+    ClearToolState {
+        options: SessionOptions,
+    },
+    HasArtifacts {
+        options: SessionOptions,
+    },
+    RecordNamedOpened {
+        options: SessionOptions,
+    },
+    ForgetNamedSessionByPath {
+        path: PathBuf,
+    },
+    #[cfg(test)]
+    PanicForTest,
+    Shutdown,
+}
+
+impl PersistenceOperation {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Save {
+                strategy: SaveStrategy::Autosave,
+                ..
+            } => "autosave",
+            Self::Save {
+                strategy: SaveStrategy::Normal,
+                ..
+            } => "save",
+            Self::SaveAs { .. } => "save-as",
+            Self::LoadConfigured { .. } => "load-configured",
+            Self::LoadNamedCandidate { .. } => "load-named-candidate",
+            Self::Inspect { .. } => "inspect",
+            Self::SaveAsOverwritePreflight { .. } => "save-as-overwrite-preflight",
+            Self::ValidateNamedOpen { .. } => "validate-named-open",
+            Self::ClearToolState { .. } => "clear-tool-state",
+            Self::HasArtifacts { .. } => "has-artifacts",
+            Self::RecordNamedOpened { .. } => "record-named-opened",
+            Self::ForgetNamedSessionByPath { .. } => "forget-named-session",
+            #[cfg(test)]
+            Self::PanicForTest => "panic-for-test",
+            Self::Shutdown => "shutdown",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct SaveCompletion {
+    pub(in crate::backend::wayland) report: Option<SaveSnapshotReport>,
+    pub(in crate::backend::wayland) committed_board_data: bool,
+}
+
+impl SaveCompletion {
+    pub(in crate::backend::wayland) fn committed(&self) -> bool {
+        self.report.is_some()
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) enum PersistenceOutcome {
+    Save(SaveCompletion),
+    SaveAs {
+        report: SaveSnapshotReport,
+        committed_board_data: bool,
+    },
+    Load(LoadSnapshotOutcome),
+    Inspection(SessionInspection),
+    SaveAsPreflight {
+        same_target: bool,
+        overwrite_required: bool,
+    },
+    ToolStateCleared(ClearToolStateOutcome),
+    HasArtifacts(bool),
+    CatalogForgotten(bool),
+    Unit,
+}
+
+#[derive(Debug)]
+struct PersistenceRequest {
+    id: RequestId,
+    queued_at: Instant,
+    operation: PersistenceOperation,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct PersistenceCompletion {
+    pub(in crate::backend::wayland) id: RequestId,
+    pub(in crate::backend::wayland) result: Result<PersistenceOutcome>,
+    pub(in crate::backend::wayland) queue_wait: Duration,
+    pub(in crate::backend::wayland) execution_time: Duration,
+    pub(in crate::backend::wayland) worker_thread_id: thread::ThreadId,
+    pub(in crate::backend::wayland) finished_at: Instant,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) enum SubmitError {
+    Busy,
+    Full,
+    Disconnected,
+    Unhealthy,
+}
+
+impl std::fmt::Display for SubmitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::Busy => "a persistence operation is already active",
+            Self::Full => "persistence request channel unexpectedly full",
+            Self::Disconnected => "persistence worker disconnected",
+            Self::Unhealthy => "persistence worker is unhealthy",
+        };
+        f.write_str(message)
+    }
+}
+
+impl std::error::Error for SubmitError {}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct SubmitFailure {
+    pub(in crate::backend::wayland) error: SubmitError,
+    pub(in crate::backend::wayland) operation: Box<PersistenceOperation>,
+}
+
+pub(in crate::backend::wayland) struct PersistenceController {
+    request_tx: Option<SyncSender<PersistenceRequest>>,
+    completion_rx: Receiver<PersistenceCompletion>,
+    worker: Option<JoinHandle<()>>,
+    active_id: Option<RequestId>,
+    next_sequence: u64,
+    healthy: bool,
+}
+
+impl PersistenceController {
+    pub(in crate::backend::wayland) fn start() -> Result<Self> {
+        assert_send_static::<SessionSnapshot>();
+        assert_send_static::<LoadSnapshotOutcome>();
+        assert_send_static::<PersistenceOperation>();
+        assert_send_static::<PersistenceOutcome>();
+
+        let (request_tx, request_rx) = mpsc::sync_channel(1);
+        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let worker = thread::Builder::new()
+            .name("wayscriber-persistence".to_string())
+            .spawn(move || worker_main(request_rx, completion_tx))
+            .context("failed to start session persistence worker")?;
+
+        Ok(Self {
+            request_tx: Some(request_tx),
+            completion_rx,
+            worker: Some(worker),
+            active_id: None,
+            next_sequence: 0,
+            healthy: true,
+        })
+    }
+
+    pub(in crate::backend::wayland) fn is_active(&self) -> bool {
+        self.active_id.is_some()
+    }
+
+    pub(in crate::backend::wayland) fn is_healthy(&self) -> bool {
+        self.healthy
+    }
+
+    pub(in crate::backend::wayland) fn is_stopped(&self) -> bool {
+        self.worker.is_none()
+    }
+
+    fn next_id(&mut self, target_epoch: u64) -> RequestId {
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        RequestId {
+            target_epoch,
+            sequence: self.next_sequence,
+        }
+    }
+
+    pub(in crate::backend::wayland) fn try_submit(
+        &mut self,
+        target_epoch: u64,
+        operation: PersistenceOperation,
+    ) -> std::result::Result<RequestId, SubmitFailure> {
+        if !self.healthy {
+            return Err(SubmitFailure {
+                error: SubmitError::Unhealthy,
+                operation: Box::new(operation),
+            });
+        }
+        if self.active_id.is_some() {
+            return Err(SubmitFailure {
+                error: SubmitError::Busy,
+                operation: Box::new(operation),
+            });
+        }
+        let id = self.next_id(target_epoch);
+        let request = PersistenceRequest {
+            id,
+            queued_at: Instant::now(),
+            operation,
+        };
+        let Some(sender) = self.request_tx.as_ref() else {
+            self.healthy = false;
+            return Err(SubmitFailure {
+                error: SubmitError::Disconnected,
+                operation: Box::new(request.operation),
+            });
+        };
+        match sender.try_send(request) {
+            Ok(()) => {
+                self.active_id = Some(id);
+                Ok(id)
+            }
+            Err(TrySendError::Full(request)) => {
+                self.healthy = false;
+                Err(SubmitFailure {
+                    error: SubmitError::Full,
+                    operation: Box::new(request.operation),
+                })
+            }
+            Err(TrySendError::Disconnected(request)) => {
+                self.healthy = false;
+                Err(SubmitFailure {
+                    error: SubmitError::Disconnected,
+                    operation: Box::new(request.operation),
+                })
+            }
+        }
+    }
+
+    pub(in crate::backend::wayland) fn run(
+        &mut self,
+        target_epoch: u64,
+        operation: PersistenceOperation,
+    ) -> Result<PersistenceOutcome> {
+        if self.active_id.is_some() {
+            return Err(anyhow!(SubmitError::Busy));
+        }
+        if !self.healthy {
+            return Err(anyhow!(SubmitError::Unhealthy));
+        }
+        let id = self.next_id(target_epoch);
+        let request = PersistenceRequest {
+            id,
+            queued_at: Instant::now(),
+            operation,
+        };
+        let sender = self
+            .request_tx
+            .as_ref()
+            .ok_or_else(|| anyhow!(SubmitError::Disconnected))?;
+        sender.send(request).map_err(|err| {
+            self.healthy = false;
+            anyhow!("failed to submit persistence operation: {err}")
+        })?;
+        self.active_id = Some(id);
+        let completion = self.receive_active(true)?.ok_or_else(|| {
+            self.healthy = false;
+            anyhow!("persistence worker returned no completion")
+        })?;
+        completion.result
+    }
+
+    pub(in crate::backend::wayland) fn try_receive(
+        &mut self,
+    ) -> Result<Option<PersistenceCompletion>> {
+        self.receive_active(false)
+    }
+
+    pub(in crate::backend::wayland) fn wait_for_completion(
+        &mut self,
+    ) -> Result<Option<PersistenceCompletion>> {
+        self.receive_active(true)
+    }
+
+    fn receive_active(&mut self, block: bool) -> Result<Option<PersistenceCompletion>> {
+        let Some(expected) = self.active_id else {
+            return Ok(None);
+        };
+        let received = if block {
+            Some(self.completion_rx.recv().map_err(|err| {
+                self.healthy = false;
+                self.active_id = None;
+                anyhow!("persistence worker disconnected before completion: {err}")
+            })?)
+        } else {
+            match self.completion_rx.try_recv() {
+                Ok(completion) => Some(completion),
+                Err(TryRecvError::Empty) => None,
+                Err(TryRecvError::Disconnected) => {
+                    self.healthy = false;
+                    self.active_id = None;
+                    return Err(anyhow!(
+                        "persistence worker disconnected before publishing completion"
+                    ));
+                }
+            }
+        };
+        let Some(completion) = received else {
+            return Ok(None);
+        };
+        self.active_id = None;
+        if completion.id != expected {
+            self.healthy = false;
+            return Err(anyhow!(
+                "persistence completion identity mismatch: expected {:?}, received {:?}",
+                expected,
+                completion.id
+            ));
+        }
+        log::debug!(
+            "Persistence completion {:?}: worker={:?}, queue_wait={:?}, execution={:?}, application_delay={:?}",
+            completion.id,
+            completion.worker_thread_id,
+            completion.queue_wait,
+            completion.execution_time,
+            completion.finished_at.elapsed()
+        );
+        Ok(Some(completion))
+    }
+
+    pub(in crate::backend::wayland) fn shutdown(&mut self, target_epoch: u64) -> Result<()> {
+        if self.active_id.is_some() && self.healthy {
+            return Err(anyhow!(
+                "cannot stop persistence worker while a request is active"
+            ));
+        }
+        if self.worker.is_none() {
+            return Ok(());
+        }
+
+        let mut shutdown_error = None;
+        if self.healthy
+            && self.request_tx.is_some()
+            && let Err(err) = self.run(target_epoch, PersistenceOperation::Shutdown)
+        {
+            shutdown_error = Some(err);
+        }
+        self.request_tx.take();
+        let join = self.worker.take().expect("worker presence checked").join();
+        self.active_id = None;
+        if join.is_err() {
+            self.healthy = false;
+            return Err(anyhow!(
+                "session persistence worker panicked during shutdown"
+            ));
+        }
+        if let Some(err) = shutdown_error {
+            return Err(err);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for PersistenceController {
+    fn drop(&mut self) {
+        if self.worker.is_none() {
+            return;
+        }
+        let shutdown_id = (self.active_id.is_none() && self.healthy).then(|| self.next_id(0));
+        if let (Some(id), Some(sender)) = (shutdown_id, self.request_tx.as_ref()) {
+            let _ = sender.try_send(PersistenceRequest {
+                id,
+                queued_at: Instant::now(),
+                operation: PersistenceOperation::Shutdown,
+            });
+        }
+        self.request_tx.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+fn worker_main(
+    request_rx: Receiver<PersistenceRequest>,
+    completion_tx: SyncSender<PersistenceCompletion>,
+) {
+    while let Ok(request) = request_rx.recv() {
+        let PersistenceRequest {
+            id,
+            queued_at,
+            operation,
+        } = request;
+        let queue_wait = queued_at.elapsed();
+        let label = operation.label();
+        let shutdown = matches!(operation, PersistenceOperation::Shutdown);
+        let started = Instant::now();
+        log::debug!("Persistence worker starting {label} request {id:?}");
+        let result = execute(operation);
+        let execution_time = started.elapsed();
+        let worker_thread_id = thread::current().id();
+        let finished_at = Instant::now();
+        if completion_tx
+            .send(PersistenceCompletion {
+                id,
+                result,
+                queue_wait,
+                execution_time,
+                worker_thread_id,
+                finished_at,
+            })
+            .is_err()
+        {
+            break;
+        }
+        if shutdown {
+            break;
+        }
+    }
+}
+
+fn execute(operation: PersistenceOperation) -> Result<PersistenceOutcome> {
+    match operation {
+        PersistenceOperation::Save {
+            snapshot,
+            options,
+            strategy,
+            contentless_clear_boundary,
+        } => {
+            log_snapshot_summary(&snapshot, &options, strategy);
+            let snapshot_board_data = snapshot.has_board_data();
+            let report = match strategy {
+                SaveStrategy::Autosave => {
+                    session::save_snapshot_autosave_with_report_and_clear_boundary(
+                        &snapshot,
+                        &options,
+                        contentless_clear_boundary,
+                    )?
+                }
+                SaveStrategy::Normal => session::save_snapshot_with_report_and_clear_boundary(
+                    &snapshot,
+                    &options,
+                    contentless_clear_boundary,
+                )?,
+            };
+            let committed_board_data = report.as_ref().is_some_and(|report| {
+                !matches!(report.outcome, SaveSnapshotOutcome::ClearedEmpty) && snapshot_board_data
+            });
+            Ok(PersistenceOutcome::Save(SaveCompletion {
+                report,
+                committed_board_data,
+            }))
+        }
+        PersistenceOperation::SaveAs {
+            snapshot,
+            options,
+            overwrite,
+        } => {
+            let snapshot_board_data = snapshot.has_board_data();
+            let report = session::save_snapshot_as_with_report(&snapshot, &options, overwrite)?;
+            let committed_board_data =
+                !matches!(report.outcome, SaveSnapshotOutcome::ClearedEmpty) && snapshot_board_data;
+            session::catalog::record_named_session_saved(&options);
+            Ok(PersistenceOutcome::SaveAs {
+                report,
+                committed_board_data,
+            })
+        }
+        PersistenceOperation::LoadConfigured { options } => Ok(PersistenceOutcome::Load(
+            session::load_snapshot_with_outcome(&options)?,
+        )),
+        PersistenceOperation::LoadNamedCandidate { options } => Ok(PersistenceOutcome::Load(
+            session::load_named_session_candidate(&options)?,
+        )),
+        PersistenceOperation::Inspect { options } => Ok(PersistenceOutcome::Inspection(
+            session::inspect_session(&options)?,
+        )),
+        PersistenceOperation::SaveAsOverwritePreflight {
+            current_path,
+            options,
+        } => {
+            // Validation must run before identity matching: identity canonicalization follows
+            // symlinks, while named foreground targets must reject them.
+            let target_path = options.session_file_path();
+            session::validate_named_session_file_for_foreground(&target_path)?;
+            let (same_target, overwrite_required) =
+                save_as_preflight_after_validation(&current_path, &target_path, || {
+                    session::save_snapshot_as_requires_overwrite(&options)
+                })?;
+            Ok(PersistenceOutcome::SaveAsPreflight {
+                same_target,
+                overwrite_required,
+            })
+        }
+        PersistenceOperation::ValidateNamedOpen { path } => {
+            session::validate_named_session_file_for_open(&path)?;
+            Ok(PersistenceOutcome::Unit)
+        }
+        PersistenceOperation::ClearToolState { options } => Ok(
+            PersistenceOutcome::ToolStateCleared(session::clear_tool_state(&options)?),
+        ),
+        PersistenceOperation::HasArtifacts { options } => Ok(PersistenceOutcome::HasArtifacts(
+            super::has_session_artifact(&options),
+        )),
+        PersistenceOperation::RecordNamedOpened { options } => {
+            session::catalog::record_named_session_opened(&options);
+            Ok(PersistenceOutcome::Unit)
+        }
+        PersistenceOperation::ForgetNamedSessionByPath { path } => Ok(
+            PersistenceOutcome::CatalogForgotten(session::catalog::forget_session_by_path(&path)?),
+        ),
+        #[cfg(test)]
+        PersistenceOperation::PanicForTest => {
+            panic!("intentional persistence worker panic for disconnect testing")
+        }
+        PersistenceOperation::Shutdown => Ok(PersistenceOutcome::Unit),
+    }
+}
+
+fn save_as_preflight_after_validation(
+    current_path: &Path,
+    target_path: &Path,
+    discover_overwrite: impl FnOnce() -> Result<bool>,
+) -> Result<(bool, bool)> {
+    let same_target = session::catalog::session_paths_match(current_path, target_path);
+    if same_target {
+        return Ok((true, false));
+    }
+    Ok((false, discover_overwrite()?))
+}
+
+fn assert_send_static<T: Send + 'static>() {}
+
+fn log_snapshot_summary(
+    snapshot: &SessionSnapshot,
+    options: &SessionOptions,
+    strategy: SaveStrategy,
+) {
+    let mut boards = 0usize;
+    let mut pages = 0usize;
+    let mut shapes = 0usize;
+    let mut undo_entries = 0usize;
+    let mut redo_entries = 0usize;
+    let mut visible_image_shapes = 0usize;
+    let mut visible_image_bytes = 0usize;
+    let mut max_history_depth = 0usize;
+    for board in &snapshot.boards {
+        boards += 1;
+        pages += board.pages.pages.len();
+        for frame in &board.pages.pages {
+            let undo = frame.undo_stack_len();
+            let redo = frame.redo_stack_len();
+            shapes += frame.shapes.len();
+            undo_entries += undo;
+            redo_entries += redo;
+            max_history_depth = max_history_depth.max(undo.max(redo));
+            for drawn in &frame.shapes {
+                if let crate::draw::Shape::Image { data, .. } = &drawn.shape {
+                    visible_image_shapes += 1;
+                    visible_image_bytes = visible_image_bytes.saturating_add(data.bytes.len());
+                }
+            }
+        }
+    }
+    log::info!(
+        "Persistence worker snapshot diagnostics for {} ({strategy:?}): boards={boards}, pages={pages}, shapes={shapes}, undo_entries={undo_entries}, redo_entries={redo_entries}, max_history_depth={max_history_depth}, visible_images={visible_image_shapes} ({visible_image_bytes} bytes), tool_state={}",
+        options.session_file_path().display(),
+        snapshot.tool_state.is_some()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_and_completion_payloads_are_send_and_static() {
+        assert_send_static::<PersistenceOperation>();
+        assert_send_static::<PersistenceOutcome>();
+        assert_send_static::<PersistenceCompletion>();
+    }
+
+    fn test_options(base_dir: PathBuf) -> SessionOptions {
+        let mut options = SessionOptions::new(base_dir, "worker-test");
+        options.persist_transparent = true;
+        options.persist_whiteboard = false;
+        options.persist_blackboard = false;
+        options.persist_history = false;
+        options.restore_tool_state = false;
+        options
+    }
+
+    #[test]
+    fn real_worker_executes_production_operation_off_caller_thread() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let options = test_options(temp.path().to_path_buf());
+        let mut controller = PersistenceController::start().unwrap();
+        controller
+            .try_submit(7, PersistenceOperation::HasArtifacts { options })
+            .unwrap();
+        let completion = controller
+            .wait_for_completion()
+            .unwrap()
+            .expect("worker completion");
+        assert_ne!(completion.worker_thread_id, thread::current().id());
+        assert!(matches!(
+            completion.result.unwrap(),
+            PersistenceOutcome::HasArtifacts(false)
+        ));
+        controller.shutdown(7).unwrap();
+    }
+
+    #[test]
+    fn real_worker_uses_existing_save_pipeline_and_reports_committed_state() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let options = test_options(temp.path().to_path_buf());
+        let snapshot = SessionSnapshot {
+            active_board_id: "transparent".to_string(),
+            boards: Vec::new(),
+            tool_state: None,
+        };
+        let mut controller = PersistenceController::start().unwrap();
+        let outcome = controller
+            .run(
+                0,
+                PersistenceOperation::Save {
+                    snapshot,
+                    options: options.clone(),
+                    strategy: SaveStrategy::Normal,
+                    contentless_clear_boundary: true,
+                },
+            )
+            .unwrap();
+        let PersistenceOutcome::Save(save) = outcome else {
+            panic!("unexpected worker outcome");
+        };
+        assert!(save.committed());
+        assert!(!save.committed_board_data);
+        assert!(matches!(
+            save.report.unwrap().outcome,
+            SaveSnapshotOutcome::ClearedEmpty
+        ));
+        assert!(matches!(
+            controller
+                .run(0, PersistenceOperation::LoadConfigured { options })
+                .unwrap(),
+            PersistenceOutcome::Load(LoadSnapshotOutcome::Empty)
+        ));
+        controller.shutdown(0).unwrap();
+    }
+
+    #[test]
+    fn production_error_does_not_kill_worker() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let missing = temp.path().join("missing.wayscriber-session");
+        let options = test_options(temp.path().to_path_buf());
+        let mut controller = PersistenceController::start().unwrap();
+        assert!(
+            controller
+                .run(0, PersistenceOperation::ValidateNamedOpen { path: missing })
+                .is_err()
+        );
+        assert!(controller.is_healthy());
+        assert!(matches!(
+            controller
+                .run(0, PersistenceOperation::HasArtifacts { options })
+                .unwrap(),
+            PersistenceOutcome::HasArtifacts(false)
+        ));
+        controller.shutdown(0).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_autosave_can_be_followed_by_normal_save_on_same_worker() {
+        use std::os::unix::fs::symlink;
+
+        let temp = crate::test_temp::tempdir().unwrap();
+        let target = temp.path().join("autosave-target.wayscriber-session");
+        let alias = temp.path().join("autosave-alias.wayscriber-session");
+        std::fs::write(&target, b"{}").unwrap();
+        symlink(&target, &alias).unwrap();
+        let mut invalid_options = test_options(temp.path().to_path_buf());
+        invalid_options.set_named_file_target(alias);
+        let valid_options = test_options(temp.path().join("valid"));
+        let snapshot = SessionSnapshot {
+            active_board_id: "transparent".to_string(),
+            boards: Vec::new(),
+            tool_state: None,
+        };
+        let mut controller = PersistenceController::start().unwrap();
+
+        assert!(
+            controller
+                .run(
+                    0,
+                    PersistenceOperation::Save {
+                        snapshot: snapshot.clone(),
+                        options: invalid_options,
+                        strategy: SaveStrategy::Autosave,
+                        contentless_clear_boundary: true,
+                    },
+                )
+                .is_err()
+        );
+        assert!(controller.is_healthy());
+        let outcome = controller
+            .run(
+                0,
+                PersistenceOperation::Save {
+                    snapshot,
+                    options: valid_options,
+                    strategy: SaveStrategy::Normal,
+                    contentless_clear_boundary: true,
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            PersistenceOutcome::Save(ref save) if save.committed()
+        ));
+        controller.shutdown(0).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_as_preflight_rejects_same_target_symlink_before_identity_matching() {
+        use std::os::unix::fs::symlink;
+
+        let temp = crate::test_temp::tempdir().unwrap();
+        let current_path = temp.path().join("current.wayscriber-session");
+        let alias_path = temp.path().join("current-alias.wayscriber-session");
+        std::fs::write(&current_path, b"{}").unwrap();
+        symlink(&current_path, &alias_path).unwrap();
+
+        let mut options = test_options(temp.path().to_path_buf());
+        options.set_named_file_target(alias_path);
+        let mut controller = PersistenceController::start().unwrap();
+        let err = controller
+            .run(
+                0,
+                PersistenceOperation::SaveAsOverwritePreflight {
+                    current_path,
+                    options,
+                },
+            )
+            .expect_err("symlink alias must fail validation before matching the current target");
+
+        assert!(format!("{err:#}").contains("symlink"));
+        assert!(controller.is_healthy());
+        controller.shutdown(0).unwrap();
+    }
+
+    #[test]
+    fn save_as_preflight_reports_regular_current_target_after_validation() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let current_path = temp.path().join("current.wayscriber-session");
+        std::fs::write(&current_path, b"{}").unwrap();
+        let mut options = test_options(temp.path().to_path_buf());
+        options.set_named_file_target(current_path.clone());
+        let mut controller = PersistenceController::start().unwrap();
+
+        let outcome = controller
+            .run(
+                0,
+                PersistenceOperation::SaveAsOverwritePreflight {
+                    current_path,
+                    options,
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            PersistenceOutcome::SaveAsPreflight {
+                same_target: true,
+                overwrite_required: false
+            }
+        ));
+        controller.shutdown(0).unwrap();
+    }
+
+    #[test]
+    fn same_target_preflight_skips_overwrite_discovery() {
+        let current_path = Path::new("/tmp/current.wayscriber-session");
+        let mut discovery_called = false;
+
+        let result = save_as_preflight_after_validation(current_path, current_path, || {
+            discovery_called = true;
+            Ok(true)
+        })
+        .unwrap();
+
+        assert_eq!(result, (true, false));
+        assert!(!discovery_called);
+    }
+
+    #[test]
+    fn different_target_preflight_runs_overwrite_discovery() {
+        let current_path = Path::new("/tmp/current.wayscriber-session");
+        let target_path = Path::new("/tmp/target.wayscriber-session");
+        let mut discovery_called = false;
+
+        let result = save_as_preflight_after_validation(current_path, target_path, || {
+            discovery_called = true;
+            Ok(true)
+        })
+        .unwrap();
+
+        assert_eq!(result, (false, true));
+        assert!(discovery_called);
+    }
+
+    #[test]
+    fn full_try_submit_returns_owned_operation_without_installing_ticket() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let options = test_options(temp.path().to_path_buf());
+        let (request_tx, request_rx) = mpsc::sync_channel(1);
+        request_tx
+            .send(PersistenceRequest {
+                id: RequestId {
+                    target_epoch: 0,
+                    sequence: 99,
+                },
+                queued_at: Instant::now(),
+                operation: PersistenceOperation::Shutdown,
+            })
+            .unwrap();
+        let (_completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let mut controller = PersistenceController {
+            request_tx: Some(request_tx),
+            completion_rx,
+            worker: None,
+            active_id: None,
+            next_sequence: 0,
+            healthy: true,
+        };
+
+        let result = controller.try_submit(
+            0,
+            PersistenceOperation::HasArtifacts {
+                options: options.clone(),
+            },
+        );
+        let failure = result.expect_err("full request channel must reject submission");
+        assert!(matches!(failure.error, SubmitError::Full));
+        assert!(matches!(
+            *failure.operation,
+            PersistenceOperation::HasArtifacts { .. }
+        ));
+        assert!(controller.active_id.is_none());
+        assert!(!controller.is_healthy());
+        drop(request_rx);
+    }
+
+    #[test]
+    fn disconnected_try_submit_returns_owned_operation_without_installing_ticket() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let options = test_options(temp.path().to_path_buf());
+        let (request_tx, request_rx) = mpsc::sync_channel(1);
+        drop(request_rx);
+        let (_completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let mut controller = PersistenceController {
+            request_tx: Some(request_tx),
+            completion_rx,
+            worker: None,
+            active_id: None,
+            next_sequence: 0,
+            healthy: true,
+        };
+
+        let result = controller.try_submit(0, PersistenceOperation::HasArtifacts { options });
+        let failure = result.expect_err("disconnected channel must reject submission");
+        assert!(matches!(failure.error, SubmitError::Disconnected));
+        assert!(matches!(
+            *failure.operation,
+            PersistenceOperation::HasArtifacts { .. }
+        ));
+        assert!(controller.active_id.is_none());
+        assert!(!controller.is_healthy());
+    }
+}

--- a/src/backend/wayland/session/tests.rs
+++ b/src/backend/wayland/session/tests.rs
@@ -1817,3 +1817,108 @@ fn contentless_save_guard_allows_noop_when_no_session_artifact_exists() {
         false, false, false, false, false,
     ));
 }
+
+#[test]
+fn autosave_completion_does_not_clear_newer_generation() {
+    let mut options = SessionOptions::new(PathBuf::from("/tmp"), "generation-test");
+    options.persist_transparent = true;
+    options.autosave_enabled = true;
+    options.autosave_idle = Duration::from_millis(1);
+    options.autosave_interval = Duration::from_millis(1);
+    let mut state = SessionState::new(Some(options.clone()));
+    let started = Instant::now();
+    state.record_input_dirty(started, true);
+    let request_id = RequestId {
+        target_epoch: state.target_epoch(),
+        sequence: 1,
+    };
+    let window = state.prepare_autosave_submission().unwrap();
+    state.commit_autosave_submission(request_id, window);
+
+    let newer_edit = started + Duration::from_millis(2);
+    state.record_input_dirty(newer_edit, true);
+    let result = Ok(SaveCompletion {
+        report: Some(crate::session::SaveSnapshotReport {
+            path: PathBuf::from("/tmp/generation-test.json"),
+            outcome: crate::session::SaveSnapshotOutcome::Full,
+            raw_size: 1,
+            written_size: 1,
+            max_file_size_bytes: 1024,
+            compressed: false,
+        }),
+        committed_board_data: false,
+    });
+    assert!(
+        state
+            .complete_autosave(request_id, newer_edit, &result)
+            .unwrap()
+    );
+    assert!(state.is_dirty());
+    assert!(state.autosave_due(newer_edit + Duration::from_millis(2), &options));
+}
+
+#[test]
+fn failed_autosave_restores_original_dirty_window() {
+    let mut options = SessionOptions::new(PathBuf::from("/tmp"), "failure-window");
+    options.persist_transparent = true;
+    options.autosave_enabled = true;
+    options.autosave_idle = Duration::from_millis(1);
+    options.autosave_interval = Duration::from_millis(1);
+    let mut state = SessionState::new(Some(options.clone()));
+    let started = Instant::now();
+    state.record_input_dirty(started, true);
+    let request_id = RequestId {
+        target_epoch: state.target_epoch(),
+        sequence: 2,
+    };
+    let window = state.prepare_autosave_submission().unwrap();
+    state.commit_autosave_submission(request_id, window);
+    let result = Err(anyhow!("expected test failure"));
+    assert!(
+        !state
+            .complete_autosave(request_id, started, &result)
+            .unwrap()
+    );
+    assert!(state.is_dirty());
+    assert!(state.autosave_due(started + Duration::from_millis(2), &options));
+}
+
+#[test]
+fn target_commit_invalidates_pending_output_transition_epoch() {
+    let options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+    let mut staged = options.clone();
+    staged.set_output_identity(Some("target-output"));
+    let mut state = SessionState::new(Some(options));
+    state.stage_output_transition(
+        staged.clone(),
+        Some("target-output".to_string()),
+        Instant::now(),
+    );
+    assert_eq!(
+        state
+            .pending_output_transition()
+            .expect("pending transition")
+            .source_epoch,
+        0
+    );
+
+    state.commit_runtime_open(staged, false);
+
+    assert_eq!(state.target_epoch(), 1);
+    assert!(state.pending_output_transition().is_none());
+}
+
+#[test]
+fn output_transition_deferral_moves_deadline_forward() {
+    let options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+    let mut staged = options.clone();
+    staged.set_output_identity(Some("target-output"));
+    let mut state = SessionState::new(Some(options));
+    let now = Instant::now();
+    state.stage_output_transition(staged, Some("target-output".to_string()), now);
+    state.defer_output_transition(now, Duration::from_millis(500));
+    assert_eq!(
+        state.output_transition_timeout(now),
+        Some(Duration::from_millis(500))
+    );
+}

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -141,6 +141,7 @@ pub(in crate::backend::wayland) struct WaylandStateInit {
     pub onboarding: crate::onboarding::OnboardingStore,
     pub capture_manager: CaptureManager,
     pub session_options: Option<SessionOptions>,
+    pub persistence: crate::backend::wayland::session::PersistenceController,
     pub tokio_handle: tokio::runtime::Handle,
     pub exit_after_capture_mode: ExitAfterCaptureMode,
     pub frozen_enabled: bool,
@@ -267,6 +268,7 @@ pub(super) struct WaylandState {
 
     // Session persistence
     pub(super) session: SessionState,
+    pub(super) persistence: crate::backend::wayland::session::PersistenceController,
 
     // Tokio runtime handle for async operations
     pub(super) tokio_handle: tokio::runtime::Handle,

--- a/src/backend/wayland/state/core/accessors.rs
+++ b/src/backend/wayland/state/core/accessors.rs
@@ -176,6 +176,7 @@ impl WaylandState {
         self.data.pending_freeze_on_start = value;
     }
 
+    #[allow(dead_code)]
     pub(in crate::backend::wayland) fn has_seen_surface_enter(&self) -> bool {
         self.data.has_seen_surface_enter
     }
@@ -325,6 +326,7 @@ impl WaylandState {
         self.session.options()
     }
 
+    #[allow(dead_code)]
     pub(in crate::backend::wayland) fn session_options_mut(
         &mut self,
     ) -> Option<&mut SessionOptions> {

--- a/src/backend/wayland/state/core/init.rs
+++ b/src/backend/wayland/state/core/init.rs
@@ -11,6 +11,7 @@ impl WaylandState {
             onboarding,
             capture_manager,
             session_options,
+            persistence,
             tokio_handle,
             exit_after_capture_mode,
             frozen_enabled,
@@ -168,6 +169,7 @@ impl WaylandState {
             #[cfg(tablet)]
             stylus_pre_eraser_tool_override: None,
             session: SessionState::new(session_options),
+            persistence,
             tokio_handle,
         }
     }

--- a/src/backend/wayland/state/core/output.rs
+++ b/src/backend/wayland/state/core/output.rs
@@ -1,16 +1,70 @@
 use log::{debug, info, warn};
 use smithay_client_toolkit::shell::{WaylandSurface, wlr_layer::Anchor};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use super::super::*;
 use crate::{
-    backend::wayland::session as runtime_session,
+    backend::wayland::{
+        backend::event_loop::session_save,
+        session::{
+            self as runtime_session, PersistenceOperation, PersistenceOutcome, SaveStrategy,
+        },
+    },
     input::state::{OutputFocusAction, UiToastKind},
     notification,
     session::{self, SessionSnapshot},
 };
 
 const OUTPUT_BADGE_MAX_LEN: usize = 28;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputTransitionStart {
+    IgnoreCurrentTarget,
+    KeepPending,
+    DeferForInteraction,
+    LoadInitial,
+    ResolveTransition,
+}
+
+fn output_transition_start(
+    loaded: bool,
+    target_changed: bool,
+    matching_pending: bool,
+    same_epoch_pending: bool,
+    live_source_resolution_pending: bool,
+    interaction_active: bool,
+) -> OutputTransitionStart {
+    let superseding_pending_destination = same_epoch_pending && !matching_pending;
+    if !target_changed
+        && (loaded || superseding_pending_destination || live_source_resolution_pending)
+    {
+        OutputTransitionStart::IgnoreCurrentTarget
+    } else if matching_pending {
+        OutputTransitionStart::KeepPending
+    } else if interaction_active {
+        OutputTransitionStart::DeferForInteraction
+    } else if loaded || same_epoch_pending {
+        OutputTransitionStart::ResolveTransition
+    } else {
+        OutputTransitionStart::LoadInitial
+    }
+}
+
+fn output_transition_retry_at(backoff: Duration) -> Instant {
+    Instant::now() + backoff
+}
+
+fn live_source_reconciliation_ready(
+    live_source_resolution_pending: bool,
+    output_transition_pending: bool,
+    interaction_active: bool,
+    worker_healthy: bool,
+) -> bool {
+    live_source_resolution_pending
+        && !output_transition_pending
+        && !interaction_active
+        && worker_healthy
+}
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn preferred_fullscreen_output(
@@ -114,131 +168,372 @@ impl WaylandState {
         }
     }
 
-    pub(in crate::backend::wayland) fn persist_session_for_output(
+    pub(in crate::backend::wayland) fn begin_session_output_transition(
         &mut self,
-        output: Option<&wl_output::WlOutput>,
+        physical_output_identity: Option<String>,
         reason: &str,
     ) {
-        let output_identity =
-            output.and_then(|surface_output| self.output_identity_for(surface_output));
-        let Some(mut save_options) = self.session_options().cloned() else {
+        let Some(current_options) = self.session_options().cloned() else {
             return;
         };
-        save_options.set_output_identity(output_identity.as_deref());
+        let mut staged_options = current_options.clone();
+        let changed = staged_options.set_output_identity(physical_output_identity.as_deref());
+        let same_epoch_pending = self
+            .session
+            .pending_output_transition()
+            .is_some_and(|pending| pending.source_epoch == self.session.target_epoch());
+        let matching_pending = same_epoch_pending
+            && self
+                .session
+                .pending_output_transition()
+                .is_some_and(|pending| {
+                    pending.physical_output_identity == physical_output_identity
+                });
+        let interaction_active = session_save::should_defer_for_interaction(self);
+        let input_dirty = self.input_state.is_session_dirty();
+        let live_source_resolution_pending = self
+            .session
+            .resolve_live_source_resolution(input_dirty, interaction_active);
+        let start = output_transition_start(
+            self.session.is_loaded(),
+            changed,
+            matching_pending,
+            same_epoch_pending,
+            live_source_resolution_pending,
+            interaction_active,
+        );
 
-        if self.should_skip_protected_session_save(&save_options) {
-            return;
-        }
-
-        let snapshot = session::snapshot_from_input(&self.input_state, &save_options);
-        if self.should_skip_unloaded_contentless_session_save(&save_options, snapshot.as_ref()) {
-            return;
-        }
-
-        let contentless_clear_boundary = self.session.has_loaded_board_data();
-        let saved_board_data = snapshot
-            .as_ref()
-            .is_some_and(session::SessionSnapshot::has_board_data);
-        let save_result = if let Some(snapshot) = snapshot {
-            session::save_snapshot_with_report_and_clear_boundary(
-                &snapshot,
-                &save_options,
-                contentless_clear_boundary,
-            )
-            .map(|report| report.is_some())
-        } else if Self::session_persistence_enabled(&save_options) {
-            let empty_snapshot = SessionSnapshot {
-                active_board_id: self.input_state.board_id().to_string(),
-                boards: Vec::new(),
-                tool_state: None,
-            };
-            session::save_snapshot_with_report_and_clear_boundary(
-                &empty_snapshot,
-                &save_options,
-                contentless_clear_boundary,
-            )
-            .map(|report| report.is_some())
-        } else {
-            Ok(false)
-        };
-
-        match save_result {
-            Ok(saved) => {
-                if !saved {
-                    return;
+        let retry_at = Instant::now() + session_save::interaction_defer_interval();
+        match start {
+            OutputTransitionStart::IgnoreCurrentTarget => {
+                if self
+                    .session
+                    .cancel_output_transition_for_live_source(input_dirty)
+                    .is_some()
+                {
+                    log::info!(
+                        "Canceling pending output transition because the physical output matches the active logical target"
+                    );
                 }
-                if let Some(runtime_options) = self.session_options_mut() {
-                    runtime_options.set_output_identity(output_identity.as_deref());
-                }
-                let _ = self.input_state.take_session_dirty();
-                self.session.mark_saved(Instant::now(), saved_board_data);
-                info!(
-                    "Persisted session before {} (output_identity={:?})",
-                    reason,
-                    output_identity.as_deref()
+            }
+            OutputTransitionStart::KeepPending => {
+                log::debug!(
+                    "Keeping existing pending output transition for physical output {:?}",
+                    physical_output_identity
                 );
             }
-            Err(err) => warn!(
-                "Failed to persist session before {} (output_identity={:?}): {}",
-                reason,
-                output_identity.as_deref(),
-                err
-            ),
+            OutputTransitionStart::DeferForInteraction => {
+                self.session.stage_output_transition(
+                    staged_options,
+                    physical_output_identity,
+                    retry_at,
+                );
+                self.notify_output_transition_deferred();
+            }
+            OutputTransitionStart::LoadInitial => {
+                if let Err(err) = self.load_configured_session_for_options(
+                    staged_options.clone(),
+                    "initial output load",
+                ) {
+                    warn!("Failed to load initial output session: {err:#}");
+                    self.session.stage_output_transition(
+                        staged_options,
+                        physical_output_identity,
+                        output_transition_retry_at(self.output_transition_failure_backoff()),
+                    );
+                    self.notify_output_transition_deferred();
+                }
+            }
+            OutputTransitionStart::ResolveTransition => {
+                if let Err(err) = self.run_output_transition(
+                    staged_options.clone(),
+                    physical_output_identity.clone(),
+                    reason,
+                ) {
+                    warn!("Failed to complete session transition for {reason}: {err:#}");
+                    let retry_at =
+                        output_transition_retry_at(self.output_transition_failure_backoff());
+                    self.session.stage_output_transition(
+                        staged_options,
+                        physical_output_identity,
+                        retry_at,
+                    );
+                    self.notify_output_transition_deferred();
+                }
+            }
         }
     }
 
-    pub(in crate::backend::wayland) fn handle_session_load_outcome(
+    pub(in crate::backend::wayland) fn retry_pending_output_transition_if_due(
+        &mut self,
+        now: Instant,
+    ) -> anyhow::Result<bool> {
+        let Some(pending) = self.session.pending_output_transition() else {
+            return Ok(false);
+        };
+        if now < pending.retry_at {
+            return Ok(false);
+        }
+        if pending.source_epoch != self.session.target_epoch() {
+            warn!(
+                "Discarding stale output transition owned by epoch {} while active epoch is {}",
+                pending.source_epoch,
+                self.session.target_epoch()
+            );
+            self.session.cancel_pending_output_transition();
+            return Ok(true);
+        }
+        if session_save::should_defer_for_interaction(self) {
+            self.session
+                .defer_output_transition(now, session_save::interaction_defer_interval());
+            log::debug!("Deferring pending output transition while interaction is active");
+            return Ok(true);
+        }
+
+        let pending = self
+            .session
+            .take_pending_output_transition()
+            .expect("pending transition checked above");
+        if let Err(err) = self.run_output_transition(
+            pending.staged_options.clone(),
+            pending.physical_output_identity.clone(),
+            "deferred output transition",
+        ) {
+            let retry_at = output_transition_retry_at(self.output_transition_failure_backoff());
+            self.session.stage_output_transition(
+                pending.staged_options,
+                pending.physical_output_identity,
+                retry_at,
+            );
+            return Err(err);
+        }
+        Ok(true)
+    }
+
+    pub(in crate::backend::wayland) fn begin_configure_fallback_session_transition(
+        &mut self,
+        reason: &str,
+    ) {
+        if self.session.is_loaded() {
+            return;
+        }
+        let physical_output_identity = self
+            .surface
+            .current_output()
+            .as_ref()
+            .and_then(|output| self.output_identity_for(output));
+        self.begin_session_output_transition(physical_output_identity, reason);
+        self.input_state.needs_redraw = true;
+    }
+
+    /// Resolves a canceled return-to-source transition as soon as the interaction
+    /// that protected it becomes idle. This is called after protocol dispatch and
+    /// from the persistence tick, so a clean initial load does not depend on another
+    /// compositor configure event.
+    pub(in crate::backend::wayland) fn reconcile_live_source_interaction_if_idle(
+        &mut self,
+        reason: &str,
+    ) -> bool {
+        if !self.session.has_pending_live_source_resolution() {
+            return false;
+        }
+        if self.session.is_loaded() {
+            let _ = self.session.resolve_live_source_resolution(false, false);
+            return false;
+        }
+        let interaction_active = session_save::should_defer_for_interaction(self);
+        if !live_source_reconciliation_ready(
+            true,
+            self.session.pending_output_transition().is_some(),
+            interaction_active,
+            self.persistence.is_healthy(),
+        ) {
+            return false;
+        }
+
+        log::info!(
+            "Resolving live source after output-transition cancellation ({reason}, epoch={})",
+            self.session.target_epoch()
+        );
+        self.begin_configure_fallback_session_transition(reason);
+        true
+    }
+
+    fn run_output_transition(
+        &mut self,
+        staged_options: session::SessionOptions,
+        physical_output_identity: Option<String>,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        if session_save::should_defer_for_interaction(self) {
+            return Err(anyhow::anyhow!(
+                "output transition became ineligible because an interaction started"
+            ));
+        }
+        if let Some(pending) = self.session.pending_output_transition()
+            && pending.source_epoch != self.session.target_epoch()
+        {
+            return Err(anyhow::anyhow!("stale output transition source epoch"));
+        }
+        session_save::persistence_barrier(self)?;
+        let current_options = self
+            .session_options()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("output transition has no active session options"))?;
+        self.persist_current_session_for_transition(&current_options, reason)?;
+
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::LoadConfigured {
+                options: staged_options.clone(),
+            },
+        )?;
+        let PersistenceOutcome::Load(load_outcome) = outcome else {
+            return Err(anyhow::anyhow!("unexpected output-load worker outcome"));
+        };
+        let loaded_board_data = load_outcome.has_board_data();
+        self.handle_session_load_outcome_for_options(load_outcome, &staged_options, "output load");
+        self.session
+            .commit_output_options(staged_options, loaded_board_data);
+        info!(
+            "Committed logical session output transition after {} (physical_output_identity={:?}, epoch={})",
+            reason,
+            physical_output_identity,
+            self.session.target_epoch()
+        );
+        Ok(())
+    }
+
+    fn persist_current_session_for_transition(
+        &mut self,
+        options: &session::SessionOptions,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        if self.should_skip_protected_session_save(options) {
+            return Ok(());
+        }
+        let snapshot = session::snapshot_from_input(&self.input_state, options);
+        if self.should_skip_unloaded_contentless_session_save(options, snapshot.as_ref())? {
+            return Ok(());
+        }
+        let snapshot = if let Some(snapshot) = snapshot {
+            snapshot
+        } else if Self::session_persistence_enabled(options) {
+            SessionSnapshot {
+                active_board_id: self.input_state.board_id().to_string(),
+                boards: Vec::new(),
+                tool_state: None,
+            }
+        } else {
+            return Ok(());
+        };
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::Save {
+                snapshot,
+                options: options.clone(),
+                strategy: SaveStrategy::Normal,
+                contentless_clear_boundary: self.session.has_loaded_board_data(),
+            },
+        )?;
+        let PersistenceOutcome::Save(save) = outcome else {
+            return Err(anyhow::anyhow!("unexpected output-save worker outcome"));
+        };
+        if !save.committed() {
+            return Err(anyhow::anyhow!(
+                "required session save before {reason} produced no committed write"
+            ));
+        }
+        self.session
+            .mark_saved(Instant::now(), save.committed_board_data);
+        info!("Persisted active logical target before {reason}");
+        Ok(())
+    }
+
+    pub(in crate::backend::wayland) fn load_configured_session_for_options(
+        &mut self,
+        options: session::SessionOptions,
+        context: &str,
+    ) -> anyhow::Result<()> {
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::LoadConfigured {
+                options: options.clone(),
+            },
+        )?;
+        let PersistenceOutcome::Load(load_outcome) = outcome else {
+            return Err(anyhow::anyhow!("unexpected configured-load worker outcome"));
+        };
+        let loaded_board_data = load_outcome.has_board_data();
+        self.handle_session_load_outcome_for_options(load_outcome, &options, context);
+        self.session
+            .commit_output_options(options, loaded_board_data);
+        Ok(())
+    }
+
+    fn notify_output_transition_deferred(&mut self) {
+        if !self.session.mark_output_transition_notified() {
+            return;
+        }
+        self.input_state.set_ui_toast(
+            UiToastKind::Warning,
+            "Session switch deferred until the active drawing is committed and the current session is saved.",
+        );
+        self.input_state.needs_redraw = true;
+    }
+
+    fn output_transition_failure_backoff(&self) -> Duration {
+        self.session_options()
+            .map_or(Duration::from_secs(1), |options| {
+                options.autosave_failure_backoff
+            })
+    }
+
+    fn handle_session_load_outcome_for_options(
         &mut self,
         outcome: session::LoadSnapshotOutcome,
+        options: &session::SessionOptions,
         context: &str,
     ) {
         match outcome {
             session::LoadSnapshotOutcome::Loaded(snapshot) => {
-                if let Some(options) = self.session_options().cloned() {
-                    debug!(
-                        "Restoring session {} from {}",
-                        context,
-                        options.session_file_path().display()
-                    );
-                    session::apply_snapshot(&mut self.input_state, *snapshot, &options);
-                }
+                debug!(
+                    "Restoring session {} from {}",
+                    context,
+                    options.session_file_path().display()
+                );
+                session::apply_snapshot(&mut self.input_state, *snapshot, options);
             }
             session::LoadSnapshotOutcome::LoadedFromBackup(snapshot) => {
-                if let Some(options) = self.session_options().cloned() {
-                    warn!(
-                        "Restoring session {} from backup {} because the primary session had no board data",
-                        context,
-                        options.backup_file_path().display()
-                    );
-                    session::apply_snapshot(&mut self.input_state, *snapshot, &options);
-                    self.input_state.set_ui_toast(
-                        UiToastKind::Warning,
-                        "Restored drawings from the session backup; the primary session had no board data.",
-                    );
-                }
+                warn!(
+                    "Restoring session {} from backup {} because the primary session had no board data",
+                    context,
+                    options.backup_file_path().display()
+                );
+                session::apply_snapshot(&mut self.input_state, *snapshot, options);
+                self.input_state.set_ui_toast(
+                    UiToastKind::Warning,
+                    "Restored drawings from the session backup; the primary session had no board data.",
+                );
             }
             session::LoadSnapshotOutcome::LoadedFromRecovery(snapshot) => {
-                if let Some(options) = self.session_options().cloned() {
-                    debug!(
-                        "Restoring session {} from recovery artifact {}",
-                        context,
-                        options.recovery_file_path().display()
-                    );
-                    session::apply_snapshot(&mut self.input_state, *snapshot, &options);
-                    self.input_state.set_ui_toast(
-                        UiToastKind::Warning,
-                        "Restored session from recovery file; normal save previously exceeded the size limit.",
-                    );
-                }
+                debug!(
+                    "Restoring session {} from recovery artifact {}",
+                    context,
+                    options.recovery_file_path().display()
+                );
+                session::apply_snapshot(&mut self.input_state, *snapshot, options);
+                self.input_state.set_ui_toast(
+                    UiToastKind::Warning,
+                    "Restored session from recovery file; normal save previously exceeded the size limit.",
+                );
             }
             session::LoadSnapshotOutcome::Empty => {
-                if let Some(options) = self.session_options() {
-                    debug!(
-                        "No session data found for {} ({})",
-                        options.session_file_path().display(),
-                        context
-                    );
-                }
+                debug!(
+                    "No session data found for {} ({})",
+                    options.session_file_path().display(),
+                    context
+                );
             }
             session::LoadSnapshotOutcome::NonRegularArtifact { path } => {
                 debug!(
@@ -290,16 +585,33 @@ impl WaylandState {
     }
 
     fn should_skip_unloaded_contentless_session_save(
-        &self,
+        &mut self,
         options: &session::SessionOptions,
         snapshot: Option<&SessionSnapshot>,
-    ) -> bool {
+    ) -> anyhow::Result<bool> {
+        let has_board_data = snapshot.is_some_and(SessionSnapshot::has_board_data);
+        if has_board_data
+            || self.session.has_loaded_board_data()
+            || self.session.is_dirty()
+            || self.input_state.is_session_dirty()
+        {
+            return Ok(false);
+        }
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::HasArtifacts {
+                options: options.clone(),
+            },
+        )?;
+        let PersistenceOutcome::HasArtifacts(has_artifacts) = outcome else {
+            return Err(anyhow::anyhow!("unexpected artifact-inspection outcome"));
+        };
         let skip = runtime_session::should_skip_unloaded_contentless_save(
             self.session.has_loaded_board_data(),
             self.session.is_dirty(),
             self.input_state.is_session_dirty(),
-            snapshot.is_some_and(SessionSnapshot::has_board_data),
-            runtime_session::has_session_artifact(options),
+            has_board_data,
+            has_artifacts,
         );
         if skip {
             info!(
@@ -307,7 +619,7 @@ impl WaylandState {
                 options.session_file_path().display()
             );
         }
-        skip
+        Ok(skip)
     }
 
     fn session_persistence_enabled(options: &session::SessionOptions) -> bool {
@@ -371,10 +683,7 @@ impl WaylandState {
         let target_label = self
             .output_badge_label_for(&target_output)
             .unwrap_or_else(|| format!("Output {}", target_index + 1));
-
-        if self.has_seen_surface_enter() {
-            self.persist_session_for_output(surface_current_output.as_ref(), "output switch");
-        }
+        let target_identity = self.output_identity_for(&target_output);
 
         if self.surface.is_xdg_window() {
             if !self.xdg_fullscreen() {
@@ -395,6 +704,7 @@ impl WaylandState {
             self.surface.set_current_output(target_output);
             self.set_has_seen_surface_enter(false);
             self.refresh_active_output_label();
+            self.begin_session_output_transition(target_identity, "output switch");
             self.request_xdg_activation(qh);
             self.input_state.needs_redraw = true;
             return;
@@ -411,6 +721,7 @@ impl WaylandState {
         self.surface.set_current_output(target_output);
         self.set_has_seen_surface_enter(false);
         self.refresh_active_output_label();
+        self.begin_session_output_transition(target_identity, "output switch");
         self.set_keyboard_focus(false);
         self.set_overlay_ready(false);
         self.input_state.needs_redraw = true;
@@ -450,5 +761,284 @@ impl WaylandState {
         self.buffer_damage
             .mark_all_full(FullDamageReason::LayerSurfaceRecreated);
         self.set_toolbar_needs_recreate(true);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OutputTransitionStart, live_source_reconciliation_ready, output_transition_retry_at,
+        output_transition_start,
+    };
+    use crate::{backend::wayland::session::SessionState, session::SessionOptions};
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn configure_retry_keeps_matching_epoch_bound_transition() {
+        assert_eq!(
+            output_transition_start(false, false, true, true, false, false),
+            OutputTransitionStart::KeepPending
+        );
+    }
+
+    #[test]
+    fn initial_and_loaded_transitions_defer_for_active_interaction() {
+        assert_eq!(
+            output_transition_start(false, true, false, false, false, true),
+            OutputTransitionStart::DeferForInteraction
+        );
+        assert_eq!(
+            output_transition_start(true, true, false, false, false, true),
+            OutputTransitionStart::DeferForInteraction
+        );
+    }
+
+    #[test]
+    fn transition_start_distinguishes_initial_load_and_loaded_switch() {
+        assert_eq!(
+            output_transition_start(false, true, false, false, false, false),
+            OutputTransitionStart::LoadInitial
+        );
+        assert_eq!(
+            output_transition_start(true, true, false, false, false, false),
+            OutputTransitionStart::ResolveTransition
+        );
+    }
+
+    #[test]
+    fn unloaded_dirty_source_with_nonmatching_pending_transition_resolves_before_load() {
+        let mut options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+        options.per_output = true;
+        let mut first_target = options.clone();
+        first_target.set_output_identity(Some("output-a"));
+        let mut session = SessionState::new(Some(options.clone()));
+        session.stage_output_transition(first_target, Some("output-a".to_string()), Instant::now());
+        session.record_input_dirty(Instant::now(), true);
+
+        let incoming_identity = Some("output-b".to_string());
+        let mut incoming = options;
+        let changed = incoming.set_output_identity(incoming_identity.as_deref());
+        let same_epoch_pending = session
+            .pending_output_transition()
+            .is_some_and(|pending| pending.source_epoch == session.target_epoch());
+        let matching_pending = same_epoch_pending
+            && session
+                .pending_output_transition()
+                .is_some_and(|pending| pending.physical_output_identity == incoming_identity);
+
+        assert!(!session.is_loaded());
+        assert!(session.is_dirty());
+        assert!(!matching_pending);
+        assert_eq!(
+            output_transition_start(
+                session.is_loaded(),
+                changed,
+                matching_pending,
+                same_epoch_pending,
+                false,
+                false,
+            ),
+            OutputTransitionStart::ResolveTransition
+        );
+        assert!(session.is_dirty());
+    }
+
+    #[test]
+    fn unloaded_dirty_return_to_current_target_blocks_followup_configure_load() {
+        let mut options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+        options.per_output = true;
+        let mut destination = options.clone();
+        destination.set_output_identity(Some("output-a"));
+        let mut session = SessionState::new(Some(options.clone()));
+        session.stage_output_transition(destination, Some("output-a".to_string()), Instant::now());
+        session.record_input_dirty(Instant::now(), true);
+        let source_epoch = session.target_epoch();
+        let edit_generation = session.edit_generation();
+
+        let incoming_identity = None;
+        let mut incoming = options.clone();
+        let changed = incoming.set_output_identity(incoming_identity);
+        let same_epoch_pending = session
+            .pending_output_transition()
+            .is_some_and(|pending| pending.source_epoch == source_epoch);
+        let matching_pending = same_epoch_pending
+            && session
+                .pending_output_transition()
+                .is_some_and(|pending| pending.physical_output_identity.is_none());
+        let start = output_transition_start(
+            session.is_loaded(),
+            changed,
+            matching_pending,
+            same_epoch_pending,
+            false,
+            false,
+        );
+
+        assert!(!session.is_loaded());
+        assert!(!changed);
+        assert!(!matching_pending);
+        assert_eq!(start, OutputTransitionStart::IgnoreCurrentTarget);
+        assert!(
+            session
+                .cancel_output_transition_for_live_source(false)
+                .is_some()
+        );
+        assert!(session.pending_output_transition().is_none());
+        assert!(session.is_loaded());
+        assert!(session.is_dirty());
+        assert!(session.prepare_autosave_submission().is_ok());
+        assert_eq!(session.target_epoch(), source_epoch);
+        assert_eq!(session.edit_generation(), edit_generation);
+
+        let mut configure_options = options;
+        let configure_changed = configure_options.set_output_identity(None);
+        let followup = output_transition_start(
+            session.is_loaded(),
+            configure_changed,
+            false,
+            false,
+            false,
+            false,
+        );
+
+        assert!(!configure_changed);
+        assert_eq!(followup, OutputTransitionStart::IgnoreCurrentTarget);
+        assert_ne!(followup, OutputTransitionStart::LoadInitial);
+        assert!(session.is_dirty());
+        assert!(session.prepare_autosave_submission().is_ok());
+        assert_eq!(session.target_epoch(), source_epoch);
+        assert_eq!(session.edit_generation(), edit_generation);
+    }
+
+    #[test]
+    fn active_stroke_return_resolves_to_dirty_live_source_or_clean_initial_load() {
+        let mut options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+        options.per_output = true;
+        let mut destination = options.clone();
+        destination.set_output_identity(Some("output-a"));
+
+        let mut committed = SessionState::new(Some(options.clone()));
+        committed.stage_output_transition(
+            destination.clone(),
+            Some("output-a".to_string()),
+            Instant::now(),
+        );
+        let committed_epoch = committed.target_epoch();
+        assert_eq!(
+            output_transition_start(false, false, false, true, false, true),
+            OutputTransitionStart::IgnoreCurrentTarget
+        );
+        assert!(
+            committed
+                .cancel_output_transition_for_live_source(false)
+                .is_some()
+        );
+        assert!(!committed.is_loaded());
+        assert!(committed.resolve_live_source_resolution(false, true));
+        assert_eq!(
+            output_transition_start(false, false, false, false, true, true),
+            OutputTransitionStart::IgnoreCurrentTarget
+        );
+
+        committed.record_input_dirty(Instant::now(), true);
+        assert!(committed.is_loaded());
+        assert!(committed.is_dirty());
+        assert!(!committed.resolve_live_source_resolution(false, false));
+        assert_eq!(committed.target_epoch(), committed_epoch);
+        assert_eq!(
+            output_transition_start(true, false, false, false, false, false),
+            OutputTransitionStart::IgnoreCurrentTarget
+        );
+
+        let mut configure_first = SessionState::new(Some(options.clone()));
+        configure_first.stage_output_transition(
+            destination.clone(),
+            Some("output-a".to_string()),
+            Instant::now(),
+        );
+        assert!(
+            configure_first
+                .cancel_output_transition_for_live_source(false)
+                .is_some()
+        );
+        assert!(!configure_first.resolve_live_source_resolution(true, false));
+        assert!(configure_first.is_loaded());
+
+        let mut canceled = SessionState::new(Some(options));
+        canceled.stage_output_transition(destination, Some("output-a".to_string()), Instant::now());
+        let canceled_epoch = canceled.target_epoch();
+        assert!(
+            canceled
+                .cancel_output_transition_for_live_source(false)
+                .is_some()
+        );
+        assert!(!canceled.resolve_live_source_resolution(false, false));
+        assert!(!canceled.is_loaded());
+        assert!(!canceled.is_dirty());
+        assert_eq!(canceled.target_epoch(), canceled_epoch);
+        assert_eq!(
+            output_transition_start(false, false, false, false, false, false),
+            OutputTransitionStart::LoadInitial
+        );
+    }
+
+    #[test]
+    fn live_source_reconciliation_runs_only_when_idle_without_a_destination() {
+        assert!(live_source_reconciliation_ready(true, false, false, true));
+        assert!(!live_source_reconciliation_ready(false, false, false, true));
+        assert!(!live_source_reconciliation_ready(true, true, false, true));
+        assert!(!live_source_reconciliation_ready(true, false, true, true));
+        assert!(!live_source_reconciliation_ready(true, false, false, false));
+    }
+
+    #[test]
+    fn clean_unloaded_cancellation_arms_immediate_source_resolution() {
+        let options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+        let mut session = SessionState::new(Some(options.clone()));
+        session.stage_output_transition(options, Some("output-a".to_string()), Instant::now());
+
+        assert!(
+            session
+                .cancel_output_transition_for_live_source(false)
+                .is_some()
+        );
+        assert!(session.has_pending_live_source_resolution());
+        assert!(live_source_reconciliation_ready(true, false, false, true));
+        assert!(!session.resolve_live_source_resolution(false, false));
+        assert!(!session.is_loaded());
+        assert!(!session.has_pending_live_source_resolution());
+        assert_eq!(
+            output_transition_start(false, false, false, false, false, false),
+            OutputTransitionStart::LoadInitial
+        );
+    }
+
+    #[test]
+    fn loaded_source_cancellation_does_not_arm_provisional_resolution() {
+        let mut session = SessionState::new(None);
+        session.mark_loaded(false);
+        session.stage_output_transition(
+            SessionOptions::new(PathBuf::from("/tmp"), "loaded-destination"),
+            Some("output-a".to_string()),
+            Instant::now(),
+        );
+
+        assert!(
+            session
+                .cancel_output_transition_for_live_source(false)
+                .is_some()
+        );
+        assert!(session.is_loaded());
+        assert!(!session.has_pending_live_source_resolution());
+    }
+
+    #[test]
+    fn failure_retry_deadline_is_based_on_failure_observation_time() {
+        let backoff = Duration::from_millis(50);
+        let before_failure_handling = Instant::now();
+        let retry_at = output_transition_retry_at(backoff);
+
+        assert!(retry_at >= before_failure_handling + backoff);
     }
 }

--- a/src/backend/wayland/state/core/output.rs
+++ b/src/backend/wayland/state/core/output.rs
@@ -66,6 +66,19 @@ fn live_source_reconciliation_ready(
         && worker_healthy
 }
 
+fn replace_output_session_snapshot(
+    input_state: &mut crate::input::InputState,
+    snapshot: Option<SessionSnapshot>,
+    options: &session::SessionOptions,
+) -> anyhow::Result<()> {
+    let snapshot = snapshot.unwrap_or_else(|| SessionSnapshot {
+        active_board_id: input_state.board_id().to_string(),
+        boards: Vec::new(),
+        tool_state: None,
+    });
+    session::apply_snapshot_replacing_boards(input_state, snapshot, options)
+}
+
 impl WaylandState {
     pub(in crate::backend::wayland) fn preferred_fullscreen_output(
         &self,
@@ -392,7 +405,7 @@ impl WaylandState {
             return Err(anyhow::anyhow!("unexpected output-load worker outcome"));
         };
         let loaded_board_data = load_outcome.has_board_data();
-        self.handle_session_load_outcome_for_options(load_outcome, &staged_options, "output load");
+        self.handle_session_load_outcome_for_options(load_outcome, &staged_options, "output load")?;
         self.session
             .commit_output_options(staged_options, loaded_board_data);
         info!(
@@ -465,7 +478,7 @@ impl WaylandState {
             return Err(anyhow::anyhow!("unexpected configured-load worker outcome"));
         };
         let loaded_board_data = load_outcome.has_board_data();
-        self.handle_session_load_outcome_for_options(load_outcome, &options, context);
+        self.handle_session_load_outcome_for_options(load_outcome, &options, context)?;
         self.session
             .commit_output_options(options, loaded_board_data);
         Ok(())
@@ -494,7 +507,7 @@ impl WaylandState {
         outcome: session::LoadSnapshotOutcome,
         options: &session::SessionOptions,
         context: &str,
-    ) {
+    ) -> anyhow::Result<()> {
         match outcome {
             session::LoadSnapshotOutcome::Loaded(snapshot) => {
                 debug!(
@@ -502,7 +515,7 @@ impl WaylandState {
                     context,
                     options.session_file_path().display()
                 );
-                session::apply_snapshot(&mut self.input_state, *snapshot, options);
+                replace_output_session_snapshot(&mut self.input_state, Some(*snapshot), options)?;
             }
             session::LoadSnapshotOutcome::LoadedFromBackup(snapshot) => {
                 warn!(
@@ -510,7 +523,7 @@ impl WaylandState {
                     context,
                     options.backup_file_path().display()
                 );
-                session::apply_snapshot(&mut self.input_state, *snapshot, options);
+                replace_output_session_snapshot(&mut self.input_state, Some(*snapshot), options)?;
                 self.input_state.set_ui_toast(
                     UiToastKind::Warning,
                     "Restored drawings from the session backup; the primary session had no board data.",
@@ -522,7 +535,7 @@ impl WaylandState {
                     context,
                     options.recovery_file_path().display()
                 );
-                session::apply_snapshot(&mut self.input_state, *snapshot, options);
+                replace_output_session_snapshot(&mut self.input_state, Some(*snapshot), options)?;
                 self.input_state.set_ui_toast(
                     UiToastKind::Warning,
                     "Restored session from recovery file; normal save previously exceeded the size limit.",
@@ -534,6 +547,7 @@ impl WaylandState {
                     options.session_file_path().display(),
                     context
                 );
+                replace_output_session_snapshot(&mut self.input_state, None, options)?;
             }
             session::LoadSnapshotOutcome::NonRegularArtifact { path } => {
                 debug!(
@@ -541,11 +555,13 @@ impl WaylandState {
                     path.display(),
                     context
                 );
+                replace_output_session_snapshot(&mut self.input_state, None, options)?;
             }
             session::LoadSnapshotOutcome::ExpandedTooLarge {
                 path,
                 max_expanded_size,
             } => {
+                replace_output_session_snapshot(&mut self.input_state, None, options)?;
                 self.session.protect_session_path(path.clone());
                 if self.session.mark_expanded_load_notified(&path) {
                     notification::send_notification_async(
@@ -562,6 +578,7 @@ impl WaylandState {
             }
         }
         self.mark_clean_after_session_load();
+        Ok(())
     }
 
     fn mark_clean_after_session_load(&mut self) {
@@ -768,11 +785,98 @@ impl WaylandState {
 mod tests {
     use super::{
         OutputTransitionStart, live_source_reconciliation_ready, output_transition_retry_at,
-        output_transition_start,
+        output_transition_start, replace_output_session_snapshot,
     };
-    use crate::{backend::wayland::session::SessionState, session::SessionOptions};
+    use crate::{
+        backend::wayland::session::SessionState,
+        draw::{Color, Frame, Shape},
+        input::state::test_support::make_test_input_state,
+        session::{BoardPagesSnapshot, BoardSnapshot, SessionOptions, SessionSnapshot},
+    };
     use std::path::PathBuf;
     use std::time::{Duration, Instant};
+
+    fn add_test_line(input: &mut crate::input::InputState) {
+        input.boards.active_frame_mut().add_shape(Shape::Line {
+            x1: 0,
+            y1: 0,
+            x2: 20,
+            y2: 20,
+            color: Color {
+                r: 1.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+            thick: 2.0,
+        });
+    }
+
+    #[test]
+    fn empty_output_load_replaces_source_board_contents() {
+        let options = SessionOptions::new(PathBuf::from("/tmp"), "empty-output");
+        let mut input = make_test_input_state();
+        add_test_line(&mut input);
+        assert_eq!(input.boards.active_frame().shapes.len(), 1);
+
+        replace_output_session_snapshot(&mut input, None, &options)
+            .expect("empty output replacement");
+
+        assert!(input.boards.active_frame().shapes.is_empty());
+    }
+
+    #[test]
+    fn partial_output_load_clears_boards_omitted_from_snapshot() {
+        let options = SessionOptions::new(PathBuf::from("/tmp"), "partial-output");
+        let mut input = make_test_input_state();
+        input.switch_board_force("transparent");
+        add_test_line(&mut input);
+        assert_eq!(input.boards.active_frame().shapes.len(), 1);
+        let snapshot = SessionSnapshot {
+            active_board_id: "whiteboard".to_string(),
+            boards: vec![BoardSnapshot {
+                id: "whiteboard".to_string(),
+                pages: BoardPagesSnapshot {
+                    pages: vec![Frame::new()],
+                    active: 0,
+                },
+            }],
+            tool_state: None,
+        };
+
+        replace_output_session_snapshot(&mut input, Some(snapshot), &options)
+            .expect("partial output replacement");
+
+        input.switch_board_force("transparent");
+        assert!(input.boards.active_frame().shapes.is_empty());
+    }
+
+    #[test]
+    fn failed_output_replacement_preserves_source_board_contents() {
+        let options = SessionOptions::new(PathBuf::from("/tmp"), "oversized-output");
+        let mut input = make_test_input_state();
+        add_test_line(&mut input);
+        let boards = (0..=input.boards.max_count())
+            .map(|index| BoardSnapshot {
+                id: format!("replacement-{index}"),
+                pages: BoardPagesSnapshot {
+                    pages: vec![Frame::new()],
+                    active: 0,
+                },
+            })
+            .collect();
+        let snapshot = SessionSnapshot {
+            active_board_id: "replacement-0".to_string(),
+            boards,
+            tool_state: None,
+        };
+
+        let err = replace_output_session_snapshot(&mut input, Some(snapshot), &options)
+            .expect_err("oversized replacement must fail before mutating live boards");
+
+        assert!(err.to_string().contains("current runtime allows"));
+        assert_eq!(input.boards.active_frame().shapes.len(), 1);
+    }
 
     #[test]
     fn configure_retry_keeps_matching_epoch_bound_transition() {

--- a/src/backend/wayland/state/core/session.rs
+++ b/src/backend/wayland/state/core/session.rs
@@ -1,14 +1,21 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
 use super::super::*;
-use crate::backend::wayland::session::{
-    self as runtime_session, RuntimeClearSessionReport, RuntimeClearToolStateReport,
-    RuntimeOpenSessionReport, RuntimeSaveAsSessionReport,
+use crate::backend::wayland::{
+    backend::event_loop::session_save,
+    session::{
+        PersistenceOperation, PersistenceOutcome, RuntimeClearSessionReport,
+        RuntimeClearToolStateReport, RuntimeOpenSessionReport, RuntimeSaveAsSessionReport,
+        SaveStrategy,
+    },
 };
-use crate::session::{ClearToolStateOutcome, SaveAsOverwrite, ToolStateSnapshot};
+use crate::session::{
+    self as stored_session, ClearToolStateOutcome, LoadSnapshotOutcome, SaveAsOverwrite,
+    SessionOptions, SessionSnapshot, ToolStateSnapshot,
+};
 
 impl WaylandState {
     #[allow(dead_code)]
@@ -16,12 +23,69 @@ impl WaylandState {
         &mut self,
         target_path: &Path,
     ) -> Result<RuntimeOpenSessionReport> {
-        runtime_session::open_named_session_runtime(
+        let current_options = self
+            .session_options()
+            .cloned()
+            .ok_or_else(|| anyhow!("cannot open session without active session options"))?;
+        let previous_path = current_options.session_file_path();
+
+        let validation = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::ValidateNamedOpen {
+                path: target_path.to_path_buf(),
+            },
+        )?;
+        accept_open_preflight(&mut self.session, validation)?;
+
+        let saved_current = self.save_current_before_explicit_target_change(&current_options)?;
+        let mut candidate_options = current_options;
+        candidate_options.set_named_file_target(target_path.to_path_buf());
+        candidate_options.force_resume_persistence();
+
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::LoadNamedCandidate {
+                options: candidate_options.clone(),
+            },
+        )?;
+        let PersistenceOutcome::Load(load_outcome) = outcome else {
+            return Err(anyhow!("unexpected named-session load outcome"));
+        };
+        let candidate_snapshot = named_candidate_snapshot(load_outcome, &candidate_options)?;
+        let loaded_board_data = candidate_snapshot.has_board_data();
+        stored_session::apply_snapshot_replacing_boards(
             &mut self.input_state,
-            &mut self.session,
-            target_path,
-            Instant::now(),
-        )
+            candidate_snapshot,
+            &candidate_options,
+        )?;
+        self.input_state
+            .set_session_preflight_options(Some(candidate_options.clone()));
+        self.input_state.clear_session_dirty();
+        let opened_path = candidate_options.session_file_path();
+        self.session
+            .commit_runtime_open(candidate_options.clone(), loaded_board_data);
+
+        match session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::RecordNamedOpened {
+                options: candidate_options,
+            },
+        ) {
+            Ok(PersistenceOutcome::Unit) => {}
+            Ok(other) => log::warn!(
+                "Named session opened, but catalog worker returned an unexpected outcome: {other:?}"
+            ),
+            Err(err) => log::warn!(
+                "Named session opened, but recording it in the recent-session catalog failed: {err:#}"
+            ),
+        }
+
+        Ok(RuntimeOpenSessionReport {
+            previous_path,
+            opened_path,
+            saved_current,
+            loaded_board_data,
+        })
     }
 
     #[allow(dead_code)]
@@ -30,32 +94,154 @@ impl WaylandState {
         target_path: &Path,
         overwrite: SaveAsOverwrite,
     ) -> Result<RuntimeSaveAsSessionReport> {
-        runtime_session::save_named_session_as_runtime(
-            &mut self.input_state,
-            &mut self.session,
-            target_path,
-            overwrite,
-            Instant::now(),
-        )
+        let current_options = self
+            .session_options()
+            .cloned()
+            .ok_or_else(|| anyhow!("cannot save session as without active session options"))?;
+        let previous_path = current_options.session_file_path();
+        let mut target_options = current_options.clone();
+        target_options.set_named_file_target(target_path.to_path_buf());
+        target_options.force_resume_persistence();
+        let preflight = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::SaveAsOverwritePreflight {
+                current_path: previous_path.clone(),
+                options: target_options.clone(),
+            },
+        )?;
+        match accept_save_as_preflight(&mut self.session, preflight, overwrite, target_path)? {
+            SaveAsPreflightDecision::SameTarget => {
+                let saved = self.save_current_before_explicit_target_change(&current_options)?;
+                return Ok(RuntimeSaveAsSessionReport {
+                    previous_path: previous_path.clone(),
+                    saved_path: previous_path,
+                    switched_target: false,
+                    saved,
+                    saved_board_data: self.session.has_loaded_board_data(),
+                    outcome: None,
+                    written_size: None,
+                });
+            }
+            SaveAsPreflightDecision::SwitchTarget => {}
+        }
+
+        let snapshot = self
+            .input_state
+            .with_active_interaction_canceled_for_capture(|input_state| {
+                stored_session::snapshot_from_input(input_state, &target_options)
+            })
+            .ok_or_else(|| anyhow!("Save Session As has no session data to write"))?;
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::SaveAs {
+                snapshot,
+                options: target_options.clone(),
+                overwrite,
+            },
+        )?;
+        let PersistenceOutcome::SaveAs {
+            report,
+            committed_board_data,
+        } = outcome
+        else {
+            return Err(anyhow!("unexpected Save As worker outcome"));
+        };
+
+        self.input_state
+            .set_session_preflight_options(Some(target_options.clone()));
+        let _ = self.input_state.take_session_dirty();
+        self.input_state.clear_session_dirty();
+        let saved_path = target_options.session_file_path();
+        self.session
+            .commit_runtime_save_as(target_options, Instant::now(), committed_board_data);
+
+        Ok(RuntimeSaveAsSessionReport {
+            previous_path,
+            saved_path,
+            switched_target: true,
+            saved: true,
+            saved_board_data: committed_board_data,
+            outcome: Some(report.outcome),
+            written_size: Some(report.written_size),
+        })
     }
 
     #[allow(dead_code)]
     pub(in crate::backend::wayland) fn save_named_session_as_requires_overwrite(
-        &self,
+        &mut self,
         target_path: &Path,
     ) -> Result<bool> {
-        runtime_session::save_named_session_as_requires_overwrite(&self.session, target_path)
+        let current_options = self
+            .session_options()
+            .cloned()
+            .ok_or_else(|| anyhow!("cannot save session as without active session options"))?;
+        let previous_path = current_options.session_file_path();
+        let mut target_options = current_options;
+        target_options.set_named_file_target(target_path.to_path_buf());
+        target_options.force_resume_persistence();
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::SaveAsOverwritePreflight {
+                current_path: previous_path,
+                options: target_options,
+            },
+        )?;
+        let PersistenceOutcome::SaveAsPreflight {
+            same_target,
+            overwrite_required,
+        } = outcome
+        else {
+            return Err(anyhow!("unexpected Save As preflight outcome"));
+        };
+        Ok(!same_target && overwrite_required)
     }
 
     #[allow(dead_code)]
     pub(in crate::backend::wayland) fn clear_current_session_runtime(
         &mut self,
     ) -> Result<RuntimeClearSessionReport> {
-        runtime_session::clear_current_session_runtime(
+        session_save::persistence_barrier(self)?;
+        let options = self
+            .session_options()
+            .cloned()
+            .ok_or_else(|| anyhow!("cannot clear session without active session options"))?;
+        let cleared_path = options.session_file_path();
+        let empty_snapshot = SessionSnapshot {
+            active_board_id: self.input_state.board_id().to_string(),
+            boards: Vec::new(),
+            tool_state: None,
+        };
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::Save {
+                snapshot: empty_snapshot.clone(),
+                options: options.clone(),
+                strategy: SaveStrategy::Normal,
+                contentless_clear_boundary: true,
+            },
+        )?;
+        let PersistenceOutcome::Save(save) = outcome else {
+            return Err(anyhow!("unexpected clear-session worker outcome"));
+        };
+        if !save.committed() {
+            return Err(anyhow!(
+                "current session clear did not write a committed clear boundary"
+            ));
+        }
+        stored_session::apply_snapshot_replacing_boards(
             &mut self.input_state,
-            &mut self.session,
-            Instant::now(),
-        )
+            empty_snapshot,
+            &options,
+        )?;
+        self.input_state
+            .set_session_preflight_options(Some(options));
+        let _ = self.input_state.take_session_dirty();
+        self.input_state.clear_session_dirty();
+        self.session.commit_runtime_clear(Instant::now());
+        Ok(RuntimeClearSessionReport {
+            cleared_path,
+            persisted: true,
+        })
     }
 
     #[allow(dead_code)]
@@ -63,12 +249,25 @@ impl WaylandState {
         &mut self,
     ) -> Result<RuntimeClearToolStateReport> {
         let default_tool_state = ToolStateSnapshot::from_config(&self.config);
-        runtime_session::clear_saved_tool_state_runtime(
-            &mut self.input_state,
-            &mut self.session,
-            default_tool_state,
-            Instant::now(),
-        )
+        let (session_path, outcome) = if let Some(options) = self.session_options().cloned() {
+            let path = options.session_file_path();
+            let outcome = session_save::run_persistence_operation(
+                self,
+                PersistenceOperation::ClearToolState { options },
+            )?;
+            let PersistenceOutcome::ToolStateCleared(outcome) = outcome else {
+                return Err(anyhow!("unexpected clear-tool-state worker outcome"));
+            };
+            (Some(path), Some(outcome))
+        } else {
+            (None, None)
+        };
+        stored_session::apply_tool_state_snapshot(&mut self.input_state, default_tool_state);
+        self.input_state.mark_session_dirty();
+        Ok(RuntimeClearToolStateReport {
+            session_path,
+            outcome,
+        })
     }
 
     pub(in crate::backend::wayland) fn handle_clear_saved_tool_state_action(&mut self) {
@@ -87,6 +286,173 @@ impl WaylandState {
             }
         }
     }
+
+    pub(in crate::backend::wayland) fn inspect_active_session(
+        &mut self,
+    ) -> Result<stored_session::SessionInspection> {
+        let options = self
+            .session_options()
+            .cloned()
+            .ok_or_else(|| anyhow!("no active persisted session target"))?;
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::Inspect { options },
+        )?;
+        let PersistenceOutcome::Inspection(inspection) = outcome else {
+            return Err(anyhow!("unexpected session-inspection worker outcome"));
+        };
+        Ok(inspection)
+    }
+
+    pub(in crate::backend::wayland) fn forget_named_session_by_path(
+        &mut self,
+        path: PathBuf,
+    ) -> Result<bool> {
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::ForgetNamedSessionByPath { path },
+        )?;
+        let PersistenceOutcome::CatalogForgotten(forgotten) = outcome else {
+            return Err(anyhow!("unexpected catalog-forget worker outcome"));
+        };
+        Ok(forgotten)
+    }
+
+    fn save_current_before_explicit_target_change(
+        &mut self,
+        options: &SessionOptions,
+    ) -> Result<bool> {
+        session_save::persistence_barrier(self)?;
+        if !self.input_state.is_session_dirty() && !self.session.is_dirty() {
+            return Ok(false);
+        }
+        let snapshot = self
+            .input_state
+            .with_active_interaction_canceled_for_capture(|input_state| {
+                stored_session::snapshot_from_input(input_state, options)
+            });
+        let snapshot = if let Some(snapshot) = snapshot {
+            snapshot
+        } else if session_persistence_enabled(options) {
+            SessionSnapshot {
+                active_board_id: self.input_state.board_id().to_string(),
+                boards: Vec::new(),
+                tool_state: None,
+            }
+        } else {
+            return Err(anyhow!(
+                "current session has unsaved changes but persistence is disabled"
+            ));
+        };
+        let outcome = session_save::run_persistence_operation(
+            self,
+            PersistenceOperation::Save {
+                snapshot,
+                options: options.clone(),
+                strategy: SaveStrategy::Normal,
+                contentless_clear_boundary: self.session.has_loaded_board_data(),
+            },
+        )?;
+        let PersistenceOutcome::Save(save) = outcome else {
+            return Err(anyhow!("unexpected save-before-target-change outcome"));
+        };
+        if !save.committed() {
+            return Err(anyhow!(
+                "current session had unsaved changes but no session file was written"
+            ));
+        }
+        let _ = self.input_state.take_session_dirty();
+        self.session
+            .mark_saved(Instant::now(), save.committed_board_data);
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SaveAsPreflightDecision {
+    SameTarget,
+    SwitchTarget,
+}
+
+fn accept_open_preflight(
+    session: &mut crate::backend::wayland::session::SessionState,
+    validation: PersistenceOutcome,
+) -> Result<()> {
+    if !matches!(validation, PersistenceOutcome::Unit) {
+        return Err(anyhow!("unexpected named-session validation outcome"));
+    }
+    cancel_pending_output_transition_for_explicit_target(session, "Open");
+    Ok(())
+}
+
+fn accept_save_as_preflight(
+    session: &mut crate::backend::wayland::session::SessionState,
+    preflight: PersistenceOutcome,
+    overwrite: SaveAsOverwrite,
+    target_path: &Path,
+) -> Result<SaveAsPreflightDecision> {
+    let PersistenceOutcome::SaveAsPreflight {
+        same_target,
+        overwrite_required,
+    } = preflight
+    else {
+        return Err(anyhow!("unexpected Save As preflight outcome"));
+    };
+    if same_target {
+        return Ok(SaveAsPreflightDecision::SameTarget);
+    }
+    if overwrite_required && matches!(overwrite, SaveAsOverwrite::Deny) {
+        return Err(anyhow!(
+            "Save Session As target already has session artifacts; overwrite confirmation required for {}",
+            target_path.display()
+        ));
+    }
+    cancel_pending_output_transition_for_explicit_target(session, "Save As");
+    Ok(SaveAsPreflightDecision::SwitchTarget)
+}
+
+fn cancel_pending_output_transition_for_explicit_target(
+    session: &mut crate::backend::wayland::session::SessionState,
+    operation: &str,
+) {
+    if let Some(pending) = session.cancel_pending_output_transition() {
+        log::info!(
+            "{operation} superseded pending output transition from epoch {} to {:?}",
+            pending.source_epoch,
+            pending.physical_output_identity
+        );
+    }
+}
+
+fn named_candidate_snapshot(
+    outcome: LoadSnapshotOutcome,
+    options: &SessionOptions,
+) -> Result<SessionSnapshot> {
+    match outcome {
+        LoadSnapshotOutcome::Loaded(snapshot)
+        | LoadSnapshotOutcome::LoadedFromBackup(snapshot)
+        | LoadSnapshotOutcome::LoadedFromRecovery(snapshot) => Ok(*snapshot),
+        LoadSnapshotOutcome::Empty => Err(anyhow!(
+            "named session file contains no usable session data: {}",
+            options.session_file_path().display()
+        )),
+        LoadSnapshotOutcome::NonRegularArtifact { path } => Err(anyhow!(
+            "named session file is not a regular file: {}",
+            path.display()
+        )),
+        LoadSnapshotOutcome::ExpandedTooLarge {
+            path,
+            max_expanded_size,
+        } => Err(anyhow!(
+            "named session file expands beyond the {} byte safety limit: {}",
+            max_expanded_size,
+            path.display()
+        )),
+    }
+}
+
+fn session_persistence_enabled(options: &SessionOptions) -> bool {
+    options.any_enabled() || options.restore_tool_state || options.persist_history
 }
 
 fn clear_tool_state_runtime_message(report: &RuntimeClearToolStateReport) -> String {
@@ -107,5 +473,87 @@ fn clear_tool_state_runtime_message(report: &RuntimeClearToolStateReport) -> Str
         }
         None => "Tool defaults reset from config for this run. No active session file to edit."
             .to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn session_with_pending_transition() -> crate::backend::wayland::session::SessionState {
+        let options = SessionOptions::new(PathBuf::from("/tmp"), "source-output");
+        let mut staged = options.clone();
+        staged.set_output_identity(Some("target-output"));
+        let mut session = crate::backend::wayland::session::SessionState::new(Some(options));
+        session.stage_output_transition(staged, Some("target-output".to_string()), Instant::now());
+        session
+    }
+
+    #[test]
+    fn open_cancels_pending_transition_only_after_accepted_preflight() {
+        let mut rejected = session_with_pending_transition();
+        assert!(
+            accept_open_preflight(&mut rejected, PersistenceOutcome::HasArtifacts(false)).is_err()
+        );
+        assert!(rejected.pending_output_transition().is_some());
+
+        let mut accepted = session_with_pending_transition();
+        accept_open_preflight(&mut accepted, PersistenceOutcome::Unit).unwrap();
+        assert!(accepted.pending_output_transition().is_none());
+    }
+
+    #[test]
+    fn save_as_keeps_pending_transition_until_preflight_is_accepted() {
+        let target = Path::new("/tmp/target.wayscriber-session");
+        let mut denied = session_with_pending_transition();
+        assert!(
+            accept_save_as_preflight(
+                &mut denied,
+                PersistenceOutcome::SaveAsPreflight {
+                    same_target: false,
+                    overwrite_required: true,
+                },
+                SaveAsOverwrite::Deny,
+                target,
+            )
+            .is_err()
+        );
+        assert!(denied.pending_output_transition().is_some());
+
+        let mut accepted = session_with_pending_transition();
+        assert_eq!(
+            accept_save_as_preflight(
+                &mut accepted,
+                PersistenceOutcome::SaveAsPreflight {
+                    same_target: false,
+                    overwrite_required: false,
+                },
+                SaveAsOverwrite::Deny,
+                target,
+            )
+            .unwrap(),
+            SaveAsPreflightDecision::SwitchTarget
+        );
+        assert!(accepted.pending_output_transition().is_none());
+    }
+
+    #[test]
+    fn save_as_same_target_keeps_unrelated_pending_output_transition() {
+        let mut session = session_with_pending_transition();
+        assert_eq!(
+            accept_save_as_preflight(
+                &mut session,
+                PersistenceOutcome::SaveAsPreflight {
+                    same_target: true,
+                    overwrite_required: true,
+                },
+                SaveAsOverwrite::Deny,
+                Path::new("/tmp/current.wayscriber-session"),
+            )
+            .unwrap(),
+            SaveAsPreflightDecision::SameTarget
+        );
+        assert!(session.pending_output_transition().is_some());
     }
 }

--- a/src/backend/wayland/state/toolbar/events/session.rs
+++ b/src/backend/wayland/state/toolbar/events/session.rs
@@ -247,11 +247,22 @@ impl WaylandState {
                 "Opened session {}",
                 session_display_name(&report.opened_path)
             )),
-            Err(err) if forget_missing_recent_session_after_open_error(path, &err) => self
-                .set_session_toolbar_error(format!(
-                    "Session file missing; removed from recent sessions: {}",
-                    session_display_name(path)
-                )),
+            Err(err) if missing_session_error_matches_path(path, &err) => {
+                match self.forget_named_session_by_path(path.to_path_buf()) {
+                    Ok(true) => self.set_session_toolbar_error(format!(
+                        "Session file missing; removed from recent sessions: {}",
+                        session_display_name(path)
+                    )),
+                    Ok(false) => self.set_session_toolbar_error(format!(
+                        "Session file missing; no recent-session entry matched: {}",
+                        session_display_name(path)
+                    )),
+                    Err(catalog_err) => self.set_session_toolbar_error(format!(
+                        "Session file missing and recent-session cleanup failed for {}: {catalog_err:#}",
+                        session_display_name(path)
+                    )),
+                }
+            }
             Err(err) => self.set_session_toolbar_error(format!("Open session failed: {err:#}")),
         }
     }
@@ -341,14 +352,7 @@ impl WaylandState {
     }
 
     fn handle_toolbar_session_info(&mut self) {
-        let Some(options) = self.session.options().cloned() else {
-            self.set_session_toolbar_error(
-                "Session info unavailable: no active persisted session target",
-            );
-            return;
-        };
-
-        match crate::session::inspect_session(&options) {
+        match self.inspect_active_session() {
             Ok(inspection) => self.set_session_toolbar_info(session_info_summary(&inspection)),
             Err(err) => self.set_session_toolbar_error(format!("Session info failed: {err:#}")),
         }
@@ -394,6 +398,7 @@ impl WaylandState {
     }
 }
 
+#[cfg(test)]
 pub(super) fn forget_missing_recent_session_after_open_error(
     path: &Path,
     err: &AnyhowError,


### PR DESCRIPTION
## Summary

- Add a single bounded persistence worker for active Wayland sessions.
- Submit automatic autosaves without waiting for serialization, compression, or filesystem I/O.
- Serialize save, load, clear, inspection, preflight, and catalog mutations through the worker.
- Track dirty generations and target epochs so stale completions cannot clear newer edits.
- Make output transitions transactional and defer them during active pointer or stylus interactions.
- Preserve final shutdown saving, worker joining, protected-path handling, and safe fallback behavior.
- Restore dirty state, apply retry backoff, and notify once when the worker fails.

## Why

Autosave serialization and persistence previously ran on the Wayland event-loop thread. Large sessions or slow storage could therefore delay input, rendering, and other event processing.

This change keeps automatic persistence work off that thread while preserving existing session format, recovery, locking, rotation, and notification behavior.

## Scope

Snapshot capture still occurs on the event-loop thread because it deep-clones live session data.
Explicit operations such as Open, Save As, and Clear may also wait synchronously for the worker in this PR.

Persistence completion temporarily uses a short timeout while a request is active. A follow-up will connect it to the wake-driven runtime.