### PR TITLE
 Wake daemon and overlay event loops on signal delivery

### DIFF
--- a/src/backend/wayland/backend/event_loop/dispatch.rs
+++ b/src/backend/wayland/backend/event_loop/dispatch.rs
@@ -5,6 +5,8 @@ use wayland_client::{EventQueue, backend::WaylandError};
 use super::super::super::state::WaylandState;
 use super::super::helpers::dispatch_with_timeout;
 use super::super::runtime_wake::RuntimeWakeSource;
+use super::super::signals::OverlaySignalState;
+use super::super::tray::process_tray_action;
 
 trait PersistenceWakeDrain {
     fn drain_woken_persistence(&mut self) -> Result<(), anyhow::Error>;
@@ -20,6 +22,25 @@ fn route_woken_persistence(state: &mut impl PersistenceWakeDrain) {
     if let Err(err) = state.drain_woken_persistence() {
         log::warn!("Failed to apply woken persistence completion: {err}");
     }
+}
+
+fn route_woken_sources(
+    state: &mut WaylandState,
+    signals: &mut OverlaySignalState,
+) -> Result<(), anyhow::Error> {
+    route_woken_persistence(state);
+
+    if signals.exit_requested() {
+        state.input_state.should_exit = true;
+    }
+    let _signal_hint = signals.take_tray_action_requested();
+    if process_tray_action(state) {
+        state.sync_overlay_interactivity();
+    }
+    if let Some(failure) = signals.failure() {
+        return Err(anyhow::anyhow!("overlay signal listener failed: {failure}"));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,6 +104,7 @@ pub(super) fn dispatch_events(
     event_queue: &mut EventQueue<WaylandState>,
     state: &mut WaylandState,
     runtime_wake: &RuntimeWakeSource,
+    signals: &mut OverlaySignalState,
     capture_active: bool,
     animation_timeout: Option<Duration>,
 ) -> Result<(), anyhow::Error> {
@@ -94,7 +116,7 @@ pub(super) fn dispatch_events(
             event_queue,
             state,
             runtime_wake,
-            route_woken_persistence,
+            |state| route_woken_sources(state, signals),
             animation_timeout,
         )
         .map_err(|e| anyhow::anyhow!("Wayland event queue error: {}", e))

--- a/src/backend/wayland/backend/event_loop/dispatch.rs
+++ b/src/backend/wayland/backend/event_loop/dispatch.rs
@@ -50,6 +50,7 @@ enum CaptureReadOutcome {
 }
 
 trait CaptureDispatchOps {
+    fn process_runtime_wake(&mut self) -> Result<(), anyhow::Error>;
     fn dispatch_pending(&mut self) -> Result<(), anyhow::Error>;
     fn flush(&mut self) -> Result<(), anyhow::Error>;
     fn prepare_read(&mut self) -> Result<Option<CaptureReadOutcome>, anyhow::Error>;
@@ -58,9 +59,22 @@ trait CaptureDispatchOps {
 struct RealCaptureDispatchOps<'a> {
     event_queue: &'a mut EventQueue<WaylandState>,
     state: &'a mut WaylandState,
+    runtime_wake: &'a RuntimeWakeSource,
+    signals: &'a mut OverlaySignalState,
 }
 
 impl CaptureDispatchOps for RealCaptureDispatchOps<'_> {
+    fn process_runtime_wake(&mut self) -> Result<(), anyhow::Error> {
+        let drain = self
+            .runtime_wake
+            .drain()
+            .map_err(|err| anyhow::anyhow!("failed to drain runtime wake descriptor: {err}"))?;
+        if drain.reads > 0 {
+            route_woken_sources(self.state, self.signals)?;
+        }
+        Ok(())
+    }
+
     fn dispatch_pending(&mut self) -> Result<(), anyhow::Error> {
         self.event_queue
             .dispatch_pending(self.state)
@@ -90,6 +104,7 @@ impl CaptureDispatchOps for RealCaptureDispatchOps<'_> {
 }
 
 fn dispatch_capture_active(ops: &mut impl CaptureDispatchOps) -> Result<(), anyhow::Error> {
+    ops.process_runtime_wake()?;
     ops.dispatch_pending()?;
     ops.flush()?;
 
@@ -109,7 +124,12 @@ pub(super) fn dispatch_events(
     animation_timeout: Option<Duration>,
 ) -> Result<(), anyhow::Error> {
     if capture_active {
-        let mut ops = RealCaptureDispatchOps { event_queue, state };
+        let mut ops = RealCaptureDispatchOps {
+            event_queue,
+            state,
+            runtime_wake,
+            signals,
+        };
         dispatch_capture_active(&mut ops)
     } else {
         dispatch_with_timeout(
@@ -136,6 +156,7 @@ mod tests {
     use crate::session::SessionOptions;
 
     struct FakeCaptureDispatchOps {
+        runtime_wake_calls: usize,
         dispatch_calls: usize,
         flush_calls: usize,
         prepare_calls: usize,
@@ -147,6 +168,7 @@ mod tests {
     impl FakeCaptureDispatchOps {
         fn new(prepare_result: Result<Option<CaptureReadOutcome>, anyhow::Error>) -> Self {
             Self {
+                runtime_wake_calls: 0,
                 dispatch_calls: 0,
                 flush_calls: 0,
                 prepare_calls: 0,
@@ -158,6 +180,11 @@ mod tests {
     }
 
     impl CaptureDispatchOps for FakeCaptureDispatchOps {
+        fn process_runtime_wake(&mut self) -> Result<(), anyhow::Error> {
+            self.runtime_wake_calls += 1;
+            Ok(())
+        }
+
         fn dispatch_pending(&mut self) -> Result<(), anyhow::Error> {
             self.dispatch_calls += 1;
             if self.dispatch_error_on_call == Some(self.dispatch_calls) {
@@ -191,6 +218,15 @@ mod tests {
         assert_eq!(ops.dispatch_calls, 2);
         assert_eq!(ops.flush_calls, 1);
         assert_eq!(ops.prepare_calls, 1);
+    }
+
+    #[test]
+    fn capture_dispatch_processes_runtime_wake() {
+        let mut ops = FakeCaptureDispatchOps::new(Ok(None));
+
+        dispatch_capture_active(&mut ops).unwrap();
+
+        assert_eq!(ops.runtime_wake_calls, 1);
     }
 
     #[test]

--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -1,20 +1,17 @@
 use crate::notification;
 use log::{info, warn};
-use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 use wayland_client::{Connection, EventQueue};
 
 use super::super::state::WaylandState;
 use super::runtime_wake::RuntimeWakeSource;
-use super::signals::setup_signal_handlers;
+use super::signals::{OverlaySignalState, setup_signal_handlers};
 use super::tray::process_tray_action;
 
 mod capture;
 mod dispatch;
 mod render;
 pub(in crate::backend::wayland) mod session_save;
-
-const TRAY_ACTION_POLL_TIMEOUT: Duration = Duration::from_millis(50);
 
 pub(super) struct EventLoopOutcome {
     pub(super) loop_error: Option<anyhow::Error>,
@@ -36,8 +33,27 @@ pub(super) fn run_event_loop(
     state: &mut WaylandState,
     runtime_wake: &RuntimeWakeSource,
 ) -> EventLoopOutcome {
-    // Gracefully exit the overlay when external signals request termination.
-    let (exit_flag, tray_action_flag) = setup_signal_handlers();
+    let mut loop_error: Option<anyhow::Error> = None;
+    // Install signal authority before the first durable tray-action scan. An
+    // action published before installation is found here; later publications
+    // signal the installed listener and wake the shared runtime descriptor.
+    let mut signals = match install_then_scan(
+        || setup_signal_handlers(runtime_wake.handle()),
+        || {
+            if process_tray_action(state) {
+                state.sync_overlay_interactivity();
+            }
+        },
+    ) {
+        Ok(signals) => Some(signals),
+        Err(err) => {
+            warn!("Failed to register overlay signal handlers: {err}");
+            loop_error = Some(anyhow::anyhow!(
+                "failed to register overlay signal handlers: {err}"
+            ));
+            None
+        }
+    };
 
     // Track consecutive render failures for error recovery.
     let mut consecutive_render_failures = 0u32;
@@ -46,13 +62,16 @@ pub(super) fn run_event_loop(
     let mut last_render_time: Option<Instant> = None;
 
     // Main event loop.
-    let mut loop_error: Option<anyhow::Error> = None;
-    loop {
-        if exit_flag
-            .as_ref()
-            .map(|flag| flag.load(Ordering::Acquire))
-            .unwrap_or(false)
-        {
+    while let Some(signal_state) = signals.as_mut() {
+        if let Some(failure) = terminal_signal_failure(signal_state, || {
+            if process_tray_action(state) {
+                state.sync_overlay_interactivity();
+            }
+        }) {
+            loop_error = Some(failure);
+            break;
+        }
+        if signal_state.exit_requested() {
             state.input_state.should_exit = true;
         }
 
@@ -63,15 +82,6 @@ pub(super) fn run_event_loop(
         }
 
         capture::poll_portal_captures(state);
-
-        if tray_action_flag
-            .as_ref()
-            .map(|flag| flag.swap(false, Ordering::AcqRel))
-            .unwrap_or(false)
-            && process_tray_action(state)
-        {
-            state.sync_overlay_interactivity();
-        }
 
         let capture_active = state.capture.is_in_progress()
             || state.frozen.is_in_progress()
@@ -127,18 +137,19 @@ pub(super) fn run_event_loop(
                 ),
             )
         };
-        let timeout = min_timeout(
-            timeout,
-            tray_action_flag.as_ref().map(|_| TRAY_ACTION_POLL_TIMEOUT),
-        );
         // GTK toolbar events arrive on a channel that cannot wake the
         // Wayland poll, so keep the wait bounded while that frontend runs.
         let timeout = min_timeout(timeout, state.gtk_toolbar_wake_timeout());
         let timeout = min_timeout(timeout, toolbar_handoff_timeout);
         let timeout = min_timeout(timeout, command_palette_repeat_timeout);
-        if let Err(e) =
-            dispatch::dispatch_events(event_queue, state, runtime_wake, capture_active, timeout)
-        {
+        if let Err(e) = dispatch::dispatch_events(
+            event_queue,
+            state,
+            runtime_wake,
+            signal_state,
+            capture_active,
+            timeout,
+        ) {
             warn!("Event queue error: {}", e);
             loop_error = Some(e);
             break;
@@ -148,12 +159,6 @@ pub(super) fn run_event_loop(
             state.reconcile_live_source_interaction_if_idle(
                 "post-dispatch interaction reconciliation",
             );
-        }
-
-        // The timeout above is also a fallback for action signals that arrive before
-        // the overlay has installed its signal handler or do not wake the Wayland poll.
-        if process_tray_action(state) {
-            state.sync_overlay_interactivity();
         }
 
         state.process_gtk_toolbar(conn, qh);
@@ -253,12 +258,59 @@ pub(super) fn run_event_loop(
     state.flush_perf_summaries(Instant::now());
     info!("Wayland backend exiting");
 
-    if let Err(err) = session_save::persist_session(state) {
-        warn!("Failed to save session state: {}", err);
-        session_save::notify_session_failure(state, &err);
-    }
+    finalize_event_loop(
+        &mut loop_error,
+        || {
+            if let Err(err) = session_save::persist_session(state) {
+                warn!("Failed to save session state: {}", err);
+                session_save::notify_session_failure(state, &err);
+            }
+        },
+        || match signals.as_mut() {
+            Some(signal_state) => signal_state.stop_and_join(),
+            None => Ok(()),
+        },
+    );
 
     EventLoopOutcome { loop_error }
+}
+
+fn install_then_scan<T>(
+    install: impl FnOnce() -> std::io::Result<T>,
+    scan: impl FnOnce(),
+) -> std::io::Result<T> {
+    let installed = install()?;
+    scan();
+    Ok(installed)
+}
+
+fn terminal_signal_failure(
+    signals: &OverlaySignalState,
+    preserve_pending_actions: impl FnOnce(),
+) -> Option<anyhow::Error> {
+    signals.failure().map(|failure| {
+        // Durable actions remain authoritative even if their notification
+        // listener has become terminal.
+        preserve_pending_actions();
+        anyhow::anyhow!("overlay signal listener failed: {failure}")
+    })
+}
+
+fn finalize_event_loop(
+    loop_error: &mut Option<anyhow::Error>,
+    persist_final_session: impl FnOnce(),
+    stop_signal_listener: impl FnOnce() -> std::io::Result<()>,
+) {
+    persist_final_session();
+    if let Err(err) = stop_signal_listener() {
+        if loop_error.is_none() {
+            *loop_error = Some(anyhow::anyhow!(
+                "overlay signal listener teardown failed: {err}"
+            ));
+        } else {
+            warn!("Overlay signal listener teardown failed: {err}");
+        }
+    }
 }
 
 fn should_defer_xdg_unfocused_exit(
@@ -272,7 +324,9 @@ fn should_defer_xdg_unfocused_exit(
 
 #[cfg(test)]
 mod tests {
-    use super::should_defer_xdg_unfocused_exit;
+    use std::cell::RefCell;
+
+    use super::{finalize_event_loop, install_then_scan, should_defer_xdg_unfocused_exit};
 
     #[test]
     fn defers_exit_only_for_unfocused_xdg_stay_without_explicit_close() {
@@ -281,5 +335,39 @@ mod tests {
         assert!(!should_defer_xdg_unfocused_exit(true, false, false, false));
         assert!(!should_defer_xdg_unfocused_exit(false, true, false, false));
         assert!(!should_defer_xdg_unfocused_exit(true, true, false, true));
+    }
+
+    #[test]
+    fn listener_is_installed_before_the_startup_action_scan() {
+        let calls = RefCell::new(Vec::new());
+        let installed = install_then_scan(
+            || {
+                calls.borrow_mut().push("install");
+                Ok(7)
+            },
+            || calls.borrow_mut().push("scan"),
+        )
+        .unwrap();
+
+        assert_eq!(installed, 7);
+        assert_eq!(calls.into_inner(), ["install", "scan"]);
+    }
+
+    #[test]
+    fn final_save_precedes_owned_listener_teardown_after_failure() {
+        let calls = RefCell::new(Vec::new());
+        let mut loop_error = Some(anyhow::anyhow!("listener failed"));
+
+        finalize_event_loop(
+            &mut loop_error,
+            || calls.borrow_mut().push("final-save"),
+            || {
+                calls.borrow_mut().push("listener-stop");
+                Ok(())
+            },
+        );
+
+        assert_eq!(calls.into_inner(), ["final-save", "listener-stop"]);
+        assert_eq!(loop_error.unwrap().to_string(), "listener failed");
     }
 }

--- a/src/backend/wayland/backend/helpers.rs
+++ b/src/backend/wayland/backend/helpers.rs
@@ -223,7 +223,7 @@ trait RuntimeDispatchOps {
         &mut self,
         timeout: Option<Duration>,
     ) -> Result<Option<RuntimeReadOutcome>>;
-    fn process_runtime_wake(&mut self);
+    fn process_runtime_wake(&mut self) -> Result<()>;
 }
 
 fn dispatch_runtime_cycle(
@@ -246,7 +246,7 @@ fn dispatch_runtime_cycle(
             );
         }
         if outcome.wake_drain.is_some() {
-            ops.process_runtime_wake();
+            ops.process_runtime_wake()?;
         }
         if outcome.wayland_read {
             ops.dispatch_pending()?;
@@ -265,7 +265,7 @@ struct RealRuntimeDispatchOps<'a, F> {
 
 impl<F> RuntimeDispatchOps for RealRuntimeDispatchOps<'_, F>
 where
-    F: FnMut(&mut WaylandState),
+    F: FnMut(&mut WaylandState) -> Result<()>,
 {
     fn dispatch_pending(&mut self) -> Result<usize> {
         self.event_queue
@@ -293,8 +293,8 @@ where
             .transpose()
     }
 
-    fn process_runtime_wake(&mut self) {
-        (self.on_runtime_wake)(self.state);
+    fn process_runtime_wake(&mut self) -> Result<()> {
+        (self.on_runtime_wake)(self.state)
     }
 }
 
@@ -302,7 +302,7 @@ pub(super) fn dispatch_with_timeout(
     event_queue: &mut EventQueue<WaylandState>,
     state: &mut WaylandState,
     runtime_wake: &RuntimeWakeSource,
-    on_runtime_wake: impl FnMut(&mut WaylandState),
+    on_runtime_wake: impl FnMut(&mut WaylandState) -> Result<()>,
     timeout: Option<Duration>,
 ) -> Result<()> {
     let mut ops = RealRuntimeDispatchOps {
@@ -551,8 +551,9 @@ mod tests {
             Ok(self.prepared_outcome)
         }
 
-        fn process_runtime_wake(&mut self) {
+        fn process_runtime_wake(&mut self) -> Result<()> {
             self.calls.push(DispatchCall::ProcessRuntimeWake);
+            Ok(())
         }
     }
 

--- a/src/backend/wayland/backend/mod.rs
+++ b/src/backend/wayland/backend/mod.rs
@@ -8,7 +8,7 @@ use crate::backend::ExitAfterCaptureMode;
 pub(in crate::backend::wayland) mod event_loop;
 mod helpers;
 mod run;
-pub(in crate::backend::wayland) mod runtime_wake;
+pub(crate) mod runtime_wake;
 mod setup;
 mod signals;
 mod state_init;

--- a/src/backend/wayland/backend/runtime_wake.rs
+++ b/src/backend/wayland/backend/runtime_wake.rs
@@ -2,26 +2,26 @@ use std::io;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use std::sync::Arc;
 
-pub(in crate::backend::wayland) const MAX_WAKE_DRAIN_READS: usize = 8;
+pub(crate) const MAX_WAKE_DRAIN_READS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::backend::wayland) struct RuntimeWakeDrain {
-    pub(in crate::backend::wayland) reads: usize,
-    pub(in crate::backend::wayland) limit_reached: bool,
+pub(crate) struct RuntimeWakeDrain {
+    pub(crate) reads: usize,
+    pub(crate) limit_reached: bool,
 }
 
 #[derive(Debug)]
-pub(in crate::backend::wayland) struct RuntimeWakeSource {
+pub(crate) struct RuntimeWakeSource {
     fd: Arc<OwnedFd>,
 }
 
 #[derive(Clone, Debug)]
-pub(in crate::backend::wayland) struct RuntimeWakeHandle {
+pub(crate) struct RuntimeWakeHandle {
     fd: Arc<OwnedFd>,
 }
 
 impl RuntimeWakeSource {
-    pub(in crate::backend::wayland) fn new() -> io::Result<Self> {
+    pub(crate) fn new() -> io::Result<Self> {
         // SAFETY: eventfd returns a new owned descriptor on success. EFD_NONBLOCK
         // keeps both producer writes and consumer drains bounded, and EFD_CLOEXEC
         // prevents subprocesses from extending the runtime descriptor lifetime.
@@ -34,17 +34,17 @@ impl RuntimeWakeSource {
         Ok(Self { fd: Arc::new(fd) })
     }
 
-    pub(in crate::backend::wayland) fn poll_fd(&self) -> BorrowedFd<'_> {
+    pub(crate) fn poll_fd(&self) -> BorrowedFd<'_> {
         self.fd.as_fd()
     }
 
-    pub(in crate::backend::wayland) fn handle(&self) -> RuntimeWakeHandle {
+    pub(crate) fn handle(&self) -> RuntimeWakeHandle {
         RuntimeWakeHandle {
             fd: Arc::clone(&self.fd),
         }
     }
 
-    pub(in crate::backend::wayland) fn drain(&self) -> io::Result<RuntimeWakeDrain> {
+    pub(crate) fn drain(&self) -> io::Result<RuntimeWakeDrain> {
         self.drain_with_limit(MAX_WAKE_DRAIN_READS)
     }
 
@@ -92,7 +92,7 @@ impl RuntimeWakeSource {
 }
 
 impl RuntimeWakeHandle {
-    pub(in crate::backend::wayland) fn wake(&self) -> io::Result<()> {
+    pub(crate) fn wake(&self) -> io::Result<()> {
         let value = 1_u64;
         loop {
             // SAFETY: value points to a readable u64 and the shared eventfd remains

--- a/src/backend/wayland/backend/signals.rs
+++ b/src/backend/wayland/backend/signals.rs
@@ -1,50 +1,166 @@
-#[cfg(unix)]
-use libc::{SIGINT, SIGTERM, SIGUSR1, SIGUSR2};
+use std::io;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 
-pub(super) fn setup_signal_handlers() -> (Option<Arc<AtomicBool>>, Option<Arc<AtomicBool>>) {
-    // Gracefully exit the overlay when external signals request termination
+#[cfg(unix)]
+use libc::{SIGINT, SIGTERM, SIGUSR1, SIGUSR2};
+
+use super::runtime_wake::RuntimeWakeHandle;
+
+pub(super) struct OverlaySignalState {
+    exit_requested: Arc<AtomicBool>,
+    tray_action_requested: Arc<AtomicBool>,
     #[cfg(unix)]
-    {
-        let exit_flag = Arc::new(AtomicBool::new(false));
-        let tray_action_flag = Arc::new(AtomicBool::new(false));
-        let signal_exit_flag = Arc::clone(&exit_flag);
-        let signal_tray_action_flag = Arc::clone(&tray_action_flag);
-        match crate::unix_signals::spawn_listener(
-            &[SIGTERM, SIGINT, SIGUSR1, SIGUSR2],
-            move |sig| {
-                match sig {
-                    SIGUSR1 => {
-                        // SIGUSR1 is reserved for daemon toggle; ignore in overlay.
-                        log::debug!("Overlay received SIGUSR1; ignoring");
-                    }
-                    SIGUSR2 => {
-                        log::debug!("Overlay received SIGUSR2 for tray action");
-                        signal_tray_action_flag.store(true, Ordering::Release);
-                    }
-                    _ => {
-                        log::debug!(
-                            "Overlay received signal {}; scheduling graceful shutdown",
-                            sig
-                        );
-                        signal_exit_flag.store(true, Ordering::Release);
-                    }
+    listener: crate::unix_signals::SignalListener,
+}
+
+impl OverlaySignalState {
+    pub(super) fn exit_requested(&self) -> bool {
+        self.exit_requested.load(Ordering::Acquire)
+    }
+
+    pub(super) fn take_tray_action_requested(&self) -> bool {
+        self.tray_action_requested.swap(false, Ordering::AcqRel)
+    }
+
+    pub(super) fn failure(&self) -> Option<String> {
+        #[cfg(unix)]
+        {
+            match self.listener.health() {
+                crate::unix_signals::SignalListenerHealth::Failed(failure) => {
+                    Some(failure.to_string())
                 }
-            },
-        ) {
-            Ok(_) => (Some(exit_flag), Some(tray_action_flag)),
-            Err(err) => {
-                log::warn!("Failed to register overlay signal handlers: {}", err);
-                (Some(exit_flag), Some(tray_action_flag))
+                _ => None,
             }
         }
+
+        #[cfg(not(unix))]
+        {
+            None
+        }
+    }
+
+    pub(super) fn stop_and_join(&mut self) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            let failure = self.failure();
+            self.listener.stop_and_join()?;
+            match failure {
+                Some(failure) => Err(io::Error::other(format!(
+                    "overlay signal listener failed before teardown: {failure}"
+                ))),
+                None => Ok(()),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            Ok(())
+        }
+    }
+}
+
+pub(super) fn setup_signal_handlers(
+    runtime_wake: RuntimeWakeHandle,
+) -> io::Result<OverlaySignalState> {
+    let exit_requested = Arc::new(AtomicBool::new(false));
+    let tray_action_requested = Arc::new(AtomicBool::new(false));
+
+    #[cfg(unix)]
+    {
+        let signal_exit_requested = Arc::clone(&exit_requested);
+        let signal_tray_action_requested = Arc::clone(&tray_action_requested);
+        let listener_wake = runtime_wake;
+        let listener = crate::unix_signals::spawn_listener(
+            &[SIGTERM, SIGINT, SIGUSR1, SIGUSR2],
+            move |signal| match signal {
+                SIGUSR1 => {
+                    // SIGUSR1 is reserved for daemon toggle; ignore in overlay.
+                    log::debug!("Overlay received SIGUSR1; ignoring");
+                }
+                SIGUSR2 => {
+                    log::debug!("Overlay received SIGUSR2 for tray action");
+                    signal_tray_action_requested.store(true, Ordering::Release);
+                }
+                _ => {
+                    log::debug!("Overlay received signal {signal}; scheduling graceful shutdown");
+                    signal_exit_requested.store(true, Ordering::Release);
+                }
+            },
+            move || {
+                if let Err(err) = listener_wake.wake() {
+                    log::warn!("Failed to wake overlay after signal publication: {err}");
+                }
+            },
+        )?;
+
+        Ok(OverlaySignalState {
+            exit_requested,
+            tray_action_requested,
+            listener,
+        })
     }
 
     #[cfg(not(unix))]
     {
-        (None, None)
+        let _ = runtime_wake;
+        Ok(OverlaySignalState {
+            exit_requested,
+            tray_action_requested,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+
+    use super::*;
+    use crate::backend::wayland::RuntimeWakeSource;
+
+    fn wait_for_wake(source: &RuntimeWakeSource) {
+        let mut pollfd = libc::pollfd {
+            fd: source.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: source retains the descriptor throughout this bounded wait.
+        let ready = unsafe { libc::poll(&mut pollfd, 1, 1_000) };
+        assert_eq!(ready, 1);
+        assert_ne!(pollfd.revents & libc::POLLIN, 0);
+        source.drain().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tray_signal_publishes_state_then_wakes_overlay_owner() {
+        let _guard = crate::unix_signals::test_signal_lock();
+        let wake = RuntimeWakeSource::new().unwrap();
+        let mut signals = setup_signal_handlers(wake.handle()).unwrap();
+
+        crate::unix_signals::deliver_signal_for_test(SIGUSR2);
+        wait_for_wake(&wake);
+
+        assert!(signals.take_tray_action_requested());
+        assert!(signals.failure().is_none());
+        signals.stop_and_join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn listener_failure_is_published_before_overlay_owner_wake() {
+        let _guard = crate::unix_signals::test_signal_lock();
+        let wake = RuntimeWakeSource::new().unwrap();
+        let mut signals = setup_signal_handlers(wake.handle()).unwrap();
+
+        signals.listener.inject_read_error(libc::EIO);
+        wait_for_wake(&wake);
+
+        let failure = signals.failure().expect("listener failure");
+        assert!(failure.contains("os error Some(5)"), "{failure}");
+        let stop_err = signals.stop_and_join().unwrap_err();
+        assert!(stop_err.to_string().contains("failed before teardown"));
     }
 }

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -7,7 +7,6 @@ use super::super::state::{WaylandState, WaylandStateInit};
 use super::WaylandBackend;
 use super::runtime_wake::RuntimeWakeSource;
 use super::setup::WaylandSetup;
-use super::tray::process_tray_action;
 use crate::backend::wayland::portal_capture::screenshot_portal_available;
 use crate::env_vars::{DESKTOP_SESSION_ENV, XDG_CURRENT_DESKTOP_ENV, XDG_SESSION_DESKTOP_ENV};
 use crate::{
@@ -151,9 +150,6 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
     state.spawn_gtk_toolbar_if_selected();
     // Ensure pinned toolbars are created immediately if visible on startup.
     state.sync_toolbar_visibility(&setup.qh);
-    // Process any pending tray action that may have been queued before overlay start.
-    process_tray_action(&mut state);
-
     Ok(BackendRuntime {
         conn: setup.conn,
         event_queue: setup.event_queue,

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -25,5 +25,6 @@ pub(crate) use toolbar::view::top::{TopStripPlan, plan_top_strip};
 mod zoom;
 
 pub use backend::WaylandBackend;
+pub(crate) use backend::runtime_wake::RuntimeWakeSource;
 #[cfg(tablet)]
 pub use tablet_types::TabletToolType;

--- a/src/daemon/control/tests.rs
+++ b/src/daemon/control/tests.rs
@@ -2,9 +2,6 @@ use super::*;
 use crate::paths::daemon_pid_file;
 use std::env;
 use std::fs;
-use std::sync::Mutex;
-
-static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
 #[test]
 fn empty_toggle_request_reports_empty() {
@@ -202,9 +199,7 @@ fn daemon_toggle_response_parse_error_marks_existing_request_canceled() {
 
 #[test]
 fn daemon_pid_file_round_trips_runtime_info() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -226,9 +221,7 @@ fn daemon_pid_file_round_trips_runtime_info() {
 
 #[test]
 fn stale_cleanup_removes_matching_runtime_while_lock_is_free() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -262,9 +255,7 @@ fn stale_cleanup_removes_matching_runtime_while_lock_is_free() {
 
 #[test]
 fn stale_cleanup_preserves_mismatched_runtime() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -301,9 +292,7 @@ fn stale_cleanup_preserves_mismatched_runtime() {
 
 #[test]
 fn take_daemon_toggle_request_round_trips_payload() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -350,9 +339,7 @@ fn take_daemon_toggle_request_round_trips_payload() {
 
 #[test]
 fn write_daemon_toggle_request_queues_multiple_files_without_leaking_temp_files() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -393,9 +380,7 @@ fn write_daemon_toggle_request_queues_multiple_files_without_leaking_temp_files(
 
 #[test]
 fn take_daemon_toggle_request_drains_multiple_payloads_in_order() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -436,9 +421,7 @@ fn take_daemon_toggle_request_drains_multiple_payloads_in_order() {
 
 #[test]
 fn take_daemon_toggle_request_ignores_mismatched_token() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -469,9 +452,7 @@ fn take_daemon_toggle_request_ignores_mismatched_token() {
 
 #[test]
 fn take_daemon_toggle_request_ignores_stale_payload() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {
@@ -503,9 +484,7 @@ fn take_daemon_toggle_request_ignores_stale_payload() {
 
 #[test]
 fn take_daemon_toggle_request_ignores_canceled_payload_but_marks_typed_signal() {
-    let _guard = ENV_MUTEX
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let _guard = crate::test_env::lock();
     let tmp = crate::test_temp::tempdir().unwrap();
     let prev = env::var_os(XDG_RUNTIME_DIR_ENV);
     unsafe {

--- a/src/daemon/core.rs
+++ b/src/daemon/core.rs
@@ -3,15 +3,18 @@ use log::{info, warn};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::ErrorKind;
+use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
+#[cfg(test)]
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+use crate::backend::wayland::RuntimeWakeSource;
 use crate::env_vars::NO_TRAY_ENV;
 use crate::paths::daemon_lock_file;
 use crate::session::try_lock_exclusive;
@@ -38,6 +41,9 @@ use super::types::{AlreadyRunningError, BackendRunner, OverlayState};
 // Suppress only duplicate plain toggles after a successful toggle completes, so
 // typed requests still run.
 const DUPLICATE_SHORTCUT_SUPPRESSION_WINDOW: Duration = Duration::from_millis(700);
+// This remains a real child/process/tray lifecycle deadline. Signal delivery
+// and signal-listener failure independently wake the daemon control owner.
+const DAEMON_LIFECYCLE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 mod toggles;
 
@@ -66,6 +72,8 @@ pub struct Daemon {
     pub(super) overlay_spawn_next_retry: Option<std::time::Instant>,
     pub(super) overlay_spawn_backoff_logged: bool,
     pub(super) last_plain_visibility_toggle_completed_at: Option<Instant>,
+    #[cfg(unix)]
+    signal_listener: Option<crate::unix_signals::SignalListener>,
     #[cfg(feature = "tray")]
     pub(super) tray_status: Arc<TrayStatusShared>,
 }
@@ -105,6 +113,8 @@ impl Daemon {
             overlay_spawn_next_retry: None,
             overlay_spawn_backoff_logged: false,
             last_plain_visibility_toggle_completed_at: None,
+            #[cfg(unix)]
+            signal_listener: None,
             #[cfg(feature = "tray")]
             tray_status: Arc::new(TrayStatusShared::new()),
         }
@@ -141,6 +151,8 @@ impl Daemon {
             overlay_spawn_next_retry: None,
             overlay_spawn_backoff_logged: false,
             last_plain_visibility_toggle_completed_at: None,
+            #[cfg(unix)]
+            signal_listener: None,
             #[cfg(feature = "tray")]
             tray_status: Arc::new(TrayStatusShared::new()),
         }
@@ -237,46 +249,62 @@ impl Daemon {
         let signal_toggle_flag = self.signal_toggle_requested.clone();
         let quit_flag = self.should_quit.clone();
 
-        // The signal listener thread runs until process termination. The daemon
-        // exits shortly after quit signals, and the OS cleans up the detached thread.
+        let daemon_wake =
+            RuntimeWakeSource::new().context("Failed to create daemon control wake descriptor")?;
+
         #[cfg(unix)]
-        crate::unix_signals::spawn_listener(&DAEMON_SIGNALS, move |sig| {
-            if quit_flag.load(Ordering::Acquire) {
-                info!("Signal handler thread exiting");
-                return;
-            }
-            match sig {
-                libc::SIGUSR1 => {
-                    info!("Received SIGUSR1 - toggling overlay");
-                    // Use Release ordering to ensure all prior memory operations
-                    // are visible to the thread that reads this flag
-                    signal_toggle_flag.store(true, Ordering::Release);
-                    toggle_flag.store(true, Ordering::Release);
-                }
-                libc::SIGTERM | libc::SIGINT => {
-                    info!(
-                        "Received {} - initiating graceful shutdown",
-                        if sig == libc::SIGTERM {
-                            "SIGTERM"
-                        } else {
-                            "SIGINT"
+        {
+            let listener_wake = daemon_wake.handle();
+            self.signal_listener = Some(
+                crate::unix_signals::spawn_listener(
+                    &DAEMON_SIGNALS,
+                    move |sig| {
+                        if quit_flag.load(Ordering::Acquire) {
+                            return;
                         }
-                    );
-                    // Use Release ordering to ensure all prior memory operations
-                    // are visible to the thread that reads this flag
-                    quit_flag.store(true, Ordering::Release);
-                }
-                _ => {
-                    warn!("Received unexpected signal: {}", sig);
-                }
-            }
-        })
-        .context("Failed to register signal handler")?;
+                        match sig {
+                            libc::SIGUSR1 => {
+                                info!("Received SIGUSR1 - toggling overlay");
+                                signal_toggle_flag.store(true, Ordering::Release);
+                                toggle_flag.store(true, Ordering::Release);
+                            }
+                            libc::SIGTERM | libc::SIGINT => {
+                                info!(
+                                    "Received {} - initiating graceful shutdown",
+                                    if sig == libc::SIGTERM {
+                                        "SIGTERM"
+                                    } else {
+                                        "SIGINT"
+                                    }
+                                );
+                                quit_flag.store(true, Ordering::Release);
+                            }
+                            _ => warn!("Received unexpected signal: {sig}"),
+                        }
+                    },
+                    move || {
+                        if let Err(err) = listener_wake.wake() {
+                            warn!("Failed to wake daemon after signal publication: {err}");
+                        }
+                    },
+                )
+                .context("Failed to register signal handler")?,
+            );
+        }
 
         // Only publish the pid after SIGUSR1 is handled. A racing
         // `--daemon-toggle` sends SIGUSR1 to this pid, and the default action
         // before handler installation would terminate the daemon.
-        crate::daemon::write_daemon_pid_file(std::process::id(), &self.instance_token)?;
+        if let Err(err) =
+            crate::daemon::write_daemon_pid_file(std::process::id(), &self.instance_token)
+        {
+            if let Err(stop_err) = self.stop_signal_listener() {
+                warn!(
+                    "Failed to stop signal listener after readiness publication error: {stop_err}"
+                );
+            }
+            return Err(err);
+        }
 
         // Start system tray (optional)
         if self.tray_enabled {
@@ -325,8 +353,27 @@ impl Daemon {
 
         info!("Daemon ready - waiting for toggle signal");
 
-        // Main daemon loop
+        let run_result = self.run_control_loop_and_invalidate_on_failure(&daemon_wake);
+        let cleanup_result = self.shutdown_after_run();
+        run_result.and(cleanup_result)
+    }
+
+    fn run_control_loop_and_invalidate_on_failure(
+        &mut self,
+        daemon_wake: &RuntimeWakeSource,
+    ) -> Result<()> {
+        let result = self.run_control_loop(daemon_wake);
+        if result.is_err()
+            && let Err(err) = crate::daemon::clear_daemon_pid_file()
+        {
+            warn!("Failed to invalidate daemon readiness after runtime failure: {err}");
+        }
+        result
+    }
+
+    fn run_control_loop(&mut self, daemon_wake: &RuntimeWakeSource) -> Result<()> {
         loop {
+            self.ensure_signal_listener_healthy()?;
             self.update_overlay_process_state()?;
 
             // Check for quit signal
@@ -358,10 +405,12 @@ impl Daemon {
                 }
             }
 
-            // Small sleep to avoid busy-waiting
-            thread::sleep(Duration::from_millis(100));
+            wait_for_daemon_lifecycle(daemon_wake)?;
         }
+        Ok(())
+    }
 
+    fn shutdown_after_run(&mut self) -> Result<()> {
         info!("Daemon shutting down");
         // Ensure overlay is stopped before exit
         if let Err(err) = self.hide_overlay() {
@@ -386,7 +435,86 @@ impl Daemon {
         if let Err(err) = crate::daemon::clear_daemon_pid_file() {
             warn!("Failed to clear daemon pid file: {}", err);
         }
+        self.stop_signal_listener()
+    }
+
+    fn ensure_signal_listener_healthy(&self) -> Result<()> {
+        #[cfg(unix)]
+        {
+            let listener = self
+                .signal_listener
+                .as_ref()
+                .context("daemon signal listener is not installed")?;
+            match listener.health() {
+                crate::unix_signals::SignalListenerHealth::Running => Ok(()),
+                crate::unix_signals::SignalListenerHealth::Failed(failure) => {
+                    Err(anyhow::anyhow!("daemon signal listener failed: {failure}"))
+                }
+                health => Err(anyhow::anyhow!(
+                    "daemon signal listener stopped unexpectedly: {health:?}"
+                )),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            Ok(())
+        }
+    }
+
+    fn stop_signal_listener(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        if let Some(mut listener) = self.signal_listener.take() {
+            let failure = match listener.health() {
+                crate::unix_signals::SignalListenerHealth::Failed(failure) => Some(failure),
+                _ => None,
+            };
+            listener
+                .stop_and_join()
+                .context("failed to stop daemon signal listener")?;
+            if let Some(failure) = failure {
+                return Err(anyhow::anyhow!(
+                    "daemon signal listener failed before teardown: {failure}"
+                ));
+            }
+        }
         Ok(())
+    }
+}
+
+fn wait_for_daemon_lifecycle(daemon_wake: &RuntimeWakeSource) -> Result<()> {
+    let mut pollfd = libc::pollfd {
+        fd: daemon_wake.poll_fd().as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let deadline = Instant::now() + DAEMON_LIFECYCLE_POLL_INTERVAL;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+        // SAFETY: the descriptor remains owned by `daemon_wake` throughout poll.
+        let ready = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if ready == 0 {
+            return Ok(());
+        }
+        if ready < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err).context("daemon lifecycle poll failed");
+        }
+        let terminal = pollfd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL);
+        if terminal != 0 || pollfd.revents & libc::POLLIN == 0 {
+            return Err(anyhow::anyhow!(
+                "daemon wake descriptor returned invalid readiness {:#x}",
+                pollfd.revents
+            ));
+        }
+        daemon_wake
+            .drain()
+            .context("failed to drain daemon wake descriptor")?;
+        return Ok(());
     }
 }
 

--- a/src/daemon/core/tests.rs
+++ b/src/daemon/core/tests.rs
@@ -1,6 +1,54 @@
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
+#[cfg(unix)]
+#[test]
+fn listener_failure_invalidates_v1_readiness_and_runs_existing_cleanup() {
+    let _signal_guard = crate::unix_signals::test_signal_lock();
+    let _env_guard = crate::test_env::lock();
+    let temp = crate::test_temp::tempdir().unwrap();
+    let previous_runtime_dir = std::env::var_os(crate::env_vars::XDG_RUNTIME_DIR_ENV);
+    // SAFETY: this test holds the process environment mutex.
+    unsafe {
+        std::env::set_var(crate::env_vars::XDG_RUNTIME_DIR_ENV, temp.path());
+    }
+
+    let wake = RuntimeWakeSource::new().unwrap();
+    let wake_handle = wake.handle();
+    let listener = crate::unix_signals::spawn_listener(
+        &[libc::SIGWINCH],
+        |_| {},
+        move || wake_handle.wake().unwrap(),
+    )
+    .unwrap();
+    listener.inject_read_error(libc::EIO);
+    wait_for_daemon_lifecycle(&wake).unwrap();
+
+    let mut daemon = Daemon::new(None, false, None, None);
+    daemon.signal_listener = Some(listener);
+    crate::daemon::write_daemon_pid_file(std::process::id(), &daemon.instance_token).unwrap();
+    assert!(crate::paths::daemon_pid_file().exists());
+
+    let err = daemon
+        .run_control_loop_and_invalidate_on_failure(&wake)
+        .unwrap_err();
+    assert!(err.to_string().contains("daemon signal listener failed"));
+    assert!(!crate::paths::daemon_pid_file().exists());
+
+    let cleanup_err = daemon.shutdown_after_run().unwrap_err();
+    assert!(cleanup_err.to_string().contains("failed before teardown"));
+    assert!(daemon.signal_listener.is_none());
+    assert!(daemon.should_quit.load(Ordering::Acquire));
+
+    // SAFETY: this test still holds the process environment mutex.
+    unsafe {
+        match previous_runtime_dir {
+            Some(value) => std::env::set_var(crate::env_vars::XDG_RUNTIME_DIR_ENV, value),
+            None => std::env::remove_var(crate::env_vars::XDG_RUNTIME_DIR_ENV),
+        }
+    }
+}
+
 #[test]
 fn light_draw_off_request_does_not_show_hidden_overlay() {
     let called = Arc::new(AtomicUsize::new(0));

--- a/src/unix_signals.rs
+++ b/src/unix_signals.rs
@@ -1,81 +1,58 @@
 use std::io;
-use std::os::fd::RawFd;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
-use std::thread::{self, JoinHandle};
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
+
+mod listener;
+
+#[cfg(test)]
+pub(crate) use listener::SignalListenerFailure;
+pub(crate) use listener::{SignalListener, SignalListenerHealth, spawn_listener};
 
 const MAX_SIGNAL_SLOTS: usize = 8;
+const GATE_STATE_BITS: u32 = 2;
+const GATE_STATE_MASK: u64 = (1 << GATE_STATE_BITS) - 1;
+const GATE_INACTIVE: u64 = 0;
+const GATE_ACTIVE: u64 = 1;
+const GATE_STOPPING: u64 = 2;
+const GATE_SETTING_UP: u64 = 3;
+const MAX_GATE_EPOCH: u64 = u64::MAX >> GATE_STATE_BITS;
 
+#[cfg(not(target_has_atomic = "64"))]
+compile_error!("wayscriber signal handling requires lock-free 64-bit atomics");
+#[cfg(not(target_has_atomic = "ptr"))]
+compile_error!("wayscriber signal handling requires lock-free pointer-sized atomics");
+#[cfg(not(target_has_atomic = "32"))]
+compile_error!("wayscriber signal handling requires lock-free 32-bit atomics");
+#[cfg(not(target_has_atomic = "8"))]
+compile_error!("wayscriber signal handling requires lock-free 8-bit atomics");
+
+static HANDLER_GATE_TOKEN: AtomicU64 = AtomicU64::new(GATE_INACTIVE);
+static ACTIVE_HANDLERS: AtomicUsize = AtomicUsize::new(0);
 static SIGNAL_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
-static LISTENER_ACTIVE: AtomicBool = AtomicBool::new(false);
 static REGISTERED_SIGNALS: [AtomicI32; MAX_SIGNAL_SLOTS] =
     [const { AtomicI32::new(0) }; MAX_SIGNAL_SLOTS];
-static PENDING_SIGNALS: [AtomicUsize; MAX_SIGNAL_SLOTS] =
-    [const { AtomicUsize::new(0) }; MAX_SIGNAL_SLOTS];
+static PENDING_SIGNALS: [std::sync::atomic::AtomicBool; MAX_SIGNAL_SLOTS] =
+    [const { std::sync::atomic::AtomicBool::new(false) }; MAX_SIGNAL_SLOTS];
 
-pub(crate) fn spawn_listener<F>(signals: &[libc::c_int], on_signal: F) -> io::Result<JoinHandle<()>>
-where
-    F: Fn(libc::c_int) + Send + 'static,
-{
+fn gate_token(epoch: u64, state: u64) -> u64 {
+    (epoch << GATE_STATE_BITS) | state
+}
+
+fn gate_epoch(token: u64) -> u64 {
+    token >> GATE_STATE_BITS
+}
+
+fn gate_state(token: u64) -> u64 {
+    token & GATE_STATE_MASK
+}
+
+fn validate_signals(signals: &[libc::c_int]) -> io::Result<()> {
     if signals.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "at least one signal must be registered",
         ));
     }
-
-    // This lightweight signal bridge intentionally owns the process handlers for
-    // the requested signals rather than chaining prior handlers. Keep a single
-    // listener per process so signal delivery stays deterministic.
-    if LISTENER_ACTIVE.swap(true, Ordering::AcqRel) {
-        return Err(io::Error::new(
-            io::ErrorKind::AlreadyExists,
-            "a signal listener is already active",
-        ));
-    }
-
-    if let Err(err) = register_signals(signals) {
-        LISTENER_ACTIVE.store(false, Ordering::Release);
-        return Err(err);
-    }
-
-    let (read_fd, write_fd) = match create_pipe() {
-        Ok(pipe) => pipe,
-        Err(err) => {
-            clear_registered_signals();
-            LISTENER_ACTIVE.store(false, Ordering::Release);
-            return Err(err);
-        }
-    };
-
-    SIGNAL_WRITE_FD.store(write_fd, Ordering::Release);
-
-    let mut installed_handlers = Vec::with_capacity(signals.len());
-    for &signal in signals {
-        match install_handler(signal) {
-            Ok(previous) => installed_handlers.push((signal, previous)),
-            Err(err) => {
-                restore_handlers(&installed_handlers);
-                SIGNAL_WRITE_FD.store(-1, Ordering::Release);
-                clear_registered_signals();
-                close_fd(read_fd);
-                close_fd(write_fd);
-                LISTENER_ACTIVE.store(false, Ordering::Release);
-                return Err(err);
-            }
-        }
-    }
-
-    Ok(thread::spawn(move || read_signal_loop(read_fd, on_signal)))
-}
-
-fn restore_handlers(handlers: &[(libc::c_int, libc::sigaction)]) {
-    for (signal, previous) in handlers.iter().rev() {
-        // SAFETY: `previous` was returned by `sigaction` for the same signal.
-        let _ = unsafe { libc::sigaction(*signal, previous, std::ptr::null_mut()) };
-    }
-}
-
-fn register_signals(signals: &[libc::c_int]) -> io::Result<()> {
     if signals.len() > MAX_SIGNAL_SLOTS {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -83,37 +60,98 @@ fn register_signals(signals: &[libc::c_int]) -> io::Result<()> {
         ));
     }
 
-    clear_registered_signals();
     for (index, &signal) in signals.iter().enumerate() {
         if signal <= 0 {
-            clear_registered_signals();
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "signal numbers must be positive",
             ));
         }
         if signals[..index].contains(&signal) {
-            clear_registered_signals();
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "duplicate signals are not supported",
             ));
         }
+    }
+    Ok(())
+}
 
+fn reserve_listener_epoch() -> io::Result<u64> {
+    loop {
+        let current = HANDLER_GATE_TOKEN.load(Ordering::Acquire);
+        if gate_state(current) != GATE_INACTIVE || ACTIVE_HANDLERS.load(Ordering::Acquire) != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "a signal listener is already active",
+            ));
+        }
+        let epoch = gate_epoch(current)
+            .checked_add(1)
+            .filter(|epoch| *epoch <= MAX_GATE_EPOCH)
+            .ok_or_else(|| io::Error::other("signal listener epoch space exhausted"))?;
+        let setting_up = gate_token(epoch, GATE_SETTING_UP);
+        match HANDLER_GATE_TOKEN.compare_exchange(
+            current,
+            setting_up,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return Ok(epoch),
+            Err(_) => continue,
+        }
+    }
+}
+
+fn publish_listener_active(epoch: u64) {
+    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_ACTIVE), Ordering::Release);
+}
+
+fn rollback_listener_reservation(epoch: u64) {
+    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_INACTIVE), Ordering::Release);
+}
+
+fn begin_listener_teardown(epoch: u64) -> io::Result<()> {
+    HANDLER_GATE_TOKEN
+        .compare_exchange(
+            gate_token(epoch, GATE_ACTIVE),
+            gate_token(epoch, GATE_STOPPING),
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )
+        .map(|_| ())
+        .map_err(|actual| {
+            io::Error::other(format!(
+                "signal listener gate changed unexpectedly during teardown ({actual:#x})"
+            ))
+        })
+}
+
+fn finish_listener_teardown(epoch: u64) {
+    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_INACTIVE), Ordering::Release);
+}
+
+fn wait_for_admitted_handlers() {
+    while ACTIVE_HANDLERS.load(Ordering::Acquire) != 0 {
+        std::thread::yield_now();
+    }
+}
+
+fn publish_registered_signals(signals: &[libc::c_int]) {
+    clear_registered_signals();
+    for (index, &signal) in signals.iter().enumerate() {
         REGISTERED_SIGNALS[index].store(signal, Ordering::Release);
     }
-
-    Ok(())
 }
 
 fn clear_registered_signals() {
     for index in 0..MAX_SIGNAL_SLOTS {
-        PENDING_SIGNALS[index].store(0, Ordering::Release);
+        PENDING_SIGNALS[index].store(false, Ordering::Release);
         REGISTERED_SIGNALS[index].store(0, Ordering::Release);
     }
 }
 
-fn create_pipe() -> io::Result<(RawFd, RawFd)> {
+fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [-1; 2];
     // SAFETY: `fds` points to two valid c_int slots for libc to fill.
     if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
@@ -126,7 +164,9 @@ fn create_pipe() -> io::Result<(RawFd, RawFd)> {
         return Err(err);
     }
 
-    Ok((fds[0], fds[1]))
+    // SAFETY: pipe returned two fresh descriptors and ownership is transferred
+    // exactly once into these wrappers.
+    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
 }
 
 fn configure_pipe(read_fd: RawFd, write_fd: RawFd) -> io::Result<()> {
@@ -178,8 +218,14 @@ fn install_handler(signal: libc::c_int) -> io::Result<libc::sigaction> {
     if unsafe { libc::sigaction(signal, &action, &mut previous) } != 0 {
         return Err(io::Error::last_os_error());
     }
-
     Ok(previous)
+}
+
+fn restore_handlers(handlers: &[(libc::c_int, libc::sigaction)]) {
+    for (signal, previous) in handlers.iter().rev() {
+        // SAFETY: `previous` was returned by `sigaction` for the same signal.
+        let _ = unsafe { libc::sigaction(*signal, previous, std::ptr::null_mut()) };
+    }
 }
 
 fn signal_action_flags() -> libc::c_int {
@@ -188,27 +234,44 @@ fn signal_action_flags() -> libc::c_int {
 
 extern "C" fn signal_handler(signal: libc::c_int) {
     let _errno_guard = ErrnoGuard::new();
-
-    if !mark_pending(signal) {
+    let token = HANDLER_GATE_TOKEN.load(Ordering::Acquire);
+    if gate_state(token) != GATE_ACTIVE {
         return;
     }
 
-    let fd = SIGNAL_WRITE_FD.load(Ordering::Acquire);
-    if fd < 0 {
+    #[cfg(test)]
+    test_hooks::pause_if_requested(test_hooks::PAUSE_AFTER_TOKEN_READ);
+
+    ACTIVE_HANDLERS.fetch_add(1, Ordering::AcqRel);
+
+    #[cfg(test)]
+    test_hooks::pause_if_requested(test_hooks::PAUSE_AFTER_ADMISSION);
+
+    if HANDLER_GATE_TOKEN.load(Ordering::Acquire) != token {
+        ACTIVE_HANDLERS.fetch_sub(1, Ordering::AcqRel);
         return;
     }
 
-    let wakeup = 1u8;
-    // SAFETY: `fd` is a nonblocking pipe write end. `write` is async-signal-safe.
-    // The pipe is only a wakeup channel; pending signal counters above preserve
-    // signal state if this best-effort write fails with EAGAIN.
-    let _ = unsafe {
-        libc::write(
-            fd,
-            (&wakeup as *const u8).cast::<libc::c_void>(),
-            std::mem::size_of::<u8>(),
-        )
-    };
+    #[cfg(test)]
+    test_hooks::DESCRIPTOR_ACCESSES.fetch_add(1, Ordering::AcqRel);
+
+    if mark_pending(signal) {
+        let fd = SIGNAL_WRITE_FD.load(Ordering::Acquire);
+        if fd >= 0 {
+            let wakeup = 1u8;
+            // SAFETY: the exact active gate protects this stable nonblocking
+            // descriptor until every admitted handler has decremented.
+            let _ = unsafe {
+                libc::write(
+                    fd,
+                    (&wakeup as *const u8).cast::<libc::c_void>(),
+                    std::mem::size_of::<u8>(),
+                )
+            };
+        }
+    }
+
+    ACTIVE_HANDLERS.fetch_sub(1, Ordering::AcqRel);
 }
 
 struct ErrnoGuard {
@@ -233,9 +296,7 @@ impl Drop for ErrnoGuard {
     fn drop(&mut self) {
         if !self.location.is_null() {
             // SAFETY: `location` points to the current thread's errno slot.
-            unsafe {
-                *self.location = self.saved;
-            }
+            unsafe { *self.location = self.saved };
         }
     }
 }
@@ -307,78 +368,95 @@ fn errno_location() -> *mut libc::c_int {
 fn mark_pending(signal: libc::c_int) -> bool {
     for index in 0..MAX_SIGNAL_SLOTS {
         if REGISTERED_SIGNALS[index].load(Ordering::Acquire) == signal {
-            PENDING_SIGNALS[index].fetch_add(1, Ordering::Release);
-            return true;
+            return !PENDING_SIGNALS[index].swap(true, Ordering::AcqRel);
         }
     }
     false
 }
 
-fn dispatch_pending_signals<F>(on_signal: &F)
-where
-    F: Fn(libc::c_int),
-{
+fn dispatch_pending_signals(on_signal: &dyn Fn(libc::c_int)) -> bool {
+    let mut dispatched = false;
     for index in 0..MAX_SIGNAL_SLOTS {
         let signal = REGISTERED_SIGNALS[index].load(Ordering::Acquire);
-        if signal <= 0 {
-            continue;
-        }
-
-        let pending = PENDING_SIGNALS[index].swap(0, Ordering::AcqRel);
-        for _ in 0..pending {
+        if signal > 0 && PENDING_SIGNALS[index].swap(false, Ordering::AcqRel) {
+            dispatched = true;
             on_signal(signal);
         }
     }
+    dispatched
 }
 
-fn read_signal_loop<F>(read_fd: RawFd, on_signal: F)
-where
-    F: Fn(libc::c_int),
-{
+fn write_pipe_hint(fd: RawFd) -> io::Result<()> {
+    let wakeup = 1u8;
     loop {
-        match read_wakeup(read_fd) {
-            Ok(true) => dispatch_pending_signals(&on_signal),
-            Ok(false) => break,
-            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
-            Err(err) => {
-                log::warn!("Signal listener stopped: {}", err);
-                break;
-            }
-        }
-    }
-    close_fd(read_fd);
-}
-
-fn read_wakeup(read_fd: RawFd) -> io::Result<bool> {
-    let mut wakeup = 0u8;
-    loop {
-        // SAFETY: `wakeup` points to one writable byte, and `read_fd` is the
-        // blocking pipe read end owned by the listener thread.
-        let count = unsafe {
-            libc::read(
-                read_fd,
-                (&mut wakeup as *mut u8).cast::<libc::c_void>(),
+        // SAFETY: `fd` is the owner-retained nonblocking pipe write end.
+        let result = unsafe {
+            libc::write(
+                fd,
+                (&wakeup as *const u8).cast::<libc::c_void>(),
                 std::mem::size_of::<u8>(),
             )
         };
-
-        if count == 0 {
-            return Ok(false);
+        if result == 1 {
+            return Ok(());
         }
-        if count == 1 {
-            return Ok(true);
+        if result < 0 {
+            let err = io::Error::last_os_error();
+            match err.kind() {
+                io::ErrorKind::Interrupted => continue,
+                io::ErrorKind::WouldBlock => return Ok(()),
+                _ => return Err(err),
+            }
         }
-        if count < 0 {
-            return Err(io::Error::last_os_error());
-        }
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!("signal pipe returned a short write ({result} bytes)"),
+        ));
     }
 }
 
 fn close_fd(fd: RawFd) {
     if fd >= 0 {
-        // SAFETY: Closing an owned file descriptor; errors are intentionally ignored.
+        // SAFETY: Closing an owned descriptor during setup rollback.
         let _ = unsafe { libc::close(fd) };
     }
+}
+
+#[cfg(test)]
+mod test_hooks {
+    use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+
+    pub(super) const PAUSE_AFTER_TOKEN_READ: u8 = 1;
+    pub(super) const PAUSE_AFTER_ADMISSION: u8 = 2;
+    pub(super) static PAUSE_STAGE: AtomicU8 = AtomicU8::new(0);
+    pub(super) static HANDLER_PAUSED: AtomicBool = AtomicBool::new(false);
+    pub(super) static RESUME_HANDLER: AtomicBool = AtomicBool::new(false);
+    pub(super) static DESCRIPTOR_ACCESSES: AtomicUsize = AtomicUsize::new(0);
+
+    pub(super) fn pause_if_requested(stage: u8) {
+        if PAUSE_STAGE.load(Ordering::Acquire) != stage {
+            return;
+        }
+        HANDLER_PAUSED.store(true, Ordering::Release);
+        while !RESUME_HANDLER.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+            std::thread::yield_now();
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_signal_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+pub(crate) fn deliver_signal_for_test(signal: libc::c_int) {
+    signal_handler(signal);
 }
 
 #[cfg(test)]

--- a/src/unix_signals.rs
+++ b/src/unix_signals.rs
@@ -79,8 +79,8 @@ fn validate_signals(signals: &[libc::c_int]) -> io::Result<()> {
 
 fn reserve_listener_epoch() -> io::Result<u64> {
     loop {
-        let current = HANDLER_GATE_TOKEN.load(Ordering::Acquire);
-        if gate_state(current) != GATE_INACTIVE || ACTIVE_HANDLERS.load(Ordering::Acquire) != 0 {
+        let current = HANDLER_GATE_TOKEN.load(Ordering::SeqCst);
+        if gate_state(current) != GATE_INACTIVE || ACTIVE_HANDLERS.load(Ordering::SeqCst) != 0 {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 "a signal listener is already active",
@@ -94,8 +94,8 @@ fn reserve_listener_epoch() -> io::Result<u64> {
         match HANDLER_GATE_TOKEN.compare_exchange(
             current,
             setting_up,
-            Ordering::AcqRel,
-            Ordering::Acquire,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
         ) {
             Ok(_) => return Ok(epoch),
             Err(_) => continue,
@@ -104,11 +104,11 @@ fn reserve_listener_epoch() -> io::Result<u64> {
 }
 
 fn publish_listener_active(epoch: u64) {
-    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_ACTIVE), Ordering::Release);
+    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_ACTIVE), Ordering::SeqCst);
 }
 
 fn rollback_listener_reservation(epoch: u64) {
-    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_INACTIVE), Ordering::Release);
+    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_INACTIVE), Ordering::SeqCst);
 }
 
 fn begin_listener_teardown(epoch: u64) -> io::Result<()> {
@@ -116,8 +116,8 @@ fn begin_listener_teardown(epoch: u64) -> io::Result<()> {
         .compare_exchange(
             gate_token(epoch, GATE_ACTIVE),
             gate_token(epoch, GATE_STOPPING),
-            Ordering::AcqRel,
-            Ordering::Acquire,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
         )
         .map(|_| ())
         .map_err(|actual| {
@@ -128,11 +128,15 @@ fn begin_listener_teardown(epoch: u64) -> io::Result<()> {
 }
 
 fn finish_listener_teardown(epoch: u64) {
-    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_INACTIVE), Ordering::Release);
+    HANDLER_GATE_TOKEN.store(gate_token(epoch, GATE_INACTIVE), Ordering::SeqCst);
 }
 
 fn wait_for_admitted_handlers() {
-    while ACTIVE_HANDLERS.load(Ordering::Acquire) != 0 {
+    // This counter and HANDLER_GATE_TOKEN form a Dekker-style admission
+    // handshake. Sequential consistency is required so teardown cannot miss
+    // a handler that is concurrently rechecking the closed gate on weakly
+    // ordered CPUs and then close a descriptor that handler is about to use.
+    while ACTIVE_HANDLERS.load(Ordering::SeqCst) != 0 {
         std::thread::yield_now();
     }
 }
@@ -234,7 +238,7 @@ fn signal_action_flags() -> libc::c_int {
 
 extern "C" fn signal_handler(signal: libc::c_int) {
     let _errno_guard = ErrnoGuard::new();
-    let token = HANDLER_GATE_TOKEN.load(Ordering::Acquire);
+    let token = HANDLER_GATE_TOKEN.load(Ordering::SeqCst);
     if gate_state(token) != GATE_ACTIVE {
         return;
     }
@@ -242,13 +246,13 @@ extern "C" fn signal_handler(signal: libc::c_int) {
     #[cfg(test)]
     test_hooks::pause_if_requested(test_hooks::PAUSE_AFTER_TOKEN_READ);
 
-    ACTIVE_HANDLERS.fetch_add(1, Ordering::AcqRel);
+    ACTIVE_HANDLERS.fetch_add(1, Ordering::SeqCst);
 
     #[cfg(test)]
     test_hooks::pause_if_requested(test_hooks::PAUSE_AFTER_ADMISSION);
 
-    if HANDLER_GATE_TOKEN.load(Ordering::Acquire) != token {
-        ACTIVE_HANDLERS.fetch_sub(1, Ordering::AcqRel);
+    if HANDLER_GATE_TOKEN.load(Ordering::SeqCst) != token {
+        ACTIVE_HANDLERS.fetch_sub(1, Ordering::SeqCst);
         return;
     }
 
@@ -271,7 +275,7 @@ extern "C" fn signal_handler(signal: libc::c_int) {
         }
     }
 
-    ACTIVE_HANDLERS.fetch_sub(1, Ordering::AcqRel);
+    ACTIVE_HANDLERS.fetch_sub(1, Ordering::SeqCst);
 }
 
 struct ErrnoGuard {
@@ -428,6 +432,7 @@ mod test_hooks {
 
     pub(super) const PAUSE_AFTER_TOKEN_READ: u8 = 1;
     pub(super) const PAUSE_AFTER_ADMISSION: u8 = 2;
+    pub(super) const PAUSE_AFTER_HANDLER_INSTALL: u8 = 3;
     pub(super) static PAUSE_STAGE: AtomicU8 = AtomicU8::new(0);
     pub(super) static HANDLER_PAUSED: AtomicBool = AtomicBool::new(false);
     pub(super) static RESUME_HANDLER: AtomicBool = AtomicBool::new(false);

--- a/src/unix_signals/listener.rs
+++ b/src/unix_signals/listener.rs
@@ -1,0 +1,347 @@
+use std::fmt;
+use std::io;
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use super::{
+    SIGNAL_WRITE_FD, begin_listener_teardown, clear_registered_signals, create_pipe,
+    dispatch_pending_signals, finish_listener_teardown, install_handler, publish_listener_active,
+    publish_registered_signals, reserve_listener_epoch, restore_handlers,
+    rollback_listener_reservation, validate_signals, wait_for_admitted_handlers, write_pipe_hint,
+};
+
+pub(super) const MAX_SIGNAL_PIPE_BYTES_PER_PASS: usize = 4096;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SignalListenerFailure {
+    UnexpectedEof,
+    ReadFailed {
+        kind: io::ErrorKind,
+        raw_os_error: Option<i32>,
+    },
+    CallbackPanicked,
+    ListenerPanicked,
+}
+
+impl fmt::Display for SignalListenerFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedEof => write!(f, "signal pipe closed unexpectedly"),
+            Self::ReadFailed { kind, raw_os_error } => write!(
+                f,
+                "signal pipe read failed ({kind:?}, os error {raw_os_error:?})"
+            ),
+            Self::CallbackPanicked => write!(f, "signal callback panicked"),
+            Self::ListenerPanicked => write!(f, "signal listener thread panicked"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SignalListenerHealth {
+    Running,
+    Failed(SignalListenerFailure),
+    Stopping,
+    Stopped,
+}
+
+struct ListenerShared {
+    stop_requested: AtomicBool,
+    health: Mutex<SignalListenerHealth>,
+    on_signal: Box<dyn Fn(libc::c_int) + Send + Sync + 'static>,
+    owner_wake: Arc<dyn Fn() + Send + Sync + 'static>,
+    #[cfg(test)]
+    injected_read_error: std::sync::atomic::AtomicI32,
+    #[cfg(test)]
+    thread_tid: std::sync::atomic::AtomicI32,
+}
+
+pub(crate) struct SignalListener {
+    epoch: u64,
+    thread: Option<JoinHandle<()>>,
+    read_fd: Option<OwnedFd>,
+    write_fd: Option<OwnedFd>,
+    installed_handlers: Vec<(libc::c_int, libc::sigaction)>,
+    shared: Arc<ListenerShared>,
+    teardown_complete: bool,
+}
+
+pub(crate) fn spawn_listener<F, W>(
+    signals: &[libc::c_int],
+    on_signal: F,
+    owner_wake: W,
+) -> io::Result<SignalListener>
+where
+    F: Fn(libc::c_int) + Send + Sync + 'static,
+    W: Fn() + Send + Sync + 'static,
+{
+    validate_signals(signals)?;
+    let epoch = reserve_listener_epoch()?;
+    let (read_fd, write_fd) = match create_pipe() {
+        Ok(pipe) => pipe,
+        Err(err) => {
+            rollback_listener_reservation(epoch);
+            return Err(err);
+        }
+    };
+
+    publish_registered_signals(signals);
+    SIGNAL_WRITE_FD.store(write_fd.as_raw_fd(), Ordering::Release);
+
+    let mut installed_handlers = Vec::with_capacity(signals.len());
+    for &signal in signals {
+        match install_handler(signal) {
+            Ok(previous) => installed_handlers.push((signal, previous)),
+            Err(err) => {
+                rollback_setup(epoch, &installed_handlers);
+                return Err(err);
+            }
+        }
+    }
+
+    let shared = Arc::new(ListenerShared {
+        stop_requested: AtomicBool::new(false),
+        health: Mutex::new(SignalListenerHealth::Running),
+        on_signal: Box::new(on_signal),
+        owner_wake: Arc::new(owner_wake),
+        #[cfg(test)]
+        injected_read_error: std::sync::atomic::AtomicI32::new(0),
+        #[cfg(test)]
+        thread_tid: std::sync::atomic::AtomicI32::new(0),
+    });
+    let thread_shared = Arc::clone(&shared);
+    let listener_read_fd = read_fd.as_raw_fd();
+    let thread = match thread::Builder::new()
+        .name("wayscriber-signals".to_string())
+        .spawn(move || listener_thread(listener_read_fd, &thread_shared))
+    {
+        Ok(thread) => thread,
+        Err(err) => {
+            rollback_setup(epoch, &installed_handlers);
+            return Err(err);
+        }
+    };
+
+    publish_listener_active(epoch);
+    Ok(SignalListener {
+        epoch,
+        thread: Some(thread),
+        read_fd: Some(read_fd),
+        write_fd: Some(write_fd),
+        installed_handlers,
+        shared,
+        teardown_complete: false,
+    })
+}
+
+fn rollback_setup(epoch: u64, installed_handlers: &[(libc::c_int, libc::sigaction)]) {
+    restore_handlers(installed_handlers);
+    SIGNAL_WRITE_FD.store(-1, Ordering::Release);
+    clear_registered_signals();
+    rollback_listener_reservation(epoch);
+}
+
+impl SignalListener {
+    pub(crate) fn health(&self) -> SignalListenerHealth {
+        self.shared
+            .health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    pub(crate) fn stop_and_join(&mut self) -> io::Result<()> {
+        if self.teardown_complete {
+            return Ok(());
+        }
+
+        begin_listener_teardown(self.epoch)?;
+        restore_handlers(&self.installed_handlers);
+        wait_for_admitted_handlers();
+        SIGNAL_WRITE_FD.store(-1, Ordering::Release);
+        clear_registered_signals();
+
+        {
+            let mut health = self
+                .shared
+                .health
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if matches!(*health, SignalListenerHealth::Running) {
+                *health = SignalListenerHealth::Stopping;
+            }
+        }
+        self.shared.stop_requested.store(true, Ordering::Release);
+        if let Some(write_fd) = self.write_fd.as_ref() {
+            let _ = write_pipe_hint(write_fd.as_raw_fd());
+        }
+
+        let join_result = self.thread.take().map(JoinHandle::join);
+        self.read_fd.take();
+        self.write_fd.take();
+        self.installed_handlers.clear();
+        finish_listener_teardown(self.epoch);
+        *self
+            .shared
+            .health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = SignalListenerHealth::Stopped;
+        self.teardown_complete = true;
+
+        match join_result {
+            Some(Err(_)) => Err(io::Error::other(
+                "signal listener thread panicked during join",
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_read_error(&self, raw_os_error: i32) {
+        self.shared
+            .injected_read_error
+            .store(raw_os_error, Ordering::Release);
+        if let Some(write_fd) = self.write_fd.as_ref() {
+            write_pipe_hint(write_fd.as_raw_fd()).unwrap();
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn endpoint_fds(&self) -> (RawFd, RawFd) {
+        (
+            self.read_fd.as_ref().unwrap().as_raw_fd(),
+            self.write_fd.as_ref().unwrap().as_raw_fd(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retains_endpoints(&self) -> bool {
+        self.read_fd.is_some() && self.write_fd.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn thread_tid(&self) -> libc::pid_t {
+        self.shared.thread_tid.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for SignalListener {
+    fn drop(&mut self) {
+        let _ = self.stop_and_join();
+    }
+}
+
+fn listener_thread(read_fd: RawFd, shared: &ListenerShared) {
+    #[cfg(test)]
+    {
+        // SAFETY: gettid has no preconditions and is used only by tests to
+        // observe that this exact thread reached its blocking read.
+        let tid = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
+        shared.thread_tid.store(tid, Ordering::Release);
+    }
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| read_signal_loop(read_fd, shared)));
+    let failure = match outcome {
+        Ok(Ok(())) => None,
+        Ok(Err(failure)) => Some(failure),
+        Err(_) => Some(SignalListenerFailure::ListenerPanicked),
+    };
+    if let Some(failure) = failure {
+        publish_failure(shared, failure);
+    }
+}
+
+fn read_signal_loop(read_fd: RawFd, shared: &ListenerShared) -> Result<(), SignalListenerFailure> {
+    let mut buffer = [0_u8; MAX_SIGNAL_PIPE_BYTES_PER_PASS];
+    loop {
+        if should_stop(shared) {
+            return Ok(());
+        }
+
+        #[cfg(test)]
+        {
+            let injected = shared.injected_read_error.swap(0, Ordering::AcqRel);
+            if injected != 0 {
+                let err = io::Error::from_raw_os_error(injected);
+                return Err(read_failure(err));
+            }
+        }
+
+        // SAFETY: the owner retains `read_fd` through thread join, and `buffer`
+        // is writable for the requested bounded pass.
+        let count = unsafe {
+            libc::read(
+                read_fd,
+                buffer.as_mut_ptr().cast::<libc::c_void>(),
+                buffer.len(),
+            )
+        };
+        if count == 0 {
+            return Err(SignalListenerFailure::UnexpectedEof);
+        }
+        if count < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(read_failure(err));
+        }
+        if should_stop(shared) {
+            return Ok(());
+        }
+
+        let dispatched = catch_unwind(AssertUnwindSafe(|| {
+            dispatch_pending_signals(shared.on_signal.as_ref())
+        }))
+        .map_err(|_| SignalListenerFailure::CallbackPanicked)?;
+        if dispatched {
+            wake_owner(shared);
+        }
+    }
+}
+
+fn read_failure(err: io::Error) -> SignalListenerFailure {
+    SignalListenerFailure::ReadFailed {
+        kind: err.kind(),
+        raw_os_error: err.raw_os_error(),
+    }
+}
+
+fn should_stop(shared: &ListenerShared) -> bool {
+    if shared.stop_requested.load(Ordering::Acquire) {
+        return true;
+    }
+    !matches!(
+        *shared
+            .health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        SignalListenerHealth::Running
+    )
+}
+
+fn publish_failure(shared: &ListenerShared, failure: SignalListenerFailure) {
+    let published = {
+        let mut health = shared
+            .health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if matches!(*health, SignalListenerHealth::Running) {
+            *health = SignalListenerHealth::Failed(failure);
+            true
+        } else {
+            false
+        }
+    };
+    if published {
+        wake_owner(shared);
+    }
+}
+
+fn wake_owner(shared: &ListenerShared) {
+    let wake = Arc::clone(&shared.owner_wake);
+    let _ = catch_unwind(AssertUnwindSafe(move || wake()));
+}

--- a/src/unix_signals/listener.rs
+++ b/src/unix_signals/listener.rs
@@ -90,11 +90,21 @@ where
 
     publish_registered_signals(signals);
     SIGNAL_WRITE_FD.store(write_fd.as_raw_fd(), Ordering::Release);
+    // The registered slots and stable self-pipe are ready before any custom
+    // handler is installed. Admit each handler immediately so signals cannot
+    // disappear between sigaction and listener-thread startup.
+    publish_listener_active(epoch);
 
     let mut installed_handlers = Vec::with_capacity(signals.len());
     for &signal in signals {
         match install_handler(signal) {
-            Ok(previous) => installed_handlers.push((signal, previous)),
+            Ok(previous) => {
+                installed_handlers.push((signal, previous));
+                #[cfg(test)]
+                super::test_hooks::pause_if_requested(
+                    super::test_hooks::PAUSE_AFTER_HANDLER_INSTALL,
+                );
+            }
             Err(err) => {
                 rollback_setup(epoch, &installed_handlers);
                 return Err(err);
@@ -125,7 +135,6 @@ where
         }
     };
 
-    publish_listener_active(epoch);
     Ok(SignalListener {
         epoch,
         thread: Some(thread),
@@ -138,10 +147,17 @@ where
 }
 
 fn rollback_setup(epoch: u64, installed_handlers: &[(libc::c_int, libc::sigaction)]) {
+    // Setup owns this epoch and published it active before installing handlers.
+    // Closing the gate first prevents new admissions while the old actions and
+    // descriptors are restored.
+    if let Err(err) = begin_listener_teardown(epoch) {
+        log::error!("Signal listener setup rollback could not close its admission gate: {err}");
+    }
     restore_handlers(installed_handlers);
+    wait_for_admitted_handlers();
     SIGNAL_WRITE_FD.store(-1, Ordering::Release);
     clear_registered_signals();
-    rollback_listener_reservation(epoch);
+    finish_listener_teardown(epoch);
 }
 
 impl SignalListener {

--- a/src/unix_signals/tests.rs
+++ b/src/unix_signals/tests.rs
@@ -39,6 +39,42 @@ fn setup_failure_restores_partial_installation_and_releases_singleton() {
 }
 
 #[test]
+fn signal_installed_during_listener_setup_is_replayed_after_startup() {
+    let _guard = test_signal_lock();
+    reset_handler_hooks(test_hooks::PAUSE_AFTER_HANDLER_INSTALL);
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    let callback_count = Arc::clone(&callbacks);
+    let (listener_tx, listener_rx) = mpsc::channel();
+    let setup = thread::spawn(move || {
+        listener_tx
+            .send(spawn_listener(
+                &[TEST_SIGNAL],
+                move |_| {
+                    callback_count.fetch_add(1, Ordering::AcqRel);
+                },
+                || {},
+            ))
+            .unwrap();
+    });
+    wait_until(|| test_hooks::HANDLER_PAUSED.load(Ordering::Acquire));
+
+    signal_handler(TEST_SIGNAL);
+
+    test_hooks::RESUME_HANDLER.store(true, Ordering::Release);
+    let mut listener = listener_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("listener setup did not resume")
+        .expect("listener setup failed");
+    setup.join().unwrap();
+    wait_until(|| callbacks.load(Ordering::Acquire) == 1);
+    let delivered = callbacks.load(Ordering::Acquire);
+    listener.stop_and_join().unwrap();
+    reset_handler_hooks(0);
+
+    assert_eq!(delivered, 1, "signal delivered during setup was lost");
+}
+
+#[test]
 fn signal_handler_preserves_errno() {
     let _guard = test_signal_lock();
     let mut listener = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();

--- a/src/unix_signals/tests.rs
+++ b/src/unix_signals/tests.rs
@@ -1,144 +1,404 @@
-use super::{
-    PENDING_SIGNALS, SIGNAL_WRITE_FD, clear_registered_signals, close_fd, dispatch_pending_signals,
-    errno_location, register_signals, signal_action_flags, signal_handler,
-};
-use std::cell::RefCell;
+use super::listener::MAX_SIGNAL_PIPE_BYTES_PER_PASS;
+use super::*;
 use std::io;
-use std::sync::{Mutex, atomic::Ordering};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
 
-static TEST_LOCK: Mutex<()> = Mutex::new(());
+const TEST_SIGNAL: libc::c_int = libc::SIGWINCH;
 
 #[test]
 fn signal_handlers_restart_interrupted_syscalls() {
-    let _guard = TEST_LOCK.lock().unwrap();
-
+    let _guard = test_signal_lock();
     assert_ne!(signal_action_flags() & libc::SA_RESTART, 0);
 }
 
-#[cfg(any(
-    target_os = "android",
-    target_os = "cygwin",
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "ios",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "redox",
-    target_os = "solaris",
-    target_os = "tvos",
-    target_os = "visionos",
-    target_os = "watchos"
-))]
 #[test]
-fn signal_handler_preserves_errno() {
-    let _guard = TEST_LOCK.lock().unwrap();
+fn setup_failure_restores_partial_installation_and_releases_singleton() {
+    let _guard = test_signal_lock();
+    let before = current_sigaction(TEST_SIGNAL).unwrap();
 
-    clear_registered_signals();
-    register_signals(&[libc::SIGTERM]).unwrap();
-    SIGNAL_WRITE_FD.store(i32::MAX, Ordering::Release);
-    set_errno(libc::E2BIG);
-
-    signal_handler(libc::SIGTERM);
-
-    assert_eq!(current_errno(), libc::E2BIG);
-    SIGNAL_WRITE_FD.store(-1, Ordering::Release);
-    clear_registered_signals();
-}
-
-#[test]
-fn spawn_listener_restores_installed_handlers_after_partial_failure() {
-    let _guard = TEST_LOCK.lock().unwrap();
-    let signal = libc::SIGWINCH;
-    let before = current_sigaction(signal).unwrap();
-
-    let err = super::spawn_listener(&[signal, i32::MAX], |_| {}).unwrap_err();
+    let err = match spawn_listener(&[TEST_SIGNAL, i32::MAX], |_| {}, || {}) {
+        Ok(_) => panic!("invalid signal unexpectedly installed"),
+        Err(err) => err,
+    };
 
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-    let after = current_sigaction(signal).unwrap();
+    let after = current_sigaction(TEST_SIGNAL).unwrap();
     assert_eq!(after.sa_sigaction, before.sa_sigaction);
-    clear_registered_signals();
-    SIGNAL_WRITE_FD.store(-1, Ordering::Release);
+    assert_eq!(SIGNAL_WRITE_FD.load(Ordering::Acquire), -1);
+    assert_eq!(
+        gate_state(HANDLER_GATE_TOKEN.load(Ordering::Acquire)),
+        GATE_INACTIVE
+    );
+
+    let mut replacement = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    replacement.stop_and_join().unwrap();
 }
 
 #[test]
-fn pending_signals_are_preserved_when_wakeup_write_is_unavailable() {
-    let _guard = TEST_LOCK.lock().unwrap();
+fn signal_handler_preserves_errno() {
+    let _guard = test_signal_lock();
+    let mut listener = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    set_errno(libc::E2BIG);
 
-    clear_registered_signals();
-    register_signals(&[libc::SIGTERM]).unwrap();
-    SIGNAL_WRITE_FD.store(-1, Ordering::Release);
+    signal_handler(TEST_SIGNAL);
 
-    signal_handler(libc::SIGTERM);
-
-    let dispatched = RefCell::new(Vec::new());
-    dispatch_pending_signals(&|signal| dispatched.borrow_mut().push(signal));
-    assert_eq!(dispatched.into_inner(), vec![libc::SIGTERM]);
-    assert_eq!(PENDING_SIGNALS[0].load(Ordering::Acquire), 0);
-
-    clear_registered_signals();
+    assert_eq!(current_errno(), libc::E2BIG);
+    listener.stop_and_join().unwrap();
 }
 
 #[test]
-fn pending_signal_counters_preserve_repeated_delivery() {
-    let _guard = TEST_LOCK.lock().unwrap();
-
-    clear_registered_signals();
-    register_signals(&[libc::SIGUSR1]).unwrap();
+fn pending_state_survives_an_unavailable_self_pipe() {
+    let _guard = test_signal_lock();
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    let callback_count = Arc::clone(&callbacks);
+    let mut listener = spawn_listener(
+        &[TEST_SIGNAL],
+        move |_| {
+            callback_count.fetch_add(1, Ordering::AcqRel);
+        },
+        || {},
+    )
+    .unwrap();
+    let write_fd = listener.endpoint_fds().1;
     SIGNAL_WRITE_FD.store(-1, Ordering::Release);
 
-    signal_handler(libc::SIGUSR1);
-    signal_handler(libc::SIGUSR1);
+    signal_handler(TEST_SIGNAL);
 
-    let dispatched = RefCell::new(Vec::new());
-    dispatch_pending_signals(&|signal| dispatched.borrow_mut().push(signal));
-    assert_eq!(dispatched.into_inner(), vec![libc::SIGUSR1, libc::SIGUSR1]);
-
-    clear_registered_signals();
-}
-
-#[test]
-fn pending_state_survives_full_self_pipe() {
-    let _guard = TEST_LOCK.lock().unwrap();
-
-    clear_registered_signals();
-    register_signals(&[libc::SIGTERM]).unwrap();
-    let (read_fd, write_fd) = super::create_pipe().unwrap();
     SIGNAL_WRITE_FD.store(write_fd, Ordering::Release);
+    assert!(dispatch_pending_signals(&|_| {
+        callbacks.fetch_add(1, Ordering::AcqRel);
+    }));
+    assert_eq!(callbacks.load(Ordering::Acquire), 1);
+    listener.stop_and_join().unwrap();
+}
 
-    let wakeup = 1u8;
-    loop {
-        // SAFETY: `write_fd` is a nonblocking pipe write end and `wakeup`
-        // points to one readable byte.
-        let count = unsafe {
-            libc::write(
-                write_fd,
-                (&wakeup as *const u8).cast::<libc::c_void>(),
-                std::mem::size_of::<u8>(),
-            )
-        };
-        if count == 1 {
-            continue;
-        }
-        assert!(count < 0);
-        let err = std::io::Error::last_os_error();
-        assert_eq!(err.kind(), std::io::ErrorKind::WouldBlock);
-        break;
+#[test]
+fn wake_before_listener_wait_is_retained_and_callback_precedes_owner_wake() {
+    let _guard = test_signal_lock();
+    let owner_wake = crate::backend::wayland::RuntimeWakeSource::new().unwrap();
+    let wake_handle = owner_wake.handle();
+    let callback_published = Arc::new(AtomicBool::new(false));
+    let callback_state = Arc::clone(&callback_published);
+    let mut listener = spawn_listener(
+        &[TEST_SIGNAL],
+        move |_| callback_state.store(true, Ordering::Release),
+        move || wake_handle.wake().unwrap(),
+    )
+    .unwrap();
+
+    signal_handler(TEST_SIGNAL);
+
+    wait_for_owner_wake(&owner_wake);
+    assert!(callback_published.load(Ordering::Acquire));
+    listener.stop_and_join().unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn signal_delivered_while_listener_is_blocked_wakes_owner() {
+    let _guard = test_signal_lock();
+    let owner_wake = crate::backend::wayland::RuntimeWakeSource::new().unwrap();
+    let wake_handle = owner_wake.handle();
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    let callback_count = Arc::clone(&callbacks);
+    let mut listener = spawn_listener(
+        &[TEST_SIGNAL],
+        move |_| {
+            callback_count.fetch_add(1, Ordering::AcqRel);
+        },
+        move || wake_handle.wake().unwrap(),
+    )
+    .unwrap();
+    wait_until_listener_blocks(&listener);
+
+    signal_handler(TEST_SIGNAL);
+
+    wait_for_owner_wake(&owner_wake);
+    assert_eq!(callbacks.load(Ordering::Acquire), 1);
+    listener.stop_and_join().unwrap();
+}
+
+#[test]
+fn signal_burst_coalesces_while_callback_is_in_flight() {
+    let _guard = test_signal_lock();
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    let callback_entered = Arc::clone(&entered);
+    let callback_release = Arc::clone(&release);
+    let callback_count = Arc::clone(&callbacks);
+    let mut listener = spawn_listener(
+        &[TEST_SIGNAL],
+        move |_| {
+            let call = callback_count.fetch_add(1, Ordering::AcqRel);
+            if call == 0 {
+                callback_entered.wait();
+                callback_release.wait();
+            }
+        },
+        || {},
+    )
+    .unwrap();
+
+    signal_handler(TEST_SIGNAL);
+    entered.wait();
+    for _ in 0..64 {
+        signal_handler(TEST_SIGNAL);
     }
+    release.wait();
+    wait_until(|| callbacks.load(Ordering::Acquire) == 2);
 
-    signal_handler(libc::SIGTERM);
+    assert_eq!(callbacks.load(Ordering::Acquire), 2);
+    listener.stop_and_join().unwrap();
+}
 
-    let dispatched = RefCell::new(Vec::new());
-    dispatch_pending_signals(&|signal| dispatched.borrow_mut().push(signal));
-    assert_eq!(dispatched.into_inner(), vec![libc::SIGTERM]);
+#[test]
+fn read_error_publishes_failure_before_owner_wake_and_retains_endpoints() {
+    let _guard = test_signal_lock();
+    let owner_wake = crate::backend::wayland::RuntimeWakeSource::new().unwrap();
+    let wake_handle = owner_wake.handle();
+    let mut listener =
+        spawn_listener(&[TEST_SIGNAL], |_| {}, move || wake_handle.wake().unwrap()).unwrap();
+    let endpoints = listener.endpoint_fds();
 
-    SIGNAL_WRITE_FD.store(-1, Ordering::Release);
-    clear_registered_signals();
-    close_fd(read_fd);
-    close_fd(write_fd);
+    listener.inject_read_error(libc::EIO);
+    wait_for_owner_wake(&owner_wake);
+
+    assert!(matches!(
+        listener.health(),
+        SignalListenerHealth::Failed(SignalListenerFailure::ReadFailed {
+            raw_os_error: Some(libc::EIO),
+            ..
+        })
+    ));
+    assert!(fd_is_open(endpoints.0));
+    assert!(fd_is_open(endpoints.1));
+    assert!(listener.retains_endpoints());
+    listener.stop_and_join().unwrap();
+    assert!(!listener.retains_endpoints());
+}
+
+#[test]
+fn callback_panic_publishes_failure_before_independent_owner_wake() {
+    let _guard = test_signal_lock();
+    let owner_wake = crate::backend::wayland::RuntimeWakeSource::new().unwrap();
+    let wake_handle = owner_wake.handle();
+    let mut listener = spawn_listener(
+        &[TEST_SIGNAL],
+        |_| panic!("injected callback panic"),
+        move || wake_handle.wake().unwrap(),
+    )
+    .unwrap();
+
+    signal_handler(TEST_SIGNAL);
+    wait_for_owner_wake(&owner_wake);
+
+    assert_eq!(
+        listener.health(),
+        SignalListenerHealth::Failed(SignalListenerFailure::CallbackPanicked)
+    );
+    listener.stop_and_join().unwrap();
+}
+
+#[test]
+fn old_epoch_paused_before_admission_cannot_access_next_generation_descriptor() {
+    let _guard = test_signal_lock();
+    reset_handler_hooks(test_hooks::PAUSE_AFTER_TOKEN_READ);
+    let mut first = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    let old_handler = thread::spawn(|| signal_handler(TEST_SIGNAL));
+    wait_until(|| test_hooks::HANDLER_PAUSED.load(Ordering::Acquire));
+
+    first.stop_and_join().unwrap();
+    let mut second = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    let accesses_before = test_hooks::DESCRIPTOR_ACCESSES.load(Ordering::Acquire);
+    test_hooks::RESUME_HANDLER.store(true, Ordering::Release);
+    old_handler.join().unwrap();
+
+    assert_eq!(
+        test_hooks::DESCRIPTOR_ACCESSES.load(Ordering::Acquire),
+        accesses_before
+    );
+    reset_handler_hooks(0);
+    second.stop_and_join().unwrap();
+}
+
+#[test]
+fn descriptor_close_waits_for_every_admitted_handler() {
+    let _guard = test_signal_lock();
+    reset_handler_hooks(test_hooks::PAUSE_AFTER_ADMISSION);
+    let listener = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    let endpoints = listener.endpoint_fds();
+    let admitted_handler = thread::spawn(|| signal_handler(TEST_SIGNAL));
+    wait_until(|| test_hooks::HANDLER_PAUSED.load(Ordering::Acquire));
+
+    let (stopped_tx, stopped_rx) = mpsc::channel();
+    let stopper = thread::spawn(move || {
+        let mut listener = listener;
+        let result = listener.stop_and_join();
+        stopped_tx.send(result).unwrap();
+    });
+    assert!(stopped_rx.recv_timeout(Duration::from_millis(20)).is_err());
+    assert!(fd_is_open(endpoints.0));
+    assert!(fd_is_open(endpoints.1));
+
+    test_hooks::RESUME_HANDLER.store(true, Ordering::Release);
+    admitted_handler.join().unwrap();
+    stopped_rx
+        .recv_timeout(Duration::from_secs(1))
+        .unwrap()
+        .unwrap();
+    stopper.join().unwrap();
+    reset_handler_hooks(0);
+}
+
+#[test]
+fn continuous_signals_cannot_starve_stop_and_join() {
+    let _guard = test_signal_lock();
+    let listener = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    let keep_sending = Arc::new(AtomicBool::new(true));
+    let sender_flag = Arc::clone(&keep_sending);
+    let sender = thread::spawn(move || {
+        while sender_flag.load(Ordering::Acquire) {
+            signal_handler(TEST_SIGNAL);
+            thread::yield_now();
+        }
+    });
+    let (stopped_tx, stopped_rx) = mpsc::channel();
+    let stopper = thread::spawn(move || {
+        let mut listener = listener;
+        stopped_tx.send(listener.stop_and_join()).unwrap();
+    });
+
+    let result = stopped_rx.recv_timeout(Duration::from_secs(1));
+    keep_sending.store(false, Ordering::Release);
+    sender.join().unwrap();
+    result
+        .expect("continuous signals starved teardown")
+        .unwrap();
+    stopper.join().unwrap();
+}
+
+#[test]
+fn stop_restores_handlers_and_is_idempotent() {
+    let _guard = test_signal_lock();
+    let before = current_sigaction(TEST_SIGNAL).unwrap();
+    let mut listener = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    let installed = current_sigaction(TEST_SIGNAL).unwrap();
+    assert_ne!(installed.sa_sigaction, before.sa_sigaction);
+
+    listener.stop_and_join().unwrap();
+    listener.stop_and_join().unwrap();
+
+    let after = current_sigaction(TEST_SIGNAL).unwrap();
+    assert_eq!(after.sa_sigaction, before.sa_sigaction);
+    assert_eq!(listener.health(), SignalListenerHealth::Stopped);
+}
+
+#[test]
+fn stale_old_generation_handler_cannot_write_to_reused_numeric_descriptor() {
+    let _guard = test_signal_lock();
+    reset_handler_hooks(test_hooks::PAUSE_AFTER_TOKEN_READ);
+    let mut listener = spawn_listener(&[TEST_SIGNAL], |_| {}, || {}).unwrap();
+    let old_write_fd = listener.endpoint_fds().1;
+    let old_handler = thread::spawn(|| signal_handler(TEST_SIGNAL));
+    wait_until(|| test_hooks::HANDLER_PAUSED.load(Ordering::Acquire));
+    listener.stop_and_join().unwrap();
+
+    let (reuse_read, reuse_write) = create_pipe().unwrap();
+    let reuse_read = if reuse_read.as_raw_fd() == old_write_fd {
+        // SAFETY: duplicates the live read endpoint so `old_write_fd` can be
+        // deliberately reused for the write endpoint below.
+        let duplicate = unsafe { libc::dup(reuse_read.as_raw_fd()) };
+        assert!(duplicate >= 0);
+        drop(reuse_read);
+        // SAFETY: `dup` returned a fresh descriptor owned by this test.
+        unsafe { OwnedFd::from_raw_fd(duplicate) }
+    } else {
+        reuse_read
+    };
+    set_status_flag(reuse_read.as_raw_fd(), libc::O_NONBLOCK).unwrap();
+    if reuse_write.as_raw_fd() != old_write_fd {
+        // SAFETY: duplicates the live pipe endpoint onto the deliberately
+        // reused numeric descriptor for this isolated race test.
+        assert!(unsafe { libc::dup2(reuse_write.as_raw_fd(), old_write_fd) } >= 0);
+    }
+    test_hooks::RESUME_HANDLER.store(true, Ordering::Release);
+    old_handler.join().unwrap();
+
+    let mut byte = 0_u8;
+    // SAFETY: `byte` is writable and the pipe read descriptor remains open.
+    let count = unsafe {
+        libc::read(
+            reuse_read.as_raw_fd(),
+            (&mut byte as *mut u8).cast::<libc::c_void>(),
+            1,
+        )
+    };
+    assert_eq!(count, -1);
+    assert_eq!(io::Error::last_os_error().kind(), io::ErrorKind::WouldBlock);
+    if reuse_write.as_raw_fd() != old_write_fd {
+        close_fd(old_write_fd);
+    }
+    reset_handler_hooks(0);
+}
+
+#[test]
+fn listener_pass_is_explicitly_bounded() {
+    assert_eq!(MAX_SIGNAL_PIPE_BYTES_PER_PASS, 4096);
+}
+
+fn wait_for_owner_wake(source: &crate::backend::wayland::RuntimeWakeSource) {
+    let mut pollfd = libc::pollfd {
+        fd: source.poll_fd().as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: source owns the descriptor throughout this bounded wait.
+    let ready = unsafe { libc::poll(&mut pollfd, 1, 1_000) };
+    assert_eq!(ready, 1, "owner was not woken");
+    assert_ne!(pollfd.revents & libc::POLLIN, 0);
+    source.drain().unwrap();
+}
+
+#[cfg(target_os = "linux")]
+fn wait_until_listener_blocks(listener: &SignalListener) {
+    wait_until(|| {
+        let tid = listener.thread_tid();
+        if tid == 0 {
+            return false;
+        }
+        std::fs::read_to_string(format!("/proc/self/task/{tid}/stat"))
+            .ok()
+            .and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .and_then(|(_, suffix)| suffix.chars().next())
+            })
+            == Some('S')
+    });
+}
+
+fn wait_until(mut predicate: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !predicate() {
+        assert!(Instant::now() < deadline, "condition was not observed");
+        thread::yield_now();
+    }
+}
+
+fn reset_handler_hooks(stage: u8) {
+    test_hooks::PAUSE_STAGE.store(stage, Ordering::Release);
+    test_hooks::HANDLER_PAUSED.store(false, Ordering::Release);
+    test_hooks::RESUME_HANDLER.store(false, Ordering::Release);
+    test_hooks::DESCRIPTOR_ACCESSES.store(0, Ordering::Release);
+}
+
+fn fd_is_open(fd: RawFd) -> bool {
+    // SAFETY: F_GETFD only queries the supplied descriptor.
+    (unsafe { libc::fcntl(fd, libc::F_GETFD) }) >= 0
 }
 
 fn current_errno() -> libc::c_int {
@@ -152,9 +412,7 @@ fn set_errno(value: libc::c_int) {
     let location = errno_location();
     assert!(!location.is_null());
     // SAFETY: `location` points to the current thread's errno slot.
-    unsafe {
-        *location = value;
-    }
+    unsafe { *location = value };
 }
 
 fn current_sigaction(signal: libc::c_int) -> io::Result<libc::sigaction> {


### PR DESCRIPTION
## Summary

- Replace polling-based signal observation with an owned Unix signal listener.
- Wake the daemon control loop or overlay event loop immediately after publishing signal state.
- Handle daemon toggles, tray actions, and graceful shutdown without periodic signal polling.
- Preserve queued tray actions across startup and listener failures.
- Restore previous signal handlers safely during teardown and surface listener failures to runtime owners.
- Process signal wakes while capture, freeze, or zoom dispatch is active.

## Why

Signal state was previously observed through bounded polling. That caused unnecessary idle wakeups and made signal handling dependent on polling intervals.

This change makes signal delivery wake-driven: the listener publishes the signal state first, then wakes the owning event loop through the shared runtime wake descriptor.

## Coverage

The added tests cover:

- Signal delivery before and during listener waits.
- Burst coalescing and callback ordering.
- Startup installation and pending-action scanning.
- Graceful listener shutdown and handler restoration.
- Descriptor-reuse and teardown races.
- Daemon cleanup and readiness invalidation after listener failure.
- Final session persistence ordering during overlay teardown.
- Capture-active runtime wake routing.