### PR TITLE
fix(tray): detect Omarchy as a Quickshell icon host

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ on shorter or scaled displays:
 - Open the log folder
 - Open configurator / open config file / quit
 
-Supported desktops use a theme-adaptive symbolic tray icon. Hosts that do not reliably resolve named icons (including Noctalia/Quickshell/COSMIC) automatically receive scale-aware colored pixmaps, including a 48px HiDPI rendition. Set `[tray].icon_style` to `"auto"` (default), `"symbolic"`, or `"colored"` to choose the main tray icon style; restart the daemon after changing it. Use `--no-tray` or `WAYSCRIBER_NO_TRAY=1` if you don't have a system tray. If the tray icon is still blank or the menu shows square placeholders, start the daemon with `WAYSCRIBER_TRAY_FORCE_PIXMAP=1`; this environment override takes precedence over the TOML setting.
+Supported desktops use a theme-adaptive symbolic tray icon. Hosts that do not reliably resolve named icons (including Omarchy/Quickshell, Noctalia/Quickshell, and COSMIC) automatically receive scale-aware colored pixmaps, including a 48px HiDPI rendition. Set `[tray].icon_style` to `"auto"` (default), `"symbolic"`, or `"colored"` to choose the main tray icon style; restart the daemon after changing it. Use `--no-tray` or `WAYSCRIBER_NO_TRAY=1` if you don't have a system tray. If the tray icon is still blank or the menu shows square placeholders, start the daemon with `WAYSCRIBER_TRAY_FORCE_PIXMAP=1`; this environment override takes precedence over the TOML setting.
 
 **Alternative — compositor autostart instead of systemd:**
 ```conf

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -372,7 +372,7 @@ Controls the main system tray icon. Changes take effect after restarting the dae
 icon_style = "auto"
 ```
 
-- `auto` (default) uses a theme-adaptive symbolic icon on supported desktops and colored fallback pixmaps on known-incompatible tray hosts.
+- `auto` (default) uses a theme-adaptive symbolic icon on supported desktops and colored fallback pixmaps on known-incompatible tray hosts, including Omarchy/Quickshell, Noctalia/Quickshell, and COSMIC.
 - `symbolic` always requests the theme-adaptive icon. The tray host chooses its visible color.
 - `colored` always publishes the yellow, scale-aware fallback pixmaps.
 

--- a/src/daemon/tray/ksni.rs
+++ b/src/daemon/tray/ksni.rs
@@ -413,7 +413,10 @@ fn tray_theme_icons_supported(desktop_env: &str, session_env: &str, desktop_sess
 
 #[cfg(feature = "tray")]
 fn tray_theme_icons_blocked_by_desktop(value: &str) -> bool {
-    value.contains("noctalia") || value.contains("quickshell") || value.contains("cosmic")
+    value.contains("noctalia")
+        || value.contains("omarchy")
+        || value.contains("quickshell")
+        || value.contains("cosmic")
 }
 
 #[cfg(feature = "tray")]
@@ -459,6 +462,9 @@ mod tests {
     fn tray_theme_icons_supported_blocks_existing_problem_shells() {
         assert!(!tray_theme_icons_supported("quickshell", "", ""));
         assert!(!tray_theme_icons_supported("", "noctalia", ""));
+        assert!(!tray_theme_icons_supported(
+            "hyprland", "hyprland", "omarchy"
+        ));
     }
 
     #[test]
@@ -476,6 +482,13 @@ mod tests {
             "quickshell",
             "",
             ""
+        ));
+        assert!(!resolve_symbolic_tray_icon(
+            TrayIconStyle::Auto,
+            false,
+            "hyprland",
+            "hyprland",
+            "omarchy"
         ));
     }
 


### PR DESCRIPTION
## Summary

- Detect Omarchy as a tray host with unreliable named-icon resolution
- Use Wayscriber’s embedded colored tray pixmaps in `auto` mode
- Suppress named menu icons that Quickshell would render as missing-texture placeholders
- Document Omarchy/Quickshell compatibility behavior
- Add regression coverage for the `Hyprland` / `omarchy` environment

## Problem

Omarchy runs a Quickshell-based tray but identifies the session as:

- `XDG_CURRENT_DESKTOP=Hyprland`
- `XDG_SESSION_DESKTOP=Hyprland`
- `DESKTOP_SESSION=omarchy`

Wayscriber previously recognized only desktop names containing `quickshell`, `noctalia`, or `cosmic`. The existing compatibility fallback was therefore not activated on Omarchy.

Quickshell then failed to resolve `wayscriber-symbolic` and some menu icon names, displaying missing-texture placeholders.

## Solution

Treat desktop-session values containing `omarchy` as incompatible with named tray icons.

With the default `[tray].icon_style = "auto"`, Wayscriber now:
- publishes its scale-aware colored pixmaps for the main tray icon
- omits named menu icons instead of allowing the host to display broken placeholders

Explicit `symbolic` and `colored` configuration behavior remains unchanged.

