### PR TITLE
fix(test): avoid function pointer identity assumption in release builds

### DIFF
--- a/src/backend/wayland/toolbar/view/node.rs
+++ b/src/backend/wayland/toolbar/view/node.rs
@@ -50,8 +50,9 @@ impl From<String> for WidgetId {
 }
 
 /// A glyph-drawing function from `toolbar_icons`. Compared by function
-/// address; rendered in debug output as an opaque tag so golden dumps stay
-/// stable (semantic identity lives in [`WidgetId`]).
+/// address as a best-effort implementation detail; distinct functions are not
+/// guaranteed to have distinct addresses. Debug output uses an opaque tag so
+/// golden dumps stay stable (semantic identity lives in [`WidgetId`]).
 #[derive(Clone, Copy)]
 pub struct IconFn(pub fn(&cairo::Context, f64, f64, f64));
 
@@ -269,12 +270,11 @@ mod tests {
     }
 
     #[test]
-    fn icon_fn_compares_by_address_and_debugs_stably() {
-        fn a(_: &cairo::Context, _: f64, _: f64, _: f64) {}
-        fn b(_: &cairo::Context, _: f64, _: f64, _: f64) {}
+    fn icon_fn_equality_is_reflexive_and_debugs_stably() {
+        fn icon(_: &cairo::Context, _: f64, _: f64, _: f64) {}
 
-        assert_eq!(IconFn(a), IconFn(a));
-        assert_ne!(IconFn(a), IconFn(b));
-        assert_eq!(format!("{:?}", IconFn(a)), "IconFn");
+        let icon = IconFn(icon);
+        assert_eq!(icon, icon);
+        assert_eq!(format!("{icon:?}"), "IconFn");
     }
 }


### PR DESCRIPTION
Fixes #276 

## Summary

- Remove the assertion that two distinct icon functions must have different addresses.
- Keep deterministic coverage for `IconFn` equality and stable debug output.
- Document that function-address comparison is best-effort and that semantic widget identity belongs to `WidgetId`.

## Why

Optimized builds may merge equivalent functions, so distinct Rust functions are not guaranteed to have distinct addresses. This caused the `IconFn` test to fail under `cargo test --release`, including Nix package builds.

The failing assertion tested an unsupported property rather than application behavior.

## Safety

This changes only test code and documentation. Runtime behavior is unchanged:

- `IconFn` still uses `std::ptr::fn_addr_eq`.
- Rendering directly invokes the stored glyph function.
- Stable widget identity remains based on `WidgetId`.