### PR TITLE
perf(runtime): wake Wayland for bounded GTK toolbar feedback

### DIFF
--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -137,9 +137,6 @@ pub(super) fn run_event_loop(
                 ),
             )
         };
-        // GTK toolbar events arrive on a channel that cannot wake the
-        // Wayland poll, so keep the wait bounded while that frontend runs.
-        let timeout = min_timeout(timeout, state.gtk_toolbar_wake_timeout());
         let timeout = min_timeout(timeout, toolbar_handoff_timeout);
         let timeout = min_timeout(timeout, command_palette_repeat_timeout);
         if let Err(e) = dispatch::dispatch_events(

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -147,7 +147,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
     // Decide the toolbar frontend before the first visibility sync so the
     // built-in surfaces are never created just to be torn down when the
     // GTK bars take over.
-    state.spawn_gtk_toolbar_if_selected();
+    state.spawn_gtk_toolbar_if_selected(runtime_wake.handle());
     // Ensure pinned toolbars are created immediately if visible on startup.
     state.sync_toolbar_visibility(&setup.qh);
     Ok(BackendRuntime {

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -25,6 +25,6 @@ pub(crate) use toolbar::view::top::{TopStripPlan, plan_top_strip};
 mod zoom;
 
 pub use backend::WaylandBackend;
-pub(crate) use backend::runtime_wake::RuntimeWakeSource;
+pub(crate) use backend::runtime_wake::{RuntimeWakeHandle, RuntimeWakeSource};
 #[cfg(tablet)]
 pub use tablet_types::TabletToolType;

--- a/src/backend/wayland/state/gtk_toolbar.rs
+++ b/src/backend/wayland/state/gtk_toolbar.rs
@@ -101,24 +101,12 @@ impl WaylandState {
         conn: &Connection,
         qh: &QueueHandle<Self>,
     ) {
-        if self
-            .gtk_toolbar
-            .as_ref()
-            .is_some_and(GtkToolbarBridge::failed)
-        {
-            self.cancel_gtk_toolbar_drag_lifecycle();
-            self.gtk_toolbar = None;
-            return;
-        }
-        let Some(bridge) = self.gtk_toolbar.as_ref() else {
-            return;
+        let (pending, failed) = {
+            let Some(bridge) = self.gtk_toolbar.as_ref() else {
+                return;
+            };
+            bridge.drain_feedback()
         };
-        let pending = bridge.drain_feedback();
-        if bridge.failed() {
-            self.cancel_gtk_toolbar_drag_lifecycle();
-            self.gtk_toolbar = None;
-            return;
-        }
         for feedback in pending {
             // GTK uses a separate connection and bypasses the built-in
             // pointer modal gate. A drag first observed under the modal stays
@@ -217,6 +205,13 @@ impl WaylandState {
                     self.apply_gtk_side_offset(x, y, surface_size, phase);
                 }
             }
+        }
+        // Feedback committed before the terminal transition remains accepted
+        // input. Apply the drained batch before dropping the failed bridge so
+        // actions and final drag offsets are not lost during failover.
+        if failed {
+            self.cancel_gtk_toolbar_drag_lifecycle();
+            self.gtk_toolbar = None;
         }
     }
 

--- a/src/backend/wayland/state/gtk_toolbar.rs
+++ b/src/backend/wayland/state/gtk_toolbar.rs
@@ -2,8 +2,6 @@
 //! feedback draining, and state pushes. See `crate::toolbar_gtk` for the
 //! threading model.
 
-use std::time::Duration;
-
 use wayland_client::{Connection, QueueHandle};
 
 use super::WaylandState;
@@ -58,11 +56,6 @@ fn gtk_toolbar_feedback_is_blocked(
 }
 
 impl WaylandState {
-    /// Bounds the main poll while the GTK thread can produce feedback,
-    /// since nothing it sends wakes the Wayland fd.
-    const GTK_TOOLBAR_WAKE_INTERVAL: Duration = Duration::from_millis(25);
-    const GTK_TOOLBAR_DRAG_WAKE_INTERVAL: Duration = Duration::from_millis(8);
-
     /// True while the GTK frontend owns the toolbars (built-in bars stay
     /// unmapped).
     pub(in crate::backend::wayland) fn gtk_toolbars_active(&self) -> bool {
@@ -70,7 +63,10 @@ impl WaylandState {
     }
 
     /// Spawns the GTK toolbar thread when the resolved frontend is GTK.
-    pub(in crate::backend::wayland) fn spawn_gtk_toolbar_if_selected(&mut self) {
+    pub(in crate::backend::wayland) fn spawn_gtk_toolbar_if_selected(
+        &mut self,
+        runtime_wake: crate::backend::wayland::RuntimeWakeHandle,
+    ) {
         let request = requested_backend(&self.config);
         let preconditions = GtkPreconditions {
             feature_compiled: cfg!(feature = "toolbar-gtk"),
@@ -80,7 +76,7 @@ impl WaylandState {
         };
         match resolve_frontend(request, preconditions) {
             ToolbarFrontend::Gtk => {
-                self.gtk_toolbar = GtkToolbarBridge::spawn();
+                self.gtk_toolbar = GtkToolbarBridge::spawn(runtime_wake);
                 if self.gtk_toolbar.is_some() {
                     log::info!("GTK toolbars enabled; built-in toolbar surfaces stay unmapped");
                 } else {
@@ -98,18 +94,6 @@ impl WaylandState {
         }
     }
 
-    /// Wake interval for the event-loop timeout chain; `None` when the GTK
-    /// frontend is inactive.
-    pub(in crate::backend::wayland) fn gtk_toolbar_wake_timeout(&self) -> Option<Duration> {
-        self.gtk_toolbar.as_ref().map(|_| {
-            if self.data.gtk_drag_preview.is_some() {
-                Self::GTK_TOOLBAR_DRAG_WAKE_INTERVAL
-            } else {
-                Self::GTK_TOOLBAR_WAKE_INTERVAL
-            }
-        })
-    }
-
     /// Drains pending GTK toolbar feedback into the shared toolbar-event
     /// path, and falls back to the built-in bars if the GTK thread died.
     pub(in crate::backend::wayland) fn process_gtk_toolbar(
@@ -122,7 +106,6 @@ impl WaylandState {
             .as_ref()
             .is_some_and(GtkToolbarBridge::failed)
         {
-            log::warn!("GTK toolbar thread failed; falling back to built-in toolbars");
             self.cancel_gtk_toolbar_drag_lifecycle();
             self.gtk_toolbar = None;
             return;
@@ -130,9 +113,11 @@ impl WaylandState {
         let Some(bridge) = self.gtk_toolbar.as_ref() else {
             return;
         };
-        let mut pending = Vec::new();
-        while let Some(feedback) = bridge.try_recv_feedback() {
-            pending.push(feedback);
+        let pending = bridge.drain_feedback();
+        if bridge.failed() {
+            self.cancel_gtk_toolbar_drag_lifecycle();
+            self.gtk_toolbar = None;
+            return;
         }
         for feedback in pending {
             // GTK uses a separate connection and bypasses the built-in

--- a/src/toolbar_gtk/bridge.rs
+++ b/src/toolbar_gtk/bridge.rs
@@ -1,0 +1,727 @@
+//! Bounded, wake-driven transport and lifecycle ownership for the GTK toolbar thread.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::backend::wayland::RuntimeWakeHandle;
+
+use super::{GtkToolbarDragPhase, GtkToolbarFeedback, GtkToolbarKind, GtkToolbarUpdate};
+
+pub(super) const GTK_FEEDBACK_CAPACITY: usize = 64;
+pub(super) const GTK_FEEDBACK_DRAIN_LIMIT: usize = 64;
+const GTK_THREAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+const STATUS_STARTING: u8 = 0;
+const STATUS_READY: u8 = 1;
+const STATUS_FAILED: u8 = 2;
+const STATUS_STOPPING: u8 = 3;
+const STATUS_STOPPED: u8 = 4;
+
+#[derive(Clone)]
+pub(super) struct BridgeHealth {
+    status: Arc<AtomicU8>,
+    runtime_wake: RuntimeWakeHandle,
+}
+
+impl BridgeHealth {
+    pub(super) fn new(runtime_wake: RuntimeWakeHandle) -> Self {
+        Self {
+            status: Arc::new(AtomicU8::new(STATUS_STARTING)),
+            runtime_wake,
+        }
+    }
+
+    pub(super) fn mark_ready(&self) -> bool {
+        self.status
+            .compare_exchange(
+                STATUS_STARTING,
+                STATUS_READY,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    pub(super) fn fail(&self, reason: impl AsRef<str>) {
+        let mut current = self.status.load(Ordering::Acquire);
+        loop {
+            match current {
+                STATUS_FAILED | STATUS_STOPPING | STATUS_STOPPED => return,
+                STATUS_STARTING | STATUS_READY => {
+                    match self.status.compare_exchange_weak(
+                        current,
+                        STATUS_FAILED,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        Ok(_) => {
+                            log::warn!("{}", reason.as_ref());
+                            if let Err(err) = self.runtime_wake.wake() {
+                                log::error!("Failed to wake runtime for GTK terminal state: {err}");
+                            }
+                            return;
+                        }
+                        Err(observed) => current = observed,
+                    }
+                }
+                _ => unreachable!("unknown GTK bridge health state {current}"),
+            }
+        }
+    }
+
+    fn begin_stopping(&self) {
+        let mut current = self.status.load(Ordering::Acquire);
+        while matches!(current, STATUS_STARTING | STATUS_READY) {
+            match self.status.compare_exchange_weak(
+                current,
+                STATUS_STOPPING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub(super) fn stopping(&self) -> bool {
+        matches!(
+            self.status.load(Ordering::Acquire),
+            STATUS_STOPPING | STATUS_STOPPED
+        )
+    }
+
+    fn mark_stopped(&self) {
+        let _ = self.status.compare_exchange(
+            STATUS_STOPPING,
+            STATUS_STOPPED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
+
+    pub(super) fn failed(&self) -> bool {
+        self.status.load(Ordering::Acquire) == STATUS_FAILED
+    }
+
+    fn wake_owner(&self) -> std::io::Result<()> {
+        self.runtime_wake.wake()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FeedbackPublishError {
+    Closed,
+    Failed,
+}
+
+struct FeedbackMailboxState {
+    queue: VecDeque<GtkToolbarFeedback>,
+    accepting: bool,
+}
+
+struct FeedbackMailbox {
+    state: Mutex<FeedbackMailboxState>,
+    health: BridgeHealth,
+}
+
+#[derive(Clone)]
+pub(super) struct FeedbackPublisher {
+    mailbox: Arc<FeedbackMailbox>,
+}
+
+impl FeedbackPublisher {
+    fn new(health: BridgeHealth) -> Self {
+        Self {
+            mailbox: Arc::new(FeedbackMailbox {
+                state: Mutex::new(FeedbackMailboxState {
+                    queue: VecDeque::with_capacity(GTK_FEEDBACK_CAPACITY),
+                    accepting: true,
+                }),
+                health,
+            }),
+        }
+    }
+
+    pub(super) fn publish(&self, feedback: GtkToolbarFeedback) -> Result<(), FeedbackPublishError> {
+        let mut overflowed = false;
+        {
+            let mut state = match self.mailbox.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => {
+                    let mut state = poisoned.into_inner();
+                    state.accepting = false;
+                    drop(state);
+                    self.mailbox.health.fail(
+                        "GTK feedback mailbox state was poisoned; restoring built-in toolbars",
+                    );
+                    return Err(FeedbackPublishError::Failed);
+                }
+            };
+            if !state.accepting {
+                return Err(if self.mailbox.health.failed() {
+                    FeedbackPublishError::Failed
+                } else {
+                    FeedbackPublishError::Closed
+                });
+            }
+
+            if state.queue.len() < GTK_FEEDBACK_CAPACITY {
+                state.queue.push_back(feedback);
+            } else if let Some(kind) = feedback.move_kind() {
+                let mut replacement = None;
+                for (index, queued) in state.queue.iter().enumerate().rev() {
+                    if queued.is_non_coalescible_boundary() {
+                        break;
+                    }
+                    if queued.move_kind() == Some(kind) {
+                        replacement = Some(index);
+                        break;
+                    }
+                }
+                match replacement {
+                    Some(index) => state.queue[index] = feedback,
+                    None => {
+                        state.accepting = false;
+                        overflowed = true;
+                    }
+                }
+            } else {
+                let reclaim = feedback
+                    .drag_kind()
+                    .and_then(|kind| oldest_move_in_current_segment(&state.queue, kind))
+                    .or_else(|| {
+                        state
+                            .queue
+                            .iter()
+                            .position(|queued| queued.move_kind().is_some())
+                    });
+                if let Some(index) = reclaim {
+                    state.queue.remove(index);
+                    state.queue.push_back(feedback);
+                } else {
+                    state.accepting = false;
+                    overflowed = true;
+                }
+            }
+        }
+
+        if overflowed {
+            self.mailbox.health.fail(
+                "GTK feedback mailbox exhausted by ordered feedback; restoring built-in toolbars",
+            );
+            return Err(FeedbackPublishError::Failed);
+        }
+
+        if let Err(err) = self.mailbox.health.wake_owner() {
+            self.close_admission();
+            self.mailbox.health.fail(format!(
+                "GTK feedback could not wake the runtime ({err}); restoring built-in toolbars"
+            ));
+            return Err(FeedbackPublishError::Failed);
+        }
+        Ok(())
+    }
+
+    fn drain(&self, limit: usize) -> Vec<GtkToolbarFeedback> {
+        let (drained, residual) = {
+            let mut state = match self.mailbox.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => {
+                    let mut state = poisoned.into_inner();
+                    state.accepting = false;
+                    drop(state);
+                    self.mailbox.health.fail(
+                        "GTK feedback mailbox state was poisoned; restoring built-in toolbars",
+                    );
+                    return Vec::new();
+                }
+            };
+            let take = limit.min(state.queue.len());
+            let drained = state.queue.drain(..take).collect::<Vec<_>>();
+            (drained, !state.queue.is_empty())
+        };
+        if residual && let Err(err) = self.mailbox.health.wake_owner() {
+            self.close_admission();
+            self.mailbox.health.fail(format!(
+                "Residual GTK feedback could not wake the runtime ({err}); restoring built-in toolbars"
+            ));
+        }
+        drained
+    }
+
+    fn close_admission(&self) {
+        match self.mailbox.state.lock() {
+            Ok(mut state) => state.accepting = false,
+            Err(poisoned) => poisoned.into_inner().accepting = false,
+        }
+    }
+
+    #[cfg(test)]
+    fn pending_len(&self) -> usize {
+        self.mailbox
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .queue
+            .len()
+    }
+}
+
+impl GtkToolbarFeedback {
+    fn move_kind(&self) -> Option<GtkToolbarKind> {
+        match self {
+            Self::SetTopOffset {
+                phase: GtkToolbarDragPhase::Move,
+                ..
+            } => Some(GtkToolbarKind::Top),
+            Self::SetSideOffset {
+                phase: GtkToolbarDragPhase::Move,
+                ..
+            } => Some(GtkToolbarKind::Side),
+            _ => None,
+        }
+    }
+
+    fn is_non_coalescible_boundary(&self) -> bool {
+        self.move_kind().is_none()
+    }
+
+    fn drag_kind(&self) -> Option<GtkToolbarKind> {
+        match self {
+            Self::SetTopOffset { .. } => Some(GtkToolbarKind::Top),
+            Self::SetSideOffset { .. } => Some(GtkToolbarKind::Side),
+            Self::Event { .. } => None,
+        }
+    }
+}
+
+fn oldest_move_in_current_segment(
+    queue: &VecDeque<GtkToolbarFeedback>,
+    kind: GtkToolbarKind,
+) -> Option<usize> {
+    let segment_start = queue
+        .iter()
+        .rposition(GtkToolbarFeedback::is_non_coalescible_boundary)
+        .map_or(0, |index| index + 1);
+    queue
+        .iter()
+        .enumerate()
+        .skip(segment_start)
+        .find_map(|(index, feedback)| (feedback.move_kind() == Some(kind)).then_some(index))
+}
+
+struct LatestValueSender<T> {
+    sender: async_channel::Sender<T>,
+    last_sent: Option<T>,
+}
+
+impl<T: Clone + PartialEq> LatestValueSender<T> {
+    fn new(sender: async_channel::Sender<T>) -> Self {
+        Self {
+            sender,
+            last_sent: None,
+        }
+    }
+
+    fn publish(&mut self, value: T) -> Result<bool, async_channel::SendError<T>> {
+        if self.last_sent.as_ref() == Some(&value) {
+            return Ok(false);
+        }
+        self.sender.force_send(value.clone())?;
+        self.last_sent = Some(value);
+        Ok(true)
+    }
+
+    fn close(&self) {
+        self.sender.close();
+    }
+}
+
+struct ThreadCompletion(std::sync::mpsc::Sender<()>);
+
+impl Drop for ThreadCompletion {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ThreadShutdownOutcome {
+    Joined,
+    Panicked,
+    TimedOut,
+}
+
+fn finish_thread_within(
+    thread: &mut Option<JoinHandle<()>>,
+    completion: &std::sync::mpsc::Receiver<()>,
+    timeout: Duration,
+) -> ThreadShutdownOutcome {
+    let Some(handle) = thread.as_ref() else {
+        return ThreadShutdownOutcome::Joined;
+    };
+    let deadline = Instant::now() + timeout;
+    let completion_wait = deadline.saturating_duration_since(Instant::now());
+    let _ = completion.recv_timeout(completion_wait);
+    while !handle.is_finished() && Instant::now() < deadline {
+        std::thread::yield_now();
+    }
+    if !handle.is_finished() {
+        thread.take();
+        return ThreadShutdownOutcome::TimedOut;
+    }
+    match thread.take().expect("thread checked above").join() {
+        Ok(()) => ThreadShutdownOutcome::Joined,
+        Err(_) => ThreadShutdownOutcome::Panicked,
+    }
+}
+
+/// Main-thread owner of the GTK toolbar bridge and GTK thread.
+pub struct GtkToolbarBridge {
+    updates: LatestValueSender<GtkToolbarUpdate>,
+    feedback: FeedbackPublisher,
+    health: BridgeHealth,
+    thread: Option<JoinHandle<()>>,
+    completion: std::sync::mpsc::Receiver<()>,
+}
+
+impl GtkToolbarBridge {
+    /// Spawns the GTK thread. Returns `None` only when the OS thread cannot be
+    /// created; GTK-level failures are published asynchronously and wake the runtime.
+    pub fn spawn(runtime_wake: RuntimeWakeHandle) -> Option<Self> {
+        let (update_tx, update_rx) = async_channel::bounded(1);
+        let (completion_tx, completion_rx) = std::sync::mpsc::channel();
+        let health = BridgeHealth::new(runtime_wake);
+        let feedback = FeedbackPublisher::new(health.clone());
+        let thread_health = health.clone();
+        let thread_feedback = feedback.clone();
+        let spawned = std::thread::Builder::new()
+            .name("gtk-toolbar".into())
+            .spawn(move || {
+                let _completion = ThreadCompletion(completion_tx);
+                super::runtime::run(update_rx, thread_feedback, thread_health);
+            });
+        match spawned {
+            Ok(thread) => Some(Self {
+                updates: LatestValueSender::new(update_tx),
+                feedback,
+                health,
+                thread: Some(thread),
+                completion: completion_rx,
+            }),
+            Err(err) => {
+                log::error!("Failed to spawn GTK toolbar thread: {err}");
+                None
+            }
+        }
+    }
+
+    /// True once the GTK thread or bounded feedback bridge reported terminal failure.
+    pub fn failed(&self) -> bool {
+        self.health.failed()
+    }
+
+    /// Drains one bounded pass. Residual feedback retains a coalesced runtime wake.
+    pub fn drain_feedback(&self) -> Vec<GtkToolbarFeedback> {
+        self.feedback.drain(GTK_FEEDBACK_DRAIN_LIMIT)
+    }
+
+    /// Publishes the newest complete update and replaces an unread older update.
+    pub fn maybe_send(&mut self, update: GtkToolbarUpdate) {
+        if self.updates.publish(update).is_err() {
+            self.health
+                .fail("GTK toolbar update receiver disconnected; restoring built-in toolbars");
+        }
+    }
+}
+
+impl Drop for GtkToolbarBridge {
+    fn drop(&mut self) {
+        self.feedback.close_admission();
+        self.health.begin_stopping();
+        self.updates.close();
+        match finish_thread_within(
+            &mut self.thread,
+            &self.completion,
+            GTK_THREAD_SHUTDOWN_TIMEOUT,
+        ) {
+            ThreadShutdownOutcome::Joined => self.health.mark_stopped(),
+            ThreadShutdownOutcome::Panicked => self
+                .health
+                .fail("GTK toolbar thread panicked during shutdown"),
+            ThreadShutdownOutcome::TimedOut => {
+                log::warn!(
+                    "GTK toolbar thread did not stop within {:?}; detaching it safely",
+                    GTK_THREAD_SHUTDOWN_TIMEOUT
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+    use std::sync::mpsc;
+
+    use super::*;
+    use crate::backend::wayland::RuntimeWakeSource;
+    use crate::ui::toolbar::ToolbarEvent;
+
+    const SURFACE: super::super::GtkToolbarSurfaceSize = super::super::GtkToolbarSurfaceSize {
+        width: 200,
+        height: 80,
+    };
+
+    fn drag(kind: GtkToolbarKind, phase: GtkToolbarDragPhase, seq: u64) -> GtkToolbarFeedback {
+        match kind {
+            GtkToolbarKind::Top => GtkToolbarFeedback::SetTopOffset {
+                x: seq as f64,
+                y: 0.0,
+                surface_size: SURFACE,
+                seq,
+                phase,
+            },
+            GtkToolbarKind::Side => GtkToolbarFeedback::SetSideOffset {
+                x: 0.0,
+                y: seq as f64,
+                surface_size: SURFACE,
+                seq,
+                phase,
+            },
+        }
+    }
+
+    fn event() -> GtkToolbarFeedback {
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::Undo,
+            rebind_requested: false,
+        }
+    }
+
+    fn channel() -> (RuntimeWakeSource, BridgeHealth, FeedbackPublisher) {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let health = BridgeHealth::new(wake.handle());
+        let publisher = FeedbackPublisher::new(health.clone());
+        (wake, health, publisher)
+    }
+
+    fn wake_is_readable(source: &RuntimeWakeSource) -> bool {
+        let mut pollfd = libc::pollfd {
+            fd: source.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd and the source descriptor are valid for this non-blocking poll.
+        let ready = unsafe { libc::poll(&mut pollfd, 1, 0) };
+        assert!(ready >= 0);
+        ready > 0 && pollfd.revents & libc::POLLIN != 0
+    }
+
+    fn wait_until_thread_is_blocked_in_poll(tid: libc::pid_t) {
+        let stat_path = format!("/proc/self/task/{tid}/stat");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let state = std::fs::read_to_string(&stat_path).ok().and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .and_then(|(_, suffix)| suffix.chars().next())
+            });
+            if state == Some('S') {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "polling thread did not block (last state: {state:?})"
+            );
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn latest_value_replaces_unread_state_and_sender_drop_is_observable() {
+        let (tx, rx) = async_channel::bounded(1);
+        let mut latest = LatestValueSender::new(tx);
+        assert_eq!(latest.publish(1), Ok(true));
+        assert_eq!(latest.publish(2), Ok(true));
+        assert_eq!(latest.publish(2), Ok(false));
+        assert_eq!(rx.recv_blocking(), Ok(2));
+        drop(latest);
+        assert!(rx.recv_blocking().is_err());
+    }
+
+    #[test]
+    fn compatible_move_replaces_only_within_the_current_segment() {
+        let (_wake, health, publisher) = channel();
+        publisher
+            .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Start, 1))
+            .unwrap();
+        for seq in 2..=GTK_FEEDBACK_CAPACITY as u64 {
+            publisher
+                .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, seq))
+                .unwrap();
+        }
+        publisher
+            .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 100))
+            .unwrap();
+
+        let drained = publisher.drain(GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained.len(), GTK_FEEDBACK_CAPACITY);
+        assert_eq!(
+            drained.last(),
+            Some(&drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 100))
+        );
+        assert!(!health.failed());
+    }
+
+    #[test]
+    fn drag_end_reclaims_an_older_move_and_preserves_ordered_boundaries() {
+        let (_wake, health, publisher) = channel();
+        let start = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Start, 1);
+        publisher.publish(start.clone()).unwrap();
+        for seq in 2..=GTK_FEEDBACK_CAPACITY as u64 {
+            publisher
+                .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, seq))
+                .unwrap();
+        }
+        let end = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::End, 65);
+        publisher.publish(end.clone()).unwrap();
+
+        let drained = publisher.drain(GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained.len(), GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained.first(), Some(&start));
+        assert_eq!(drained.last(), Some(&end));
+        assert!(!drained.contains(&drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 2)));
+        assert!(!health.failed());
+    }
+
+    #[test]
+    fn move_never_crosses_an_event_boundary_or_toolbar_kind() {
+        let (_wake, health, publisher) = channel();
+        for seq in 0..(GTK_FEEDBACK_CAPACITY - 2) as u64 {
+            publisher
+                .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, seq))
+                .unwrap();
+        }
+        publisher.publish(event()).unwrap();
+        publisher
+            .publish(drag(GtkToolbarKind::Side, GtkToolbarDragPhase::Move, 1))
+            .unwrap();
+
+        assert_eq!(
+            publisher.publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 999)),
+            Err(FeedbackPublishError::Failed)
+        );
+        assert!(health.failed());
+        assert_eq!(publisher.pending_len(), GTK_FEEDBACK_CAPACITY);
+    }
+
+    #[test]
+    fn non_coalescible_capacity_exhaustion_publishes_failure_before_wake() {
+        let (wake, health, publisher) = channel();
+        for _ in 0..GTK_FEEDBACK_CAPACITY {
+            publisher.publish(event()).unwrap();
+        }
+        wake.drain().unwrap();
+        assert!(!wake_is_readable(&wake));
+
+        assert_eq!(
+            publisher.publish(event()),
+            Err(FeedbackPublishError::Failed)
+        );
+        assert!(health.failed());
+        assert!(wake_is_readable(&wake));
+        assert_eq!(
+            publisher.publish(event()),
+            Err(FeedbackPublishError::Failed)
+        );
+    }
+
+    #[test]
+    fn feedback_is_committed_before_its_runtime_wake() {
+        let (wake, _health, publisher) = channel();
+        publisher.publish(event()).unwrap();
+        assert!(wake_is_readable(&wake));
+        assert_eq!(publisher.pending_len(), 1);
+        assert_eq!(publisher.drain(1), vec![event()]);
+    }
+
+    #[test]
+    fn feedback_unblocks_a_runtime_already_waiting_in_poll() {
+        let (wake, _health, publisher) = channel();
+        let (tid_tx, tid_rx) = mpsc::channel();
+        let poller = std::thread::spawn(move || {
+            // SAFETY: gettid has no preconditions and is used only to observe this test thread.
+            let tid = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
+            tid_tx.send(tid).unwrap();
+            let mut pollfd = libc::pollfd {
+                fd: wake.poll_fd().as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            // SAFETY: pollfd and the source descriptor remain valid for the bounded wait.
+            let ready = unsafe { libc::poll(&mut pollfd, 1, 1_000) };
+            assert_eq!(ready, 1);
+            assert_ne!(pollfd.revents & libc::POLLIN, 0);
+        });
+
+        let tid = tid_rx.recv().unwrap();
+        wait_until_thread_is_blocked_in_poll(tid);
+        publisher.publish(event()).unwrap();
+        poller.join().unwrap();
+        assert_eq!(publisher.pending_len(), 1);
+    }
+
+    #[test]
+    fn bounded_drain_preserves_order_and_self_wakes_for_residual_work() {
+        let (wake, _health, publisher) = channel();
+        for seq in 1..=3 {
+            publisher
+                .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, seq))
+                .unwrap();
+        }
+        wake.drain().unwrap();
+
+        assert_eq!(
+            publisher.drain(2),
+            vec![
+                drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 1),
+                drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 2),
+            ]
+        );
+        assert_eq!(publisher.pending_len(), 1);
+        assert!(wake_is_readable(&wake));
+    }
+
+    #[test]
+    fn completed_thread_is_joined_without_initializing_gtk() {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        let mut thread = Some(std::thread::spawn(move || {
+            let _completion = ThreadCompletion(completion_tx);
+        }));
+        assert_eq!(
+            finish_thread_within(&mut thread, &completion_rx, Duration::from_secs(1)),
+            ThreadShutdownOutcome::Joined
+        );
+        assert!(thread.is_none());
+    }
+
+    #[test]
+    fn stuck_thread_is_detached_at_the_bounded_deadline() {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let mut thread = Some(std::thread::spawn(move || {
+            let _completion = ThreadCompletion(completion_tx);
+            let _ = release_rx.recv();
+        }));
+        assert_eq!(
+            finish_thread_within(&mut thread, &completion_rx, Duration::from_millis(1)),
+            ThreadShutdownOutcome::TimedOut
+        );
+        assert!(thread.is_none());
+        release_tx.send(()).unwrap();
+    }
+}

--- a/src/toolbar_gtk/bridge.rs
+++ b/src/toolbar_gtk/bridge.rs
@@ -185,8 +185,27 @@ impl FeedbackPublisher {
                 match replacement {
                     Some(index) => state.queue[index] = feedback,
                     None => {
-                        state.accepting = false;
-                        overflowed = true;
+                        // A boundary may have consumed a slot by reclaiming a
+                        // move from an older segment. Reclaim another move and
+                        // append this one after the boundary instead of moving
+                        // it across ordered feedback or failing the bridge.
+                        let reclaim = state
+                            .queue
+                            .iter()
+                            .position(|queued| queued.move_kind() == Some(kind))
+                            .or_else(|| {
+                                state
+                                    .queue
+                                    .iter()
+                                    .position(|queued| queued.move_kind().is_some())
+                            });
+                        if let Some(index) = reclaim {
+                            state.queue.remove(index);
+                            state.queue.push_back(feedback);
+                        } else {
+                            state.accepting = false;
+                            overflowed = true;
+                        }
                     }
                 }
             } else {
@@ -251,6 +270,22 @@ impl FeedbackPublisher {
             ));
         }
         drained
+    }
+
+    fn complete_drain(
+        &self,
+        mut drained: Vec<GtkToolbarFeedback>,
+        limit: usize,
+    ) -> (Vec<GtkToolbarFeedback>, bool) {
+        let failed = self.mailbox.health.failed();
+        if failed {
+            // A publisher may have committed feedback after the first drain
+            // and immediately before making the bridge terminal. Stop new
+            // admissions, then collect that accepted tail before failover.
+            self.close_admission();
+            drained.extend(self.drain(limit));
+        }
+        (drained, failed)
     }
 
     fn close_admission(&self) {
@@ -420,14 +455,13 @@ impl GtkToolbarBridge {
         }
     }
 
-    /// True once the GTK thread or bounded feedback bridge reported terminal failure.
-    pub fn failed(&self) -> bool {
-        self.health.failed()
-    }
-
-    /// Drains one bounded pass. Residual feedback retains a coalesced runtime wake.
-    pub fn drain_feedback(&self) -> Vec<GtkToolbarFeedback> {
-        self.feedback.drain(GTK_FEEDBACK_DRAIN_LIMIT)
+    /// Drains one bounded pass and snapshots terminal state. If failure raced
+    /// with the first drain, admission is closed and the accepted tail is
+    /// included before the caller tears down the bridge.
+    pub fn drain_feedback(&self) -> (Vec<GtkToolbarFeedback>, bool) {
+        let drained = self.feedback.drain(GTK_FEEDBACK_DRAIN_LIMIT);
+        self.feedback
+            .complete_drain(drained, GTK_FEEDBACK_DRAIN_LIMIT)
     }
 
     /// Publishes the newest complete update and replaces an unread older update.
@@ -450,9 +484,11 @@ impl Drop for GtkToolbarBridge {
             GTK_THREAD_SHUTDOWN_TIMEOUT,
         ) {
             ThreadShutdownOutcome::Joined => self.health.mark_stopped(),
-            ThreadShutdownOutcome::Panicked => self
-                .health
-                .fail("GTK toolbar thread panicked during shutdown"),
+            ThreadShutdownOutcome::Panicked => {
+                // Shutdown has already made health terminal, so `fail` cannot
+                // publish this late join result. Report it directly.
+                log::warn!("GTK toolbar thread panicked during shutdown");
+            }
             ThreadShutdownOutcome::TimedOut => {
                 log::warn!(
                     "GTK toolbar thread did not stop within {:?}; detaching it safely",
@@ -578,6 +614,30 @@ mod tests {
     }
 
     #[test]
+    fn first_move_after_a_reclaimed_drag_start_reuses_an_older_move_slot() {
+        let (_wake, health, publisher) = channel();
+        let first_start = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Start, 1);
+        publisher.publish(first_start.clone()).unwrap();
+        for seq in 2..=GTK_FEEDBACK_CAPACITY as u64 {
+            publisher
+                .publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, seq))
+                .unwrap();
+        }
+
+        let next_start = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Start, 100);
+        let next_move = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 101);
+        publisher.publish(next_start.clone()).unwrap();
+        publisher.publish(next_move.clone()).unwrap();
+
+        let drained = publisher.drain(GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained.len(), GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained.first(), Some(&first_start));
+        assert_eq!(drained[GTK_FEEDBACK_CAPACITY - 2], next_start);
+        assert_eq!(drained.last(), Some(&next_move));
+        assert!(!health.failed());
+    }
+
+    #[test]
     fn drag_end_reclaims_an_older_move_and_preserves_ordered_boundaries() {
         let (_wake, health, publisher) = channel();
         let start = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Start, 1);
@@ -599,7 +659,7 @@ mod tests {
     }
 
     #[test]
-    fn move_never_crosses_an_event_boundary_or_toolbar_kind() {
+    fn reclaimed_move_is_appended_after_event_boundary_and_other_kind() {
         let (_wake, health, publisher) = channel();
         for seq in 0..(GTK_FEEDBACK_CAPACITY - 2) as u64 {
             publisher
@@ -611,8 +671,29 @@ mod tests {
             .publish(drag(GtkToolbarKind::Side, GtkToolbarDragPhase::Move, 1))
             .unwrap();
 
+        let latest_top = drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 999);
+        publisher.publish(latest_top.clone()).unwrap();
+
+        let drained = publisher.drain(GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained.len(), GTK_FEEDBACK_CAPACITY);
+        assert_eq!(drained[GTK_FEEDBACK_CAPACITY - 3], event());
         assert_eq!(
-            publisher.publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 999)),
+            drained[GTK_FEEDBACK_CAPACITY - 2],
+            drag(GtkToolbarKind::Side, GtkToolbarDragPhase::Move, 1)
+        );
+        assert_eq!(drained.last(), Some(&latest_top));
+        assert!(!health.failed());
+    }
+
+    #[test]
+    fn move_capacity_exhaustion_without_a_reclaimable_move_fails() {
+        let (_wake, health, publisher) = channel();
+        for _ in 0..GTK_FEEDBACK_CAPACITY {
+            publisher.publish(event()).unwrap();
+        }
+
+        assert_eq!(
+            publisher.publish(drag(GtkToolbarKind::Top, GtkToolbarDragPhase::Move, 1)),
             Err(FeedbackPublishError::Failed)
         );
         assert!(health.failed());
@@ -647,6 +728,24 @@ mod tests {
         assert!(wake_is_readable(&wake));
         assert_eq!(publisher.pending_len(), 1);
         assert_eq!(publisher.drain(1), vec![event()]);
+    }
+
+    #[test]
+    fn terminal_transition_after_initial_drain_recovers_accepted_tail() {
+        let (_wake, health, publisher) = channel();
+        let drained = publisher.drain(GTK_FEEDBACK_CAPACITY);
+        assert!(drained.is_empty());
+
+        publisher.publish(event()).unwrap();
+        health.fail("intentional terminal transition after initial drain");
+
+        let (drained, failed) = publisher.complete_drain(drained, GTK_FEEDBACK_CAPACITY);
+        assert!(failed);
+        assert_eq!(drained, vec![event()]);
+        assert_eq!(
+            publisher.publish(event()),
+            Err(FeedbackPublishError::Failed)
+        );
     }
 
     #[test]
@@ -705,6 +804,20 @@ mod tests {
         assert_eq!(
             finish_thread_within(&mut thread, &completion_rx, Duration::from_secs(1)),
             ThreadShutdownOutcome::Joined
+        );
+        assert!(thread.is_none());
+    }
+
+    #[test]
+    fn panicked_thread_is_joined_with_panicked_outcome() {
+        let (completion_tx, completion_rx) = mpsc::channel();
+        let mut thread = Some(std::thread::spawn(move || {
+            let _completion = ThreadCompletion(completion_tx);
+            panic!("intentional GTK bridge shutdown test panic");
+        }));
+        assert_eq!(
+            finish_thread_within(&mut thread, &completion_rx, Duration::from_secs(1)),
+            ThreadShutdownOutcome::Panicked
         );
         assert!(thread.is_none());
     }

--- a/src/toolbar_gtk/mod.rs
+++ b/src/toolbar_gtk/mod.rs
@@ -19,6 +19,8 @@
 pub mod select;
 
 #[cfg(feature = "toolbar-gtk")]
+mod bridge;
+#[cfg(feature = "toolbar-gtk")]
 mod css;
 #[cfg(feature = "toolbar-gtk")]
 mod icons;
@@ -165,76 +167,7 @@ pub enum GtkToolbarFeedback {
 }
 
 #[cfg(feature = "toolbar-gtk")]
-pub use enabled::GtkToolbarBridge;
-
-#[cfg(feature = "toolbar-gtk")]
-mod enabled {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU8, Ordering};
-
-    use super::{GtkToolbarFeedback, GtkToolbarUpdate};
-
-    pub(super) const STATUS_STARTING: u8 = 0;
-    pub(super) const STATUS_READY: u8 = 1;
-    pub(super) const STATUS_FAILED: u8 = 2;
-
-    /// Main-thread handle to the GTK toolbar thread.
-    pub struct GtkToolbarBridge {
-        update_tx: async_channel::Sender<GtkToolbarUpdate>,
-        feedback_rx: std::sync::mpsc::Receiver<GtkToolbarFeedback>,
-        status: Arc<AtomicU8>,
-        last_sent: Option<GtkToolbarUpdate>,
-    }
-
-    impl GtkToolbarBridge {
-        /// Spawns the GTK thread. Returns `None` only when the OS thread
-        /// cannot be created; GTK-level failures are reported
-        /// asynchronously through [`Self::failed`].
-        pub fn spawn() -> Option<Self> {
-            let (update_tx, update_rx) = async_channel::unbounded();
-            let (feedback_tx, feedback_rx) = std::sync::mpsc::channel();
-            let status = Arc::new(AtomicU8::new(STATUS_STARTING));
-            let thread_status = status.clone();
-            let spawned = std::thread::Builder::new()
-                .name("gtk-toolbar".into())
-                .spawn(move || super::runtime::run(update_rx, feedback_tx, thread_status));
-            match spawned {
-                Ok(_join_handle) => Some(Self {
-                    update_tx,
-                    feedback_rx,
-                    status,
-                    last_sent: None,
-                }),
-                Err(err) => {
-                    log::error!("Failed to spawn GTK toolbar thread: {err}");
-                    None
-                }
-            }
-        }
-
-        /// True once the GTK thread reported an unrecoverable failure.
-        pub fn failed(&self) -> bool {
-            self.status.load(Ordering::Acquire) == STATUS_FAILED
-        }
-
-        /// Non-blocking receive of one feedback message from the GTK bars.
-        pub fn try_recv_feedback(&self) -> Option<GtkToolbarFeedback> {
-            self.feedback_rx.try_recv().ok()
-        }
-
-        /// Sends the update if it differs from the previously sent one.
-        pub fn maybe_send(&mut self, update: GtkToolbarUpdate) {
-            if self.last_sent.as_ref() == Some(&update) {
-                return;
-            }
-            // try_send on an unbounded channel only fails when the GTK
-            // thread is gone; the failed() flag covers that case.
-            if self.update_tx.try_send(update.clone()).is_ok() {
-                self.last_sent = Some(update);
-            }
-        }
-    }
-}
+pub use bridge::GtkToolbarBridge;
 
 #[cfg(not(feature = "toolbar-gtk"))]
 pub use disabled::GtkToolbarBridge;
@@ -242,6 +175,7 @@ pub use disabled::GtkToolbarBridge;
 #[cfg(not(feature = "toolbar-gtk"))]
 mod disabled {
     use super::{GtkToolbarFeedback, GtkToolbarUpdate};
+    use crate::backend::wayland::RuntimeWakeHandle;
 
     /// Stub bridge: without the `toolbar-gtk` feature `spawn` never
     /// succeeds, so the other methods are unreachable but keep call sites
@@ -249,7 +183,7 @@ mod disabled {
     pub struct GtkToolbarBridge {}
 
     impl GtkToolbarBridge {
-        pub fn spawn() -> Option<Self> {
+        pub fn spawn(_runtime_wake: RuntimeWakeHandle) -> Option<Self> {
             None
         }
 
@@ -257,8 +191,8 @@ mod disabled {
             false
         }
 
-        pub fn try_recv_feedback(&self) -> Option<GtkToolbarFeedback> {
-            None
+        pub fn drain_feedback(&self) -> Vec<GtkToolbarFeedback> {
+            Vec::new()
         }
 
         pub fn maybe_send(&mut self, _update: GtkToolbarUpdate) {}

--- a/src/toolbar_gtk/mod.rs
+++ b/src/toolbar_gtk/mod.rs
@@ -187,12 +187,8 @@ mod disabled {
             None
         }
 
-        pub fn failed(&self) -> bool {
-            false
-        }
-
-        pub fn drain_feedback(&self) -> Vec<GtkToolbarFeedback> {
-            Vec::new()
+        pub fn drain_feedback(&self) -> (Vec<GtkToolbarFeedback>, bool) {
+            (Vec::new(), false)
         }
 
         pub fn maybe_send(&mut self, _update: GtkToolbarUpdate) {}

--- a/src/toolbar_gtk/runtime.rs
+++ b/src/toolbar_gtk/runtime.rs
@@ -2,56 +2,63 @@
 //! toolbar windows. Nothing in here touches backend state; all traffic
 //! goes through the bridge channels.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
-
 use gtk4::glib;
 
-use super::enabled::{STATUS_FAILED, STATUS_READY};
-use super::{GtkToolbarFeedback, GtkToolbarUpdate};
+use super::GtkToolbarUpdate;
+use super::bridge::{BridgeHealth, FeedbackPublisher};
 
 /// Flags the bridge as failed unless the shutdown was the clean
 /// channel-close path — covers panics anywhere on this thread and an
 /// unexpectedly exiting main loop, so the backend falls back to the
 /// built-in bars instead of running headless.
 struct FailureGuard {
-    status: Arc<AtomicU8>,
+    health: BridgeHealth,
     clean: std::cell::Cell<bool>,
 }
 
 impl Drop for FailureGuard {
     fn drop(&mut self) {
         if !self.clean.get() {
-            log::warn!("GTK toolbar thread exited unexpectedly");
-            self.status.store(STATUS_FAILED, Ordering::Release);
+            self.health
+                .fail("GTK toolbar thread exited unexpectedly; restoring built-in toolbars");
         }
     }
 }
 
 pub(super) fn run(
     updates: async_channel::Receiver<GtkToolbarUpdate>,
-    feedback: std::sync::mpsc::Sender<GtkToolbarFeedback>,
-    status: Arc<AtomicU8>,
+    feedback: FeedbackPublisher,
+    health: BridgeHealth,
 ) {
     let guard = std::rc::Rc::new(FailureGuard {
-        status: status.clone(),
+        health: health.clone(),
         clean: std::cell::Cell::new(false),
     });
 
-    if let Err(err) = gtk4::init() {
-        log::warn!("GTK toolbars unavailable: gtk4::init failed: {err}");
+    if health.stopping() {
         guard.clean.set(true);
-        status.store(STATUS_FAILED, Ordering::Release);
-        return;
-    }
-    if !gtk4_layer_shell::is_supported() {
-        log::warn!("GTK toolbars unavailable: gtk4-layer-shell reports no compositor support");
-        guard.clean.set(true);
-        status.store(STATUS_FAILED, Ordering::Release);
         return;
     }
 
-    status.store(STATUS_READY, Ordering::Release);
+    if let Err(err) = gtk4::init() {
+        guard.clean.set(true);
+        health.fail(format!(
+            "GTK toolbars unavailable: gtk4::init failed ({err}); restoring built-in toolbars"
+        ));
+        return;
+    }
+    if !gtk4_layer_shell::is_supported() {
+        guard.clean.set(true);
+        health.fail(
+            "GTK toolbars unavailable: gtk4-layer-shell reports no compositor support; restoring built-in toolbars",
+        );
+        return;
+    }
+
+    if !health.mark_ready() {
+        guard.clean.set(true);
+        return;
+    }
 
     let main_loop = glib::MainLoop::new(None, false);
     let loop_handle = main_loop.clone();
@@ -70,4 +77,55 @@ pub(super) fn run(
         loop_handle.quit();
     });
     main_loop.run();
+    if !guard.clean.get() {
+        health.fail("GTK toolbar main loop returned unexpectedly; restoring built-in toolbars");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+
+    use super::*;
+    use crate::backend::wayland::RuntimeWakeSource;
+
+    #[test]
+    fn unexpected_runtime_exit_publishes_failure_before_wake() {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let health = BridgeHealth::new(wake.handle());
+        drop(FailureGuard {
+            health: health.clone(),
+            clean: std::cell::Cell::new(false),
+        });
+
+        let mut pollfd = libc::pollfd {
+            fd: wake.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd and the source descriptor are valid for this non-blocking poll.
+        let ready = unsafe { libc::poll(&mut pollfd, 1, 0) };
+        assert_eq!(ready, 1);
+        assert!(health.failed());
+        assert_ne!(pollfd.revents & libc::POLLIN, 0);
+    }
+
+    #[test]
+    fn clean_runtime_exit_does_not_publish_failure() {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let health = BridgeHealth::new(wake.handle());
+        drop(FailureGuard {
+            health: health.clone(),
+            clean: std::cell::Cell::new(true),
+        });
+
+        assert!(!health.failed());
+        let mut pollfd = libc::pollfd {
+            fd: wake.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd and the source descriptor are valid for this non-blocking poll.
+        assert_eq!(unsafe { libc::poll(&mut pollfd, 1, 0) }, 0);
+    }
 }

--- a/src/toolbar_gtk/widgets.rs
+++ b/src/toolbar_gtk/widgets.rs
@@ -7,6 +7,7 @@ use gtk4::prelude::*;
 use gtk4_layer_shell::{KeyboardMode, LayerShell};
 
 use super::GtkToolbarFeedback;
+use super::bridge::FeedbackPublisher;
 use super::icons::{IconPainter, IconWidget};
 use crate::config::ToolbarRebindModifier;
 use crate::draw::Color;
@@ -16,17 +17,34 @@ use crate::ui::toolbar::ToolbarEvent;
 /// rebind chord and modifier state captured from the actual GTK click.
 #[derive(Clone)]
 pub(super) struct FeedbackSender {
-    tx: std::sync::mpsc::Sender<GtkToolbarFeedback>,
+    sink: Rc<dyn FeedbackSink>,
     rebind_modifier: Rc<Cell<ToolbarRebindModifier>>,
     backend_rebind_active: Rc<Cell<bool>>,
     click_rebind_requested: Rc<Cell<bool>>,
     click_in_progress: Rc<Cell<bool>>,
 }
 
+pub(super) trait FeedbackSink {
+    fn publish(&self, feedback: GtkToolbarFeedback) -> bool;
+}
+
+impl FeedbackSink for FeedbackPublisher {
+    fn publish(&self, feedback: GtkToolbarFeedback) -> bool {
+        self.publish(feedback).is_ok()
+    }
+}
+
+#[cfg(test)]
+impl FeedbackSink for std::sync::mpsc::Sender<GtkToolbarFeedback> {
+    fn publish(&self, feedback: GtkToolbarFeedback) -> bool {
+        self.send(feedback).is_ok()
+    }
+}
+
 impl FeedbackSender {
-    pub(super) fn new(tx: std::sync::mpsc::Sender<GtkToolbarFeedback>) -> Self {
+    pub(super) fn new(sink: impl FeedbackSink + 'static) -> Self {
         Self {
-            tx,
+            sink: Rc::new(sink),
             rebind_modifier: Rc::new(Cell::new(ToolbarRebindModifier::default())),
             backend_rebind_active: Rc::new(Cell::new(false)),
             click_rebind_requested: Rc::new(Cell::new(false)),
@@ -62,11 +80,8 @@ impl FeedbackSender {
         }
     }
 
-    pub(super) fn send(
-        &self,
-        feedback: GtkToolbarFeedback,
-    ) -> Result<(), std::sync::mpsc::SendError<GtkToolbarFeedback>> {
-        self.tx.send(feedback)
+    pub(super) fn send(&self, feedback: GtkToolbarFeedback) -> Result<(), ()> {
+        self.sink.publish(feedback).then_some(()).ok_or(())
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace periodic GTK toolbar polling with runtime wake notifications.
- Bound and coalesce GTK feedback without reordering actions or drag boundaries.
- Harden GTK failure, failover, and shutdown handling.

## Why

GTK toolbar feedback previously arrived through channels that could not wake the Wayland event loop. The runtime compensated with fixed 25 ms idle polling and 8 ms drag polling, trading unnecessary wakeups for feedback latency.

The transport was also unbounded and had several terminal-state edge cases:

- accepted actions or final drag offsets could be discarded during failover;
- a recoverable backlog could disable the GTK frontend;
- panics discovered while joining the GTK thread were not reported.

## Implementation

- Pass the existing `RuntimeWakeHandle` into the GTK bridge.
- Wake the Wayland runtime only after feedback is committed or terminal state is published.
- Use a bounded 64-entry feedback mailbox with bounded draining.
- Coalesce drag moves while preserving ordered Start, End, and toolbar-action boundaries.
- Reclaim stale move entries before treating the mailbox as exhausted.
- Keep only the newest unread backend-to-GTK state update.
- Close feedback admission and recover the accepted tail before falling back.
- Track explicit starting, ready, failed, stopping, and stopped bridge states.
- Own and join the GTK thread with a bounded shutdown deadline.
- Report shutdown panics directly after the health state becomes terminal.
- Retain automatic fallback to the built-in toolbars on unrecoverable failures.

