### PR TITLE
Wake the event loop when persistence work completes

### DIFF
--- a/src/backend/wayland/backend/event_loop/dispatch.rs
+++ b/src/backend/wayland/backend/event_loop/dispatch.rs
@@ -4,6 +4,23 @@ use wayland_client::{EventQueue, backend::WaylandError};
 
 use super::super::super::state::WaylandState;
 use super::super::helpers::dispatch_with_timeout;
+use super::super::runtime_wake::RuntimeWakeSource;
+
+trait PersistenceWakeDrain {
+    fn drain_woken_persistence(&mut self) -> Result<(), anyhow::Error>;
+}
+
+impl PersistenceWakeDrain for WaylandState {
+    fn drain_woken_persistence(&mut self) -> Result<(), anyhow::Error> {
+        super::session_save::drain_persistence_completion(self)
+    }
+}
+
+fn route_woken_persistence(state: &mut impl PersistenceWakeDrain) {
+    if let Err(err) = state.drain_woken_persistence() {
+        log::warn!("Failed to apply woken persistence completion: {err}");
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CaptureReadOutcome {
@@ -65,6 +82,7 @@ fn dispatch_capture_active(ops: &mut impl CaptureDispatchOps) -> Result<(), anyh
 pub(super) fn dispatch_events(
     event_queue: &mut EventQueue<WaylandState>,
     state: &mut WaylandState,
+    runtime_wake: &RuntimeWakeSource,
     capture_active: bool,
     animation_timeout: Option<Duration>,
 ) -> Result<(), anyhow::Error> {
@@ -72,14 +90,28 @@ pub(super) fn dispatch_events(
         let mut ops = RealCaptureDispatchOps { event_queue, state };
         dispatch_capture_active(&mut ops)
     } else {
-        dispatch_with_timeout(event_queue, state, animation_timeout)
-            .map_err(|e| anyhow::anyhow!("Wayland event queue error: {}", e))
+        dispatch_with_timeout(
+            event_queue,
+            state,
+            runtime_wake,
+            route_woken_persistence,
+            animation_timeout,
+        )
+        .map_err(|e| anyhow::anyhow!("Wayland event queue error: {}", e))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::os::fd::AsRawFd;
+    use std::path::PathBuf;
+    use std::time::Instant;
+
     use super::*;
+    use crate::backend::wayland::session::{
+        PersistenceCompletion, PersistenceController, PersistenceOperation, SessionState,
+    };
+    use crate::session::SessionOptions;
 
     struct FakeCaptureDispatchOps {
         dispatch_calls: usize,
@@ -191,5 +223,122 @@ mod tests {
         assert_eq!(ops.dispatch_calls, 2);
         assert_eq!(ops.flush_calls, 1);
         assert_eq!(ops.prepare_calls, 1);
+    }
+
+    struct WorkerFailureRoute {
+        controller: PersistenceController,
+        session: SessionState,
+        options: SessionOptions,
+        drain_calls: usize,
+        notification_requests: usize,
+        toast_requests: usize,
+        apply_calls: usize,
+    }
+
+    impl super::super::session_save::PersistenceCompletionRuntime for WorkerFailureRoute {
+        fn try_receive_persistence_completion(
+            &mut self,
+        ) -> Result<Option<PersistenceCompletion>, anyhow::Error> {
+            self.controller.try_receive()
+        }
+
+        fn apply_persistence_completion(
+            &mut self,
+            _completion: PersistenceCompletion,
+        ) -> Result<(), anyhow::Error> {
+            self.apply_calls += 1;
+            Ok(())
+        }
+
+        fn persistence_session_options(&self) -> Option<SessionOptions> {
+            Some(self.options.clone())
+        }
+
+        fn persistence_session(&mut self) -> &mut SessionState {
+            &mut self.session
+        }
+
+        fn show_persistence_worker_failure(&mut self) {
+            self.toast_requests += 1;
+        }
+
+        fn notify_persistence_worker_failure(&mut self, _err: &anyhow::Error) {
+            self.notification_requests += 1;
+        }
+    }
+
+    impl PersistenceWakeDrain for WorkerFailureRoute {
+        fn drain_woken_persistence(&mut self) -> Result<(), anyhow::Error> {
+            self.drain_calls += 1;
+            super::super::session_save::drain_persistence_completion_for_runtime(self)
+        }
+    }
+
+    fn wait_for_runtime_wake(runtime_wake: &RuntimeWakeSource) {
+        let mut pollfd = libc::pollfd {
+            fd: runtime_wake.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        loop {
+            // SAFETY: pollfd and the runtime wake descriptor stay valid for this
+            // bounded test wait.
+            let ready = unsafe { libc::poll(&mut pollfd, 1, 1_000) };
+            if ready > 0 {
+                assert_ne!(pollfd.revents & libc::POLLIN, 0);
+                return;
+            }
+            if ready == 0 {
+                panic!("persistence worker did not wake the production route");
+            }
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                panic!("runtime wake poll failed: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn worker_panic_reaches_production_route_and_notifies_once() {
+        let mut options = SessionOptions::new(PathBuf::from("/tmp"), "dispatch-panic");
+        options.persist_transparent = true;
+        options.autosave_enabled = true;
+        options.autosave_failure_backoff = Duration::from_millis(50);
+
+        let started = Instant::now();
+        let mut session = SessionState::new(Some(options.clone()));
+        session.record_input_dirty(started, true);
+        let dirty_window = session.prepare_autosave_submission().unwrap();
+
+        let runtime_wake = RuntimeWakeSource::new().unwrap();
+        let mut controller = PersistenceController::start(runtime_wake.handle()).unwrap();
+        let request_id = controller
+            .try_submit(0, PersistenceOperation::PanicForTest)
+            .unwrap();
+        session.commit_autosave_submission(request_id, dirty_window);
+
+        wait_for_runtime_wake(&runtime_wake);
+        runtime_wake.drain().unwrap();
+        let mut route = WorkerFailureRoute {
+            controller,
+            session,
+            options,
+            drain_calls: 0,
+            notification_requests: 0,
+            toast_requests: 0,
+            apply_calls: 0,
+        };
+
+        route_woken_persistence(&mut route);
+        route_woken_persistence(&mut route);
+
+        assert_eq!(route.drain_calls, 2);
+        assert_eq!(route.notification_requests, 1);
+        assert_eq!(route.toast_requests, 1);
+        assert_eq!(route.apply_calls, 0);
+        assert!(route.session.is_dirty());
+        assert!(!route.controller.is_healthy());
+        assert!(route.controller.shutdown(0).is_err());
+        assert!(route.controller.is_stopped());
     }
 }

--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use wayland_client::{Connection, EventQueue};
 
 use super::super::state::WaylandState;
+use super::runtime_wake::RuntimeWakeSource;
 use super::signals::setup_signal_handlers;
 use super::tray::process_tray_action;
 
@@ -33,6 +34,7 @@ pub(super) fn run_event_loop(
     event_queue: &mut EventQueue<WaylandState>,
     qh: &wayland_client::QueueHandle<WaylandState>,
     state: &mut WaylandState,
+    runtime_wake: &RuntimeWakeSource,
 ) -> EventLoopOutcome {
     // Gracefully exit the overlay when external signals request termination.
     let (exit_flag, tray_action_flag) = setup_signal_handlers();
@@ -134,7 +136,9 @@ pub(super) fn run_event_loop(
         let timeout = min_timeout(timeout, state.gtk_toolbar_wake_timeout());
         let timeout = min_timeout(timeout, toolbar_handoff_timeout);
         let timeout = min_timeout(timeout, command_palette_repeat_timeout);
-        if let Err(e) = dispatch::dispatch_events(event_queue, state, capture_active, timeout) {
+        if let Err(e) =
+            dispatch::dispatch_events(event_queue, state, runtime_wake, capture_active, timeout)
+        {
             warn!("Event queue error: {}", e);
             loop_error = Some(e);
             break;

--- a/src/backend/wayland/backend/event_loop/session_save.rs
+++ b/src/backend/wayland/backend/event_loop/session_save.rs
@@ -10,7 +10,6 @@ use crate::{
 use std::time::{Duration, Instant};
 
 const AUTOSAVE_ACTIVE_INTERACTION_DEFER_MS: u64 = 500;
-const PERSISTENCE_COMPLETION_POLL_MS: u64 = 25;
 
 mod notifications;
 
@@ -186,19 +185,12 @@ pub(super) fn autosave_timeout(state: &WaylandState, now: Instant) -> Option<Dur
         state.persistence.is_healthy(),
         now,
     );
-    let completion = state
-        .persistence
-        .is_active()
-        .then_some(Duration::from_millis(PERSISTENCE_COMPLETION_POLL_MS));
     let output_transition = state
         .persistence
         .is_healthy()
         .then(|| state.session.output_transition_timeout(now))
         .flatten();
-    min_optional_timeout(
-        min_optional_timeout(autosave, completion),
-        output_transition,
-    )
+    min_optional_timeout(autosave, output_transition)
 }
 
 fn scheduled_autosave_timeout(
@@ -384,15 +376,71 @@ pub(in crate::backend::wayland) fn run_persistence_operation(
 pub(in crate::backend::wayland) fn drain_persistence_completion(
     state: &mut WaylandState,
 ) -> Result<(), anyhow::Error> {
-    let completion = match state.persistence.try_receive() {
+    drain_persistence_completion_for_runtime(state)
+}
+
+pub(in crate::backend::wayland) trait PersistenceCompletionRuntime {
+    fn try_receive_persistence_completion(
+        &mut self,
+    ) -> Result<Option<PersistenceCompletion>, anyhow::Error>;
+
+    fn apply_persistence_completion(
+        &mut self,
+        completion: PersistenceCompletion,
+    ) -> Result<(), anyhow::Error>;
+
+    fn persistence_session_options(&self) -> Option<session::SessionOptions>;
+
+    fn persistence_session(&mut self) -> &mut SessionState;
+
+    fn show_persistence_worker_failure(&mut self);
+
+    fn notify_persistence_worker_failure(&mut self, err: &anyhow::Error);
+}
+
+impl PersistenceCompletionRuntime for WaylandState {
+    fn try_receive_persistence_completion(
+        &mut self,
+    ) -> Result<Option<PersistenceCompletion>, anyhow::Error> {
+        self.persistence.try_receive()
+    }
+
+    fn apply_persistence_completion(
+        &mut self,
+        completion: PersistenceCompletion,
+    ) -> Result<(), anyhow::Error> {
+        apply_persistence_completion(self, completion)
+    }
+
+    fn persistence_session_options(&self) -> Option<session::SessionOptions> {
+        self.session_options().cloned()
+    }
+
+    fn persistence_session(&mut self) -> &mut SessionState {
+        &mut self.session
+    }
+
+    fn show_persistence_worker_failure(&mut self) {
+        show_persistence_worker_failure_toast(self);
+    }
+
+    fn notify_persistence_worker_failure(&mut self, err: &anyhow::Error) {
+        notify_persistence_worker_failure(self, err);
+    }
+}
+
+pub(in crate::backend::wayland) fn drain_persistence_completion_for_runtime(
+    state: &mut impl PersistenceCompletionRuntime,
+) -> Result<(), anyhow::Error> {
+    let completion = match state.try_receive_persistence_completion() {
         Ok(completion) => completion,
         Err(err) => {
-            handle_persistence_transport_failure(state, Instant::now(), &err);
+            handle_persistence_transport_failure_for_runtime(state, Instant::now(), &err);
             return Err(err);
         }
     };
     if let Some(completion) = completion {
-        apply_persistence_completion(state, completion)?;
+        state.apply_persistence_completion(completion)?;
     }
     Ok(())
 }
@@ -451,10 +499,18 @@ fn handle_persistence_transport_failure(
     now: Instant,
     err: &anyhow::Error,
 ) {
-    let options = state.session_options().cloned();
-    if record_persistence_transport_failure(&mut state.session, options.as_ref(), now) {
-        show_persistence_worker_failure_toast(state);
-        notify_persistence_worker_failure(state, err);
+    handle_persistence_transport_failure_for_runtime(state, now, err);
+}
+
+fn handle_persistence_transport_failure_for_runtime(
+    state: &mut impl PersistenceCompletionRuntime,
+    now: Instant,
+    err: &anyhow::Error,
+) {
+    let options = state.persistence_session_options();
+    if record_persistence_transport_failure(state.persistence_session(), options.as_ref(), now) {
+        state.show_persistence_worker_failure();
+        state.notify_persistence_worker_failure(err);
     }
 }
 

--- a/src/backend/wayland/backend/event_loop/session_save/tests.rs
+++ b/src/backend/wayland/backend/event_loop/session_save/tests.rs
@@ -66,7 +66,7 @@ fn accepted_autosave_worker_panic_restores_dirty_and_requests_one_notification()
     let mut session = SessionState::new(Some(options.clone()));
     session.record_input_dirty(started, true);
     let dirty_window = session.prepare_autosave_submission().unwrap();
-    let mut controller = PersistenceController::start().unwrap();
+    let mut controller = PersistenceController::start_for_test().unwrap();
     let request_id = controller
         .try_submit(0, PersistenceOperation::PanicForTest)
         .unwrap();

--- a/src/backend/wayland/backend/helpers.rs
+++ b/src/backend/wayland/backend/helpers.rs
@@ -1,11 +1,12 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use log::warn;
 use std::env;
-use std::os::fd::AsRawFd;
-use std::time::Duration;
+use std::os::fd::{AsRawFd, RawFd};
+use std::time::{Duration, Instant};
 use wayland_client::{EventQueue, backend::ReadEventsGuard, backend::WaylandError};
 
 use super::super::state::WaylandState;
+use super::runtime_wake::{RuntimeWakeDrain, RuntimeWakeSource};
 use crate::{RESUME_SESSION_ENV, runtime_session_override};
 
 pub(super) fn friendly_capture_error(error: &str) -> String {
@@ -57,68 +58,260 @@ fn normalize_read_result(result: Result<usize, WaylandError>) -> Result<usize, W
     }
 }
 
-pub(super) fn read_events_with_timeout(
-    guard: ReadEventsGuard,
-    timeout: Option<Duration>,
-) -> Result<usize, WaylandError> {
-    let mut pollfd = libc::pollfd {
-        fd: guard.connection_fd().as_raw_fd(),
-        events: libc::POLLIN,
-        revents: 0,
-    };
-    let timeout_ms = timeout_to_poll_ms(timeout);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RuntimePollReadiness {
+    wayland: bool,
+    wake: bool,
+}
 
-    loop {
-        // SAFETY: pollfd points to valid memory and the file descriptor belongs
-        // to the prepared Wayland read guard for the duration of this call.
-        let ready = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
-        if ready == 0 {
-            // Dropping the guard cancels the prepared read.
-            return Ok(0);
-        }
-        if ready < 0 {
-            let err = std::io::Error::last_os_error();
-            if err.kind() == std::io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(WaylandError::Io(err));
-        }
-        break;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RuntimeReadOutcome {
+    wayland_read: bool,
+    wake_drain: Option<RuntimeWakeDrain>,
+}
+
+trait PreparedWaylandRead {
+    fn connection_raw_fd(&self) -> RawFd;
+    fn read(self) -> Result<usize, WaylandError>;
+}
+
+impl PreparedWaylandRead for ReadEventsGuard {
+    fn connection_raw_fd(&self) -> RawFd {
+        self.connection_fd().as_raw_fd()
     }
 
-    normalize_read_result(guard.read())
+    fn read(self) -> Result<usize, WaylandError> {
+        ReadEventsGuard::read(self)
+    }
+}
+
+fn validate_poll_readiness(pollfd: &libc::pollfd, label: &str) -> std::io::Result<bool> {
+    let terminal = pollfd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL);
+    if terminal != 0 {
+        return Err(std::io::Error::other(format!(
+            "{label} poll descriptor failed with readiness {:#x}",
+            pollfd.revents
+        )));
+    }
+    let unexpected = pollfd.revents & !libc::POLLIN;
+    if unexpected != 0 {
+        return Err(std::io::Error::other(format!(
+            "{label} poll descriptor returned unexpected readiness {:#x}",
+            pollfd.revents
+        )));
+    }
+    Ok(pollfd.revents & libc::POLLIN != 0)
+}
+
+fn poll_runtime_fds_with(
+    wayland_fd: RawFd,
+    wake_fd: RawFd,
+    timeout: Option<Duration>,
+    mut poll_once: impl FnMut(&mut [libc::pollfd], i32) -> std::io::Result<i32>,
+) -> std::io::Result<RuntimePollReadiness> {
+    let deadline = timeout.and_then(|timeout| Instant::now().checked_add(timeout));
+    let mut timeout_ms = timeout_to_poll_ms(timeout);
+    loop {
+        let mut pollfds = [
+            libc::pollfd {
+                fd: wayland_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: wake_fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+        match poll_once(&mut pollfds, timeout_ms) {
+            Ok(0) => {
+                return Ok(RuntimePollReadiness {
+                    wayland: false,
+                    wake: false,
+                });
+            }
+            Ok(_) => {
+                let readiness = RuntimePollReadiness {
+                    wayland: validate_poll_readiness(&pollfds[0], "Wayland")?,
+                    wake: validate_poll_readiness(&pollfds[1], "runtime wake")?,
+                };
+                if !readiness.wayland && !readiness.wake {
+                    return Err(std::io::Error::other(
+                        "runtime poll reported readiness without a readable descriptor",
+                    ));
+                }
+                return Ok(readiness);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => {
+                timeout_ms = deadline
+                    .map(|deadline| {
+                        timeout_to_poll_ms(Some(deadline.saturating_duration_since(Instant::now())))
+                    })
+                    .unwrap_or(-1);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn poll_runtime_fds(
+    wayland_fd: RawFd,
+    wake_fd: RawFd,
+    timeout: Option<Duration>,
+) -> std::io::Result<RuntimePollReadiness> {
+    poll_runtime_fds_with(wayland_fd, wake_fd, timeout, |pollfds, timeout_ms| {
+        // SAFETY: pollfds is a live mutable slice for the duration of this call,
+        // and both descriptors remain borrowed by their runtime owners.
+        let ready = unsafe {
+            libc::poll(
+                pollfds.as_mut_ptr(),
+                pollfds.len() as libc::nfds_t,
+                timeout_ms,
+            )
+        };
+        if ready < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(ready)
+        }
+    })
+}
+
+fn read_events_with_runtime_wake(
+    guard: impl PreparedWaylandRead,
+    runtime_wake: &RuntimeWakeSource,
+    timeout: Option<Duration>,
+) -> Result<RuntimeReadOutcome> {
+    let readiness = poll_runtime_fds(
+        guard.connection_raw_fd(),
+        runtime_wake.poll_fd().as_raw_fd(),
+        timeout,
+    )
+    .context("runtime readiness poll failed")?;
+
+    let wayland_read = if readiness.wayland {
+        let _ =
+            normalize_read_result(guard.read()).map_err(|err| anyhow::anyhow!(err.to_string()))?;
+        true
+    } else {
+        // Dropping the guard cancels the prepared read when only a runtime wake
+        // or a real deadline made the poll return.
+        drop(guard);
+        false
+    };
+    let wake_drain = readiness
+        .wake
+        .then(|| {
+            runtime_wake
+                .drain()
+                .context("failed to drain runtime wake descriptor")
+        })
+        .transpose()?;
+
+    Ok(RuntimeReadOutcome {
+        wayland_read,
+        wake_drain,
+    })
+}
+
+trait RuntimeDispatchOps {
+    fn dispatch_pending(&mut self) -> Result<usize>;
+    fn take_toolbar_drag_flush_requested(&mut self) -> bool;
+    fn flush(&mut self) -> Result<()>;
+    fn poll_prepared_read(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<Option<RuntimeReadOutcome>>;
+    fn process_runtime_wake(&mut self);
+}
+
+fn dispatch_runtime_cycle(
+    ops: &mut impl RuntimeDispatchOps,
+    timeout: Option<Duration>,
+) -> Result<()> {
+    let dispatched = ops.dispatch_pending()?;
+    if dispatched > 0 {
+        if ops.take_toolbar_drag_flush_requested() {
+            ops.flush()?;
+        }
+        return Ok(());
+    }
+
+    ops.flush()?;
+    if let Some(outcome) = ops.poll_prepared_read(timeout)? {
+        if outcome.wake_drain.is_some_and(|drain| drain.limit_reached) {
+            log::debug!(
+                "Runtime wake drain reached its bounded read limit; residual readiness will force another outer pass"
+            );
+        }
+        if outcome.wake_drain.is_some() {
+            ops.process_runtime_wake();
+        }
+        if outcome.wayland_read {
+            ops.dispatch_pending()?;
+        }
+    }
+
+    Ok(())
+}
+
+struct RealRuntimeDispatchOps<'a, F> {
+    event_queue: &'a mut EventQueue<WaylandState>,
+    state: &'a mut WaylandState,
+    runtime_wake: &'a RuntimeWakeSource,
+    on_runtime_wake: F,
+}
+
+impl<F> RuntimeDispatchOps for RealRuntimeDispatchOps<'_, F>
+where
+    F: FnMut(&mut WaylandState),
+{
+    fn dispatch_pending(&mut self) -> Result<usize> {
+        self.event_queue
+            .dispatch_pending(self.state)
+            .map_err(|err| anyhow::anyhow!(err.to_string()))
+    }
+
+    fn take_toolbar_drag_flush_requested(&mut self) -> bool {
+        self.state.take_toolbar_drag_flush_requested()
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.event_queue
+            .flush()
+            .map_err(|err| anyhow::anyhow!("Wayland flush error: {err}"))
+    }
+
+    fn poll_prepared_read(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> Result<Option<RuntimeReadOutcome>> {
+        self.event_queue
+            .prepare_read()
+            .map(|guard| read_events_with_runtime_wake(guard, self.runtime_wake, timeout))
+            .transpose()
+    }
+
+    fn process_runtime_wake(&mut self) {
+        (self.on_runtime_wake)(self.state);
+    }
 }
 
 pub(super) fn dispatch_with_timeout(
     event_queue: &mut EventQueue<WaylandState>,
     state: &mut WaylandState,
+    runtime_wake: &RuntimeWakeSource,
+    on_runtime_wake: impl FnMut(&mut WaylandState),
     timeout: Option<Duration>,
-) -> Result<(), anyhow::Error> {
-    let dispatched = event_queue
-        .dispatch_pending(state)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-    if dispatched > 0 {
-        if state.take_toolbar_drag_flush_requested() {
-            event_queue
-                .flush()
-                .map_err(|e| anyhow::anyhow!("Wayland flush error: {}", e))?;
-        }
-        return Ok(());
-    }
-
-    event_queue
-        .flush()
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-
-    if let Some(guard) = event_queue.prepare_read() {
-        let _ =
-            read_events_with_timeout(guard, timeout).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        event_queue
-            .dispatch_pending(state)
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-    }
-
-    Ok(())
+) -> Result<()> {
+    let mut ops = RealRuntimeDispatchOps {
+        event_queue,
+        state,
+        runtime_wake,
+        on_runtime_wake,
+    };
+    dispatch_runtime_cycle(&mut ops, timeout)
 }
 
 pub(super) fn resume_override_from_env() -> Option<bool> {
@@ -146,6 +339,11 @@ pub(super) fn resume_override_from_env() -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Mutex, OnceLock};
 
     use super::*;
@@ -181,6 +379,318 @@ mod tests {
             }
             other => panic!("expected io error, got {other}"),
         }
+    }
+
+    #[test]
+    fn runtime_poll_observes_wake_only_readiness() {
+        let (wayland_read, _wayland_write) = UnixStream::pair().unwrap();
+        let wake = RuntimeWakeSource::new().unwrap();
+        wake.handle().wake().unwrap();
+
+        assert_eq!(
+            poll_runtime_fds(
+                wayland_read.as_raw_fd(),
+                wake.poll_fd().as_raw_fd(),
+                Some(Duration::ZERO),
+            )
+            .unwrap(),
+            RuntimePollReadiness {
+                wayland: false,
+                wake: true,
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_poll_observes_combined_wayland_and_wake_readiness() {
+        let (wayland_read, mut wayland_write) = UnixStream::pair().unwrap();
+        let wake = RuntimeWakeSource::new().unwrap();
+        wayland_write.write_all(&[1]).unwrap();
+        wake.handle().wake().unwrap();
+
+        assert_eq!(
+            poll_runtime_fds(
+                wayland_read.as_raw_fd(),
+                wake.poll_fd().as_raw_fd(),
+                Some(Duration::ZERO),
+            )
+            .unwrap(),
+            RuntimePollReadiness {
+                wayland: true,
+                wake: true,
+            }
+        );
+    }
+
+    struct FakePreparedWaylandRead {
+        stream: UnixStream,
+        reads: Arc<AtomicUsize>,
+        cancellations: Arc<AtomicUsize>,
+        read: bool,
+    }
+
+    impl PreparedWaylandRead for FakePreparedWaylandRead {
+        fn connection_raw_fd(&self) -> RawFd {
+            self.stream.as_raw_fd()
+        }
+
+        fn read(mut self) -> Result<usize, WaylandError> {
+            self.read = true;
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            Ok(1)
+        }
+    }
+
+    impl Drop for FakePreparedWaylandRead {
+        fn drop(&mut self) {
+            if !self.read {
+                self.cancellations.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn fake_prepared_read(
+        stream: UnixStream,
+    ) -> (FakePreparedWaylandRead, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let reads = Arc::new(AtomicUsize::new(0));
+        let cancellations = Arc::new(AtomicUsize::new(0));
+        (
+            FakePreparedWaylandRead {
+                stream,
+                reads: Arc::clone(&reads),
+                cancellations: Arc::clone(&cancellations),
+                read: false,
+            },
+            reads,
+            cancellations,
+        )
+    }
+
+    #[test]
+    fn wake_only_readiness_cancels_the_prepared_wayland_read() {
+        let (wayland_read, _wayland_write) = UnixStream::pair().unwrap();
+        let (guard, reads, cancellations) = fake_prepared_read(wayland_read);
+        let wake = RuntimeWakeSource::new().unwrap();
+        wake.handle().wake().unwrap();
+
+        let outcome = read_events_with_runtime_wake(guard, &wake, Some(Duration::ZERO)).unwrap();
+
+        assert!(!outcome.wayland_read);
+        assert!(outcome.wake_drain.is_some());
+        assert_eq!(reads.load(Ordering::Relaxed), 0);
+        assert_eq!(cancellations.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn combined_readiness_reads_wayland_and_drains_runtime_wake() {
+        let (wayland_read, mut wayland_write) = UnixStream::pair().unwrap();
+        wayland_write.write_all(&[1]).unwrap();
+        let (guard, reads, cancellations) = fake_prepared_read(wayland_read);
+        let wake = RuntimeWakeSource::new().unwrap();
+        wake.handle().wake().unwrap();
+
+        let outcome = read_events_with_runtime_wake(guard, &wake, Some(Duration::ZERO)).unwrap();
+
+        assert!(outcome.wayland_read);
+        assert!(outcome.wake_drain.is_some());
+        assert_eq!(reads.load(Ordering::Relaxed), 1);
+        assert_eq!(cancellations.load(Ordering::Relaxed), 0);
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum DispatchCall {
+        DispatchPending,
+        TakeToolbarFlush,
+        Flush,
+        PrepareAndPoll,
+        ProcessRuntimeWake,
+    }
+
+    struct FakeRuntimeDispatchOps {
+        pending_counts: VecDeque<usize>,
+        toolbar_flush_requested: bool,
+        prepared_outcome: Option<RuntimeReadOutcome>,
+        calls: Vec<DispatchCall>,
+    }
+
+    impl FakeRuntimeDispatchOps {
+        fn new(
+            pending_counts: impl IntoIterator<Item = usize>,
+            prepared_outcome: Option<RuntimeReadOutcome>,
+        ) -> Self {
+            Self {
+                pending_counts: pending_counts.into_iter().collect(),
+                toolbar_flush_requested: false,
+                prepared_outcome,
+                calls: Vec::new(),
+            }
+        }
+    }
+
+    impl RuntimeDispatchOps for FakeRuntimeDispatchOps {
+        fn dispatch_pending(&mut self) -> Result<usize> {
+            self.calls.push(DispatchCall::DispatchPending);
+            Ok(self.pending_counts.pop_front().unwrap_or(0))
+        }
+
+        fn take_toolbar_drag_flush_requested(&mut self) -> bool {
+            self.calls.push(DispatchCall::TakeToolbarFlush);
+            self.toolbar_flush_requested
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            self.calls.push(DispatchCall::Flush);
+            Ok(())
+        }
+
+        fn poll_prepared_read(
+            &mut self,
+            _timeout: Option<Duration>,
+        ) -> Result<Option<RuntimeReadOutcome>> {
+            self.calls.push(DispatchCall::PrepareAndPoll);
+            Ok(self.prepared_outcome)
+        }
+
+        fn process_runtime_wake(&mut self) {
+            self.calls.push(DispatchCall::ProcessRuntimeWake);
+        }
+    }
+
+    #[test]
+    fn pending_wayland_events_return_without_prepare_read_or_poll() {
+        let mut ops = FakeRuntimeDispatchOps::new([1], None);
+
+        dispatch_runtime_cycle(&mut ops, None).unwrap();
+
+        assert_eq!(
+            ops.calls,
+            [
+                DispatchCall::DispatchPending,
+                DispatchCall::TakeToolbarFlush,
+            ]
+        );
+    }
+
+    #[test]
+    fn pending_toolbar_drag_performs_only_its_conditional_flush() {
+        let mut ops = FakeRuntimeDispatchOps::new([1], None);
+        ops.toolbar_flush_requested = true;
+
+        dispatch_runtime_cycle(&mut ops, None).unwrap();
+
+        assert_eq!(
+            ops.calls,
+            [
+                DispatchCall::DispatchPending,
+                DispatchCall::TakeToolbarFlush,
+                DispatchCall::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn wake_only_readiness_processes_runtime_wake_exactly_once() {
+        let mut ops = FakeRuntimeDispatchOps::new(
+            [0],
+            Some(RuntimeReadOutcome {
+                wayland_read: false,
+                wake_drain: Some(RuntimeWakeDrain {
+                    reads: 1,
+                    limit_reached: false,
+                }),
+            }),
+        );
+
+        dispatch_runtime_cycle(&mut ops, None).unwrap();
+
+        assert_eq!(
+            ops.calls,
+            [
+                DispatchCall::DispatchPending,
+                DispatchCall::Flush,
+                DispatchCall::PrepareAndPoll,
+                DispatchCall::ProcessRuntimeWake,
+            ]
+        );
+    }
+
+    #[test]
+    fn combined_readiness_processes_wake_once_before_wayland_dispatch() {
+        let mut ops = FakeRuntimeDispatchOps::new(
+            [0, 1],
+            Some(RuntimeReadOutcome {
+                wayland_read: true,
+                wake_drain: Some(RuntimeWakeDrain {
+                    reads: 1,
+                    limit_reached: false,
+                }),
+            }),
+        );
+
+        dispatch_runtime_cycle(&mut ops, None).unwrap();
+
+        assert_eq!(
+            ops.calls,
+            [
+                DispatchCall::DispatchPending,
+                DispatchCall::Flush,
+                DispatchCall::PrepareAndPoll,
+                DispatchCall::ProcessRuntimeWake,
+                DispatchCall::DispatchPending,
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_poll_retries_interruption() {
+        let mut calls = 0;
+        let readiness = poll_runtime_fds_with(10, 11, None, |pollfds, _| {
+            calls += 1;
+            if calls == 1 {
+                return Err(std::io::Error::from(std::io::ErrorKind::Interrupted));
+            }
+            pollfds[1].revents = libc::POLLIN;
+            Ok(1)
+        })
+        .unwrap();
+
+        assert_eq!(calls, 2);
+        assert_eq!(
+            readiness,
+            RuntimePollReadiness {
+                wayland: false,
+                wake: true,
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_poll_rejects_invalid_descriptor_readiness() {
+        let err = poll_runtime_fds_with(10, 11, None, |pollfds, _| {
+            pollfds[1].revents = libc::POLLNVAL;
+            Ok(1)
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("runtime wake"));
+        assert!(err.to_string().contains("readiness"));
+    }
+
+    #[test]
+    fn runtime_poll_timeout_reports_no_readiness() {
+        let readiness = poll_runtime_fds_with(10, 11, Some(Duration::ZERO), |_, timeout_ms| {
+            assert_eq!(timeout_ms, 0);
+            Ok(0)
+        })
+        .unwrap();
+
+        assert_eq!(
+            readiness,
+            RuntimePollReadiness {
+                wayland: false,
+                wake: false,
+            }
+        );
     }
 
     #[test]

--- a/src/backend/wayland/backend/mod.rs
+++ b/src/backend/wayland/backend/mod.rs
@@ -8,6 +8,7 @@ use crate::backend::ExitAfterCaptureMode;
 pub(in crate::backend::wayland) mod event_loop;
 mod helpers;
 mod run;
+pub(in crate::backend::wayland) mod runtime_wake;
 mod setup;
 mod signals;
 mod state_init;

--- a/src/backend/wayland/backend/run.rs
+++ b/src/backend/wayland/backend/run.rs
@@ -22,6 +22,7 @@ pub(super) fn run_backend(backend: &mut WaylandBackend) -> Result<()> {
         &mut runtime.event_queue,
         &runtime.qh,
         &mut runtime.state,
+        &runtime.runtime_wake,
     );
 
     match outcome.loop_error {

--- a/src/backend/wayland/backend/runtime_wake.rs
+++ b/src/backend/wayland/backend/runtime_wake.rs
@@ -1,0 +1,253 @@
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
+use std::sync::Arc;
+
+pub(in crate::backend::wayland) const MAX_WAKE_DRAIN_READS: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::backend::wayland) struct RuntimeWakeDrain {
+    pub(in crate::backend::wayland) reads: usize,
+    pub(in crate::backend::wayland) limit_reached: bool,
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct RuntimeWakeSource {
+    fd: Arc<OwnedFd>,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::backend::wayland) struct RuntimeWakeHandle {
+    fd: Arc<OwnedFd>,
+}
+
+impl RuntimeWakeSource {
+    pub(in crate::backend::wayland) fn new() -> io::Result<Self> {
+        // SAFETY: eventfd returns a new owned descriptor on success. EFD_NONBLOCK
+        // keeps both producer writes and consumer drains bounded, and EFD_CLOEXEC
+        // prevents subprocesses from extending the runtime descriptor lifetime.
+        let raw_fd = unsafe { libc::eventfd(0, libc::EFD_NONBLOCK | libc::EFD_CLOEXEC) };
+        if raw_fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: raw_fd was just returned by eventfd and has not been wrapped.
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        Ok(Self { fd: Arc::new(fd) })
+    }
+
+    pub(in crate::backend::wayland) fn poll_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+
+    pub(in crate::backend::wayland) fn handle(&self) -> RuntimeWakeHandle {
+        RuntimeWakeHandle {
+            fd: Arc::clone(&self.fd),
+        }
+    }
+
+    pub(in crate::backend::wayland) fn drain(&self) -> io::Result<RuntimeWakeDrain> {
+        self.drain_with_limit(MAX_WAKE_DRAIN_READS)
+    }
+
+    fn drain_with_limit(&self, max_reads: usize) -> io::Result<RuntimeWakeDrain> {
+        let mut reads = 0;
+        while reads < max_reads {
+            let mut value = 0_u64;
+            // SAFETY: value points to a writable u64 and the owned eventfd remains
+            // valid for the duration of this read.
+            let result = unsafe {
+                libc::read(
+                    self.fd.as_raw_fd(),
+                    (&mut value as *mut u64).cast(),
+                    size_of::<u64>(),
+                )
+            };
+            if result == size_of::<u64>() as isize {
+                reads += 1;
+                continue;
+            }
+            if result < 0 {
+                let err = io::Error::last_os_error();
+                match err.kind() {
+                    io::ErrorKind::Interrupted => continue,
+                    io::ErrorKind::WouldBlock => {
+                        return Ok(RuntimeWakeDrain {
+                            reads,
+                            limit_reached: false,
+                        });
+                    }
+                    _ => return Err(err),
+                }
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("runtime wake eventfd returned a short read ({result} bytes)"),
+            ));
+        }
+
+        Ok(RuntimeWakeDrain {
+            reads,
+            limit_reached: true,
+        })
+    }
+}
+
+impl RuntimeWakeHandle {
+    pub(in crate::backend::wayland) fn wake(&self) -> io::Result<()> {
+        let value = 1_u64;
+        loop {
+            // SAFETY: value points to a readable u64 and the shared eventfd remains
+            // valid for the duration of this write.
+            let result = unsafe {
+                libc::write(
+                    self.fd.as_raw_fd(),
+                    (&value as *const u64).cast(),
+                    size_of::<u64>(),
+                )
+            };
+            if result == size_of::<u64>() as isize {
+                return Ok(());
+            }
+            if result < 0 {
+                let err = io::Error::last_os_error();
+                match err.kind() {
+                    io::ErrorKind::Interrupted => continue,
+                    // A saturated eventfd is already readable, so the wake is
+                    // successfully coalesced rather than lost.
+                    io::ErrorKind::WouldBlock => return Ok(()),
+                    _ => return Err(err),
+                }
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                format!("runtime wake eventfd returned a short write ({result} bytes)"),
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    fn poll_readable(source: &RuntimeWakeSource, timeout_ms: i32) -> bool {
+        let mut pollfd = libc::pollfd {
+            fd: source.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd is valid for the duration of this call.
+        let ready = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        assert!(ready >= 0, "poll failed: {}", io::Error::last_os_error());
+        ready > 0 && pollfd.revents & libc::POLLIN != 0
+    }
+
+    fn wait_until_task_is_blocked_in_poll(tid: libc::pid_t) {
+        let stat_path = format!("/proc/self/task/{tid}/stat");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let state = std::fs::read_to_string(&stat_path).ok().and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .and_then(|(_, suffix)| suffix.chars().next())
+            });
+            // The polling thread publishes its tid before calling poll and performs
+            // no other blocking operation afterward. Once Linux reports it as
+            // sleeping, the poll syscall is actively waiting on the eventfd.
+            if state == Some('S') {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "polling thread did not enter a blocked poll (last state: {state:?})"
+            );
+            thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn wake_before_poll_is_observed_and_drained() {
+        let source = RuntimeWakeSource::new().unwrap();
+        source.handle().wake().unwrap();
+
+        assert!(poll_readable(&source, 0));
+        assert_eq!(
+            source.drain().unwrap(),
+            RuntimeWakeDrain {
+                reads: 1,
+                limit_reached: false,
+            }
+        );
+        assert!(!poll_readable(&source, 0));
+    }
+
+    #[test]
+    fn wake_unblocks_a_waiting_poll() {
+        let source = RuntimeWakeSource::new().unwrap();
+        let handle = source.handle();
+        let (poll_entry_tx, poll_entry_rx) = mpsc::channel();
+        let poller = thread::spawn(move || {
+            // SAFETY: gettid has no preconditions and returns the calling Linux
+            // thread's id, used only to observe its scheduler state in this test.
+            let tid = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
+            poll_entry_tx.send(tid).unwrap();
+            assert!(poll_readable(&source, 1_000));
+        });
+
+        let poller_tid = poll_entry_rx.recv().unwrap();
+        wait_until_task_is_blocked_in_poll(poller_tid);
+        handle.wake().unwrap();
+        poller.join().unwrap();
+    }
+
+    #[test]
+    fn multiple_wakes_coalesce() {
+        let source = RuntimeWakeSource::new().unwrap();
+        let handle = source.handle();
+        for _ in 0..32 {
+            handle.wake().unwrap();
+        }
+
+        assert_eq!(source.drain().unwrap().reads, 1);
+        assert!(!poll_readable(&source, 0));
+    }
+
+    #[test]
+    fn handle_can_safely_outlive_source() {
+        let source = RuntimeWakeSource::new().unwrap();
+        let handle = source.handle();
+        drop(source);
+
+        handle.wake().unwrap();
+    }
+
+    #[test]
+    fn empty_drain_is_bounded_and_reports_no_residual_work() {
+        let source = RuntimeWakeSource::new().unwrap();
+        assert_eq!(
+            source.drain().unwrap(),
+            RuntimeWakeDrain {
+                reads: 0,
+                limit_reached: false,
+            }
+        );
+    }
+
+    #[test]
+    fn bounded_drain_leaves_residual_readiness_for_the_next_pass() {
+        let source = RuntimeWakeSource::new().unwrap();
+        source.handle().wake().unwrap();
+
+        assert_eq!(
+            source.drain_with_limit(0).unwrap(),
+            RuntimeWakeDrain {
+                reads: 0,
+                limit_reached: true,
+            }
+        );
+        assert!(poll_readable(&source, 0));
+        assert_eq!(source.drain().unwrap().reads, 1);
+    }
+}

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -5,6 +5,7 @@ use std::env;
 
 use super::super::state::{WaylandState, WaylandStateInit};
 use super::WaylandBackend;
+use super::runtime_wake::RuntimeWakeSource;
 use super::setup::WaylandSetup;
 use super::tray::process_tray_action;
 use crate::backend::wayland::portal_capture::screenshot_portal_available;
@@ -29,6 +30,9 @@ pub(super) struct BackendRuntime {
     pub(super) event_queue: wayland_client::EventQueue<WaylandState>,
     pub(super) qh: wayland_client::QueueHandle<WaylandState>,
     pub(super) state: WaylandState,
+    // Declared after state so the persistence controller and worker are dropped
+    // before the last runtime-owned wake source during startup-error unwinding.
+    pub(super) runtime_wake: RuntimeWakeSource,
 }
 
 pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Result<BackendRuntime> {
@@ -40,7 +44,10 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
     let config_dir = Config::config_directory_from_source(&source)?;
     let session_options =
         session::build_session_options(&config, &config_dir, backend.named_session_file.clone());
-    let persistence = crate::backend::wayland::session::PersistenceController::start()?;
+    let runtime_wake = RuntimeWakeSource::new()
+        .map_err(|err| anyhow::anyhow!("failed to create runtime wake descriptor: {err}"))?;
+    let persistence =
+        crate::backend::wayland::session::PersistenceController::start(runtime_wake.handle())?;
     let output_prefs = output::resolve(&config);
 
     #[cfg(tablet)]
@@ -152,6 +159,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
         event_queue: setup.event_queue,
         qh: setup.qh,
         state,
+        runtime_wake,
     })
 }
 

--- a/src/backend/wayland/session/persistence.rs
+++ b/src/backend/wayland/session/persistence.rs
@@ -5,6 +5,9 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
 
+use crate::backend::wayland::backend::runtime_wake::RuntimeWakeHandle;
+#[cfg(test)]
+use crate::backend::wayland::backend::runtime_wake::RuntimeWakeSource;
 use crate::session::{
     self, ClearToolStateOutcome, LoadSnapshotOutcome, SaveAsOverwrite, SaveSnapshotOutcome,
     SaveSnapshotReport, SessionInspection, SessionOptions, SessionSnapshot,
@@ -182,7 +185,7 @@ pub(in crate::backend::wayland) struct PersistenceController {
 }
 
 impl PersistenceController {
-    pub(in crate::backend::wayland) fn start() -> Result<Self> {
+    pub(in crate::backend::wayland) fn start(wake: RuntimeWakeHandle) -> Result<Self> {
         assert_send_static::<SessionSnapshot>();
         assert_send_static::<LoadSnapshotOutcome>();
         assert_send_static::<PersistenceOperation>();
@@ -192,7 +195,7 @@ impl PersistenceController {
         let (completion_tx, completion_rx) = mpsc::sync_channel(1);
         let worker = thread::Builder::new()
             .name("wayscriber-persistence".to_string())
-            .spawn(move || worker_main(request_rx, completion_tx))
+            .spawn(move || worker_main(request_rx, completion_tx, wake))
             .context("failed to start session persistence worker")?;
 
         Ok(Self {
@@ -203,6 +206,12 @@ impl PersistenceController {
             next_sequence: 0,
             healthy: true,
         })
+    }
+
+    #[cfg(test)]
+    pub(in crate::backend::wayland) fn start_for_test() -> Result<Self> {
+        let wake = RuntimeWakeSource::new().context("failed to create test runtime wake source")?;
+        Self::start(wake.handle())
     }
 
     pub(in crate::backend::wayland) fn is_active(&self) -> bool {
@@ -424,7 +433,9 @@ impl Drop for PersistenceController {
 fn worker_main(
     request_rx: Receiver<PersistenceRequest>,
     completion_tx: SyncSender<PersistenceCompletion>,
+    wake: RuntimeWakeHandle,
 ) {
+    let publisher = PersistenceCompletionPublisher::new(completion_tx, wake);
     while let Ok(request) = request_rx.recv() {
         let PersistenceRequest {
             id,
@@ -440,21 +451,58 @@ fn worker_main(
         let execution_time = started.elapsed();
         let worker_thread_id = thread::current().id();
         let finished_at = Instant::now();
-        if completion_tx
-            .send(PersistenceCompletion {
-                id,
-                result,
-                queue_wait,
-                execution_time,
-                worker_thread_id,
-                finished_at,
-            })
-            .is_err()
-        {
+        if !publisher.publish(PersistenceCompletion {
+            id,
+            result,
+            queue_wait,
+            execution_time,
+            worker_thread_id,
+            finished_at,
+        }) {
             break;
         }
         if shutdown {
             break;
+        }
+    }
+}
+
+struct PersistenceCompletionPublisher {
+    completion_tx: Option<SyncSender<PersistenceCompletion>>,
+    wake: RuntimeWakeHandle,
+}
+
+impl PersistenceCompletionPublisher {
+    fn new(completion_tx: SyncSender<PersistenceCompletion>, wake: RuntimeWakeHandle) -> Self {
+        Self {
+            completion_tx: Some(completion_tx),
+            wake,
+        }
+    }
+
+    fn publish(&self, completion: PersistenceCompletion) -> bool {
+        let Some(completion_tx) = self.completion_tx.as_ref() else {
+            return false;
+        };
+        if completion_tx.send(completion).is_err() {
+            return false;
+        }
+        if let Err(err) = self.wake.wake() {
+            log::error!("Failed to wake runtime after persistence completion: {err}");
+            return false;
+        }
+        true
+    }
+}
+
+impl Drop for PersistenceCompletionPublisher {
+    fn drop(&mut self) {
+        // Close the completion channel before waking. The event loop can therefore
+        // observe disconnect immediately even when the worker unwinds without a
+        // completion packet.
+        self.completion_tx.take();
+        if let Err(err) = self.wake.wake() {
+            log::error!("Failed to wake runtime after persistence worker exit: {err}");
         }
     }
 }
@@ -611,6 +659,8 @@ fn log_snapshot_summary(
 
 #[cfg(test)]
 mod tests {
+    use std::os::fd::AsRawFd;
+
     use super::*;
 
     #[test]
@@ -630,11 +680,114 @@ mod tests {
         options
     }
 
+    fn controller_with_wake() -> (RuntimeWakeSource, PersistenceController) {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let controller = PersistenceController::start(wake.handle()).unwrap();
+        (wake, controller)
+    }
+
+    fn wait_for_runtime_wake(wake: &RuntimeWakeSource) {
+        let mut pollfd = libc::pollfd {
+            fd: wake.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        loop {
+            // SAFETY: pollfd and the runtime-owned descriptor remain valid for
+            // this bounded test wait.
+            let ready = unsafe { libc::poll(&mut pollfd, 1, 1_000) };
+            if ready > 0 {
+                assert_ne!(pollfd.revents & libc::POLLIN, 0);
+                return;
+            }
+            if ready == 0 {
+                panic!("persistence worker did not wake runtime within one second");
+            }
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                panic!("runtime wake poll failed: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn real_worker_publishes_completion_before_waking_runtime() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let options = test_options(temp.path().to_path_buf());
+        let (wake, mut controller) = controller_with_wake();
+        controller
+            .try_submit(7, PersistenceOperation::HasArtifacts { options })
+            .unwrap();
+
+        wait_for_runtime_wake(&wake);
+        wake.drain().unwrap();
+        let completion = controller
+            .try_receive()
+            .unwrap()
+            .expect("wake must follow completion publication");
+        assert!(matches!(
+            completion.result.unwrap(),
+            PersistenceOutcome::HasArtifacts(false)
+        ));
+        controller.shutdown(7).unwrap();
+    }
+
+    #[test]
+    fn production_error_completion_wakes_runtime_and_worker_remains_healthy() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let missing = temp.path().join("missing.wayscriber-session");
+        let (wake, mut controller) = controller_with_wake();
+        controller
+            .try_submit(0, PersistenceOperation::ValidateNamedOpen { path: missing })
+            .unwrap();
+
+        wait_for_runtime_wake(&wake);
+        wake.drain().unwrap();
+        let completion = controller.try_receive().unwrap().unwrap();
+        assert!(completion.result.is_err());
+        assert!(controller.is_healthy());
+        controller.shutdown(0).unwrap();
+    }
+
+    #[test]
+    fn worker_panic_closes_completion_channel_before_waking_runtime() {
+        let (wake, mut controller) = controller_with_wake();
+        controller
+            .try_submit(0, PersistenceOperation::PanicForTest)
+            .unwrap();
+
+        wait_for_runtime_wake(&wake);
+        wake.drain().unwrap();
+        let err = controller
+            .try_receive()
+            .expect_err("exit wake must expose the already-closed completion channel");
+        assert!(err.to_string().contains("disconnected"));
+        assert!(!controller.is_healthy());
+        assert!(controller.shutdown(0).is_err());
+        assert!(controller.is_stopped());
+    }
+
+    #[test]
+    fn synchronous_barriers_and_shutdown_tolerate_redundant_unread_wake() {
+        let temp = crate::test_temp::tempdir().unwrap();
+        let options = test_options(temp.path().to_path_buf());
+        let (wake, mut controller) = controller_with_wake();
+
+        assert!(matches!(
+            controller
+                .run(0, PersistenceOperation::HasArtifacts { options })
+                .unwrap(),
+            PersistenceOutcome::HasArtifacts(false)
+        ));
+        controller.shutdown(0).unwrap();
+        assert!(wake.drain().unwrap().reads > 0);
+    }
+
     #[test]
     fn real_worker_executes_production_operation_off_caller_thread() {
         let temp = crate::test_temp::tempdir().unwrap();
         let options = test_options(temp.path().to_path_buf());
-        let mut controller = PersistenceController::start().unwrap();
+        let mut controller = PersistenceController::start_for_test().unwrap();
         controller
             .try_submit(7, PersistenceOperation::HasArtifacts { options })
             .unwrap();
@@ -659,7 +812,7 @@ mod tests {
             boards: Vec::new(),
             tool_state: None,
         };
-        let mut controller = PersistenceController::start().unwrap();
+        let mut controller = PersistenceController::start_for_test().unwrap();
         let outcome = controller
             .run(
                 0,
@@ -694,7 +847,7 @@ mod tests {
         let temp = crate::test_temp::tempdir().unwrap();
         let missing = temp.path().join("missing.wayscriber-session");
         let options = test_options(temp.path().to_path_buf());
-        let mut controller = PersistenceController::start().unwrap();
+        let mut controller = PersistenceController::start_for_test().unwrap();
         assert!(
             controller
                 .run(0, PersistenceOperation::ValidateNamedOpen { path: missing })
@@ -728,7 +881,7 @@ mod tests {
             boards: Vec::new(),
             tool_state: None,
         };
-        let mut controller = PersistenceController::start().unwrap();
+        let mut controller = PersistenceController::start_for_test().unwrap();
 
         assert!(
             controller
@@ -776,7 +929,7 @@ mod tests {
 
         let mut options = test_options(temp.path().to_path_buf());
         options.set_named_file_target(alias_path);
-        let mut controller = PersistenceController::start().unwrap();
+        let mut controller = PersistenceController::start_for_test().unwrap();
         let err = controller
             .run(
                 0,
@@ -799,7 +952,7 @@ mod tests {
         std::fs::write(&current_path, b"{}").unwrap();
         let mut options = test_options(temp.path().to_path_buf());
         options.set_named_file_target(current_path.clone());
-        let mut controller = PersistenceController::start().unwrap();
+        let mut controller = PersistenceController::start_for_test().unwrap();
 
         let outcome = controller
             .run(


### PR DESCRIPTION
## Summary

Replace periodic persistence-completion polling with an event-driven runtime wake mechanism.

- Add an `eventfd`-backed runtime wake source and clonable producer handle.
- Poll the runtime wake descriptor alongside the Wayland connection.
- Wake the event loop after persistence completions are published.
- Wake on persistence-worker exit or panic so failures are observed promptly.
- Remove the recurring 25 ms persistence-completion polling interval.
- Add coverage for wake delivery, coalescing, bounded draining, worker failures, and shutdown behavior.

## Motivation

Persistence completions were previously discovered through a recurring 25 ms event-loop timeout. This added unnecessary idle wakeups and could delay completion handling until the next polling interval.

The new wake descriptor lets the event loop remain asleep until persistence work actually completes.

## Implementation details

- Uses non-blocking, close-on-exec Linux `eventfd`.
- Multiple notifications safely coalesce into one readable wake.
- Persistence results are published before signaling the event loop.
- Worker shutdown closes the completion channel before signaling, allowing disconnects and panics to be observed immediately.
- Wake draining is bounded so the event loop cannot be monopolized.
- Existing Wayland dispatch, animation deadlines, autosave deadlines, and output-transition timeouts remain supported.