### PR TITLE
perf(runtime): wake Wayland for clipboard completions

### DIFF
--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -103,14 +103,8 @@ pub(super) fn run_event_loop(
         let autosave_timeout = session_save::autosave_timeout(state, now);
         let focus_exit_timeout = state.focus_exit_timeout(now);
         let command_palette_repeat_timeout = state.input_state.command_palette_repeat_timeout(now);
-        let clipboard_timeout = (state.clipboard_paste_rx.is_some()
-            || state.clipboard_publish_rx.is_some())
-        .then_some(Duration::from_millis(25));
         let timeout = if should_block {
-            min_timeout(
-                clipboard_timeout,
-                min_timeout(autosave_timeout, focus_exit_timeout),
-            )
+            min_timeout(autosave_timeout, focus_exit_timeout)
         } else if !vsync_enabled && state.input_state.needs_redraw {
             // When VSync is off and we need to redraw, wake up when frame budget allows
             let frame_cap_timeout = render::frame_rate_cap_timeout(
@@ -124,17 +118,11 @@ pub(super) fn run_event_loop(
                 (Some(fc), None) => Some(fc),
                 (None, _) => Some(Duration::ZERO),
             };
-            min_timeout(
-                clipboard_timeout,
-                min_timeout(merged, min_timeout(autosave_timeout, focus_exit_timeout)),
-            )
+            min_timeout(merged, min_timeout(autosave_timeout, focus_exit_timeout))
         } else {
             min_timeout(
-                clipboard_timeout,
-                min_timeout(
-                    animation_timeout,
-                    min_timeout(autosave_timeout, focus_exit_timeout),
-                ),
+                animation_timeout,
+                min_timeout(autosave_timeout, focus_exit_timeout),
             )
         };
         let timeout = min_timeout(timeout, toolbar_handoff_timeout);

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -132,6 +132,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
         capture_manager,
         session_options,
         persistence,
+        runtime_wake: runtime_wake.handle(),
         tokio_handle,
         exit_after_capture_mode,
         frozen_enabled: frozen_supported,

--- a/src/backend/wayland/clipboard/completion.rs
+++ b/src/backend/wayland/clipboard/completion.rs
@@ -1,0 +1,641 @@
+//! Identified capacity-one completion transport for event-loop clipboard operations.
+
+use std::fmt;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError};
+use std::sync::{Arc, Mutex};
+
+use crate::backend::wayland::RuntimeWakeHandle;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(in crate::backend::wayland) struct ClipboardOperationId(u64);
+
+impl fmt::Display for ClipboardOperationId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+#[derive(Clone)]
+pub(in crate::backend::wayland) struct ClipboardOperationIdSource {
+    next: Arc<Mutex<Option<u64>>>,
+}
+
+impl ClipboardOperationIdSource {
+    pub(in crate::backend::wayland) fn new() -> Self {
+        Self {
+            next: Arc::new(Mutex::new(Some(1))),
+        }
+    }
+
+    fn allocate(&self) -> Result<ClipboardOperationId, ClipboardSubmitError> {
+        let mut next = self
+            .next
+            .lock()
+            .map_err(|_| ClipboardSubmitError::Unhealthy)?;
+        let value = next.ok_or(ClipboardSubmitError::IdentityExhausted)?;
+        *next = value.checked_add(1);
+        Ok(ClipboardOperationId(value))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum ClipboardSubmitError {
+    Busy { active_id: ClipboardOperationId },
+    IdentityExhausted,
+    Unhealthy,
+    SpawnFailed { reason: String },
+}
+
+impl fmt::Display for ClipboardSubmitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Busy { active_id } => {
+                write!(formatter, "clipboard operation {active_id} is still active")
+            }
+            Self::IdentityExhausted => formatter.write_str("clipboard operation IDs exhausted"),
+            Self::Unhealthy => formatter.write_str("clipboard completion controller is unhealthy"),
+            Self::SpawnFailed { reason } => {
+                write!(formatter, "failed to spawn clipboard producer: {reason}")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::backend::wayland) struct ClipboardSubmitFailure<C> {
+    error: ClipboardSubmitError,
+    context: C,
+}
+
+impl<C> ClipboardSubmitFailure<C> {
+    pub(in crate::backend::wayland) fn into_parts(self) -> (ClipboardSubmitError, C) {
+        (self.error, self.context)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(in crate::backend::wayland) enum ClipboardPoll<C, T> {
+    Idle,
+    Pending {
+        id: ClipboardOperationId,
+    },
+    Ready {
+        id: ClipboardOperationId,
+        context: C,
+        outcome: T,
+    },
+    ProducerFailed {
+        id: ClipboardOperationId,
+        context: C,
+        reason: String,
+    },
+    Disconnected {
+        id: ClipboardOperationId,
+        context: C,
+    },
+}
+
+enum ProducerMessage<T> {
+    Ready {
+        id: ClipboardOperationId,
+        outcome: T,
+    },
+    Failed {
+        id: ClipboardOperationId,
+        reason: String,
+    },
+}
+
+struct ActiveOperation<C, T> {
+    id: ClipboardOperationId,
+    context: C,
+    receiver: Receiver<ProducerMessage<T>>,
+}
+
+pub(in crate::backend::wayland) struct ClipboardOperationController<C, T> {
+    ids: ClipboardOperationIdSource,
+    runtime_wake: RuntimeWakeHandle,
+    active: Option<ActiveOperation<C, T>>,
+    healthy: bool,
+}
+
+impl<C, T> ClipboardOperationController<C, T>
+where
+    T: Send + 'static,
+{
+    pub(in crate::backend::wayland) fn new(
+        ids: ClipboardOperationIdSource,
+        runtime_wake: RuntimeWakeHandle,
+    ) -> Self {
+        Self {
+            ids,
+            runtime_wake,
+            active: None,
+            healthy: true,
+        }
+    }
+
+    pub(in crate::backend::wayland) fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+
+    pub(in crate::backend::wayland) fn try_submit(
+        &mut self,
+        context: C,
+        thread_name: &'static str,
+        operation: impl FnOnce() -> T + Send + 'static,
+    ) -> Result<ClipboardOperationId, ClipboardSubmitFailure<C>> {
+        self.try_submit_with_spawner(context, operation, |job| {
+            std::thread::Builder::new()
+                .name(thread_name.to_string())
+                .spawn(job)
+                .map(drop)
+        })
+    }
+
+    fn try_submit_with_spawner(
+        &mut self,
+        context: C,
+        operation: impl FnOnce() -> T + Send + 'static,
+        spawn: impl FnOnce(Box<dyn FnOnce() + Send>) -> std::io::Result<()>,
+    ) -> Result<ClipboardOperationId, ClipboardSubmitFailure<C>> {
+        if !self.healthy {
+            return Err(ClipboardSubmitFailure {
+                error: ClipboardSubmitError::Unhealthy,
+                context,
+            });
+        }
+        if let Some(active) = &self.active {
+            return Err(ClipboardSubmitFailure {
+                error: ClipboardSubmitError::Busy {
+                    active_id: active.id,
+                },
+                context,
+            });
+        }
+        let id = match self.ids.allocate() {
+            Ok(id) => id,
+            Err(error) => {
+                if error == ClipboardSubmitError::Unhealthy {
+                    self.healthy = false;
+                }
+                return Err(ClipboardSubmitFailure { error, context });
+            }
+        };
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let runtime_wake = self.runtime_wake.clone();
+        let job = Box::new(move || {
+            let guard = ClipboardProducerExitGuard::new(id, sender, runtime_wake);
+            let message = match catch_unwind(AssertUnwindSafe(operation)) {
+                Ok(outcome) => ProducerMessage::Ready { id, outcome },
+                Err(payload) => ProducerMessage::Failed {
+                    id,
+                    reason: panic_reason(payload),
+                },
+            };
+            guard.publish(message);
+        });
+        if let Err(err) = spawn(job) {
+            return Err(ClipboardSubmitFailure {
+                error: ClipboardSubmitError::SpawnFailed {
+                    reason: err.to_string(),
+                },
+                context,
+            });
+        }
+        self.active = Some(ActiveOperation {
+            id,
+            context,
+            receiver,
+        });
+        Ok(id)
+    }
+
+    pub(in crate::backend::wayland) fn poll(&mut self) -> ClipboardPoll<C, T> {
+        let Some(active) = self.active.as_ref() else {
+            return ClipboardPoll::Idle;
+        };
+        let active_id = active.id;
+        match active.receiver.try_recv() {
+            Err(TryRecvError::Empty) => ClipboardPoll::Pending { id: active_id },
+            Err(TryRecvError::Disconnected) => {
+                let active = self.active.take().expect("active receiver checked above");
+                ClipboardPoll::Disconnected {
+                    id: active.id,
+                    context: active.context,
+                }
+            }
+            Ok(ProducerMessage::Ready { id, outcome }) if id == active_id => {
+                let active = self.active.take().expect("active receiver checked above");
+                ClipboardPoll::Ready {
+                    id,
+                    context: active.context,
+                    outcome,
+                }
+            }
+            Ok(ProducerMessage::Failed { id, reason }) if id == active_id => {
+                let active = self.active.take().expect("active receiver checked above");
+                ClipboardPoll::ProducerFailed {
+                    id,
+                    context: active.context,
+                    reason,
+                }
+            }
+            Ok(ProducerMessage::Ready { id, .. } | ProducerMessage::Failed { id, .. }) => {
+                self.healthy = false;
+                let active = self.active.take().expect("active receiver checked above");
+                ClipboardPoll::ProducerFailed {
+                    id: active.id,
+                    context: active.context,
+                    reason: format!(
+                        "clipboard producer reported transport identity {id}, expected {}",
+                        active.id
+                    ),
+                }
+            }
+        }
+    }
+}
+
+fn panic_reason(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "clipboard producer panicked with a non-string payload".to_string()
+    }
+}
+
+struct ClipboardProducerExitGuard<T> {
+    id: ClipboardOperationId,
+    sender: Option<SyncSender<ProducerMessage<T>>>,
+    runtime_wake: RuntimeWakeHandle,
+    terminal_published: bool,
+}
+
+impl<T> ClipboardProducerExitGuard<T> {
+    fn new(
+        id: ClipboardOperationId,
+        sender: SyncSender<ProducerMessage<T>>,
+        runtime_wake: RuntimeWakeHandle,
+    ) -> Self {
+        Self {
+            id,
+            sender: Some(sender),
+            runtime_wake,
+            terminal_published: false,
+        }
+    }
+
+    fn publish(mut self, message: ProducerMessage<T>) {
+        let result = self
+            .sender
+            .as_ref()
+            .expect("producer sender retained until publication")
+            .try_send(message);
+        self.sender.take();
+        self.terminal_published = true;
+        match result {
+            Ok(()) | Err(TrySendError::Disconnected(_)) => {}
+            Err(TrySendError::Full(_)) => {
+                log::error!(
+                    "Clipboard producer {} found an impossible full terminal channel",
+                    self.id
+                );
+            }
+        }
+        if let Err(err) = self.runtime_wake.wake() {
+            log::error!(
+                "Failed to wake runtime for clipboard operation {}: {err}",
+                self.id
+            );
+        }
+    }
+}
+
+impl<T> Drop for ClipboardProducerExitGuard<T> {
+    fn drop(&mut self) {
+        if self.terminal_published {
+            return;
+        }
+        // Closing the producer side is the terminal publication for a disconnect.
+        self.sender.take();
+        if let Err(err) = self.runtime_wake.wake() {
+            log::error!(
+                "Failed to wake runtime for disconnected clipboard operation {}: {err}",
+                self.id
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+    use crate::backend::wayland::RuntimeWakeSource;
+
+    fn controller<C, T: Send + 'static>() -> (RuntimeWakeSource, ClipboardOperationController<C, T>)
+    {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let controller =
+            ClipboardOperationController::new(ClipboardOperationIdSource::new(), wake.handle());
+        (wake, controller)
+    }
+
+    fn wait_for_wake(wake: &RuntimeWakeSource) {
+        let mut pollfd = libc::pollfd {
+            fd: wake.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd and the runtime wake descriptor remain valid for the bounded wait.
+        assert_eq!(unsafe { libc::poll(&mut pollfd, 1, 1_000) }, 1);
+        assert_ne!(pollfd.revents & libc::POLLIN, 0);
+    }
+
+    fn wait_until_thread_is_blocked_in_poll(tid: libc::pid_t) {
+        let stat_path = format!("/proc/self/task/{tid}/stat");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let state = std::fs::read_to_string(&stat_path).ok().and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .and_then(|(_, suffix)| suffix.chars().next())
+            });
+            if state == Some('S') {
+                return;
+            }
+            assert!(Instant::now() < deadline, "poller did not block: {state:?}");
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn shared_source_allocates_distinct_ids_across_controllers() {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let ids = ClipboardOperationIdSource::new();
+        let mut publish = ClipboardOperationController::new(ids.clone(), wake.handle());
+        let mut paste = ClipboardOperationController::new(ids, wake.handle());
+
+        let publish_id = publish.try_submit("publish", "test-publish", || 1).unwrap();
+        let paste_id = paste.try_submit("paste", "test-paste", || 2).unwrap();
+        assert_eq!(publish_id, ClipboardOperationId(1));
+        assert_eq!(paste_id, ClipboardOperationId(2));
+    }
+
+    #[test]
+    fn unread_result_remains_busy_until_matching_consumption() {
+        let (wake, mut controller) = controller::<&'static str, u32>();
+        let first = controller.try_submit("first", "test-first", || 7).unwrap();
+        wait_for_wake(&wake);
+        let failure = controller
+            .try_submit("second", "test-second", || 8)
+            .unwrap_err();
+        assert_eq!(
+            failure.into_parts().0,
+            ClipboardSubmitError::Busy { active_id: first }
+        );
+        assert_eq!(
+            controller.poll(),
+            ClipboardPoll::Ready {
+                id: first,
+                context: "first",
+                outcome: 7,
+            }
+        );
+        let next = controller.try_submit("third", "test-third", || 9).unwrap();
+        assert!(next > first);
+    }
+
+    #[test]
+    fn pending_operation_rejects_submission_as_busy() {
+        let (wake, mut controller) = controller::<&'static str, u32>();
+        let (release_tx, release_rx) = mpsc::channel();
+        let first = controller
+            .try_submit("first", "test-pending", move || {
+                release_rx.recv().unwrap();
+                7
+            })
+            .unwrap();
+
+        let failure = controller
+            .try_submit("second", "test-busy", || 8)
+            .unwrap_err();
+        assert_eq!(
+            failure.into_parts(),
+            (ClipboardSubmitError::Busy { active_id: first }, "second",)
+        );
+
+        release_tx.send(()).unwrap();
+        wait_for_wake(&wake);
+        assert!(matches!(controller.poll(), ClipboardPoll::Ready { .. }));
+    }
+
+    #[test]
+    fn completion_is_visible_before_its_wake() {
+        let (wake, mut controller) = controller::<u64, u64>();
+        let id = controller.try_submit(11, "test-ready", || 29).unwrap();
+        wait_for_wake(&wake);
+        assert_eq!(
+            controller.poll(),
+            ClipboardPoll::Ready {
+                id,
+                context: 11,
+                outcome: 29,
+            }
+        );
+    }
+
+    #[test]
+    fn completion_unblocks_an_existing_runtime_poll() {
+        let (wake, mut controller) = controller::<u64, u64>();
+        let (release_tx, release_rx) = mpsc::channel();
+        let id = controller
+            .try_submit(5, "test-waiting", move || {
+                release_rx.recv().unwrap();
+                13
+            })
+            .unwrap();
+        let (tid_tx, tid_rx) = mpsc::channel();
+        let poller = std::thread::spawn(move || {
+            // SAFETY: gettid has no preconditions and is used only to observe this test thread.
+            let tid = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
+            tid_tx.send(tid).unwrap();
+            wait_for_wake(&wake);
+        });
+        let tid = tid_rx.recv().unwrap();
+        wait_until_thread_is_blocked_in_poll(tid);
+        release_tx.send(()).unwrap();
+        poller.join().unwrap();
+        assert_eq!(
+            controller.poll(),
+            ClipboardPoll::Ready {
+                id,
+                context: 5,
+                outcome: 13,
+            }
+        );
+    }
+
+    #[test]
+    fn producer_panic_publishes_failure_and_wakes() {
+        let (wake, mut controller) = controller::<u64, u64>();
+        let id = controller
+            .try_submit(17, "test-panic", || panic!("expected producer panic"))
+            .unwrap();
+        wait_for_wake(&wake);
+        assert_eq!(
+            controller.poll(),
+            ClipboardPoll::ProducerFailed {
+                id,
+                context: 17,
+                reason: "expected producer panic".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn exit_guard_disconnects_before_waking() {
+        let wake = RuntimeWakeSource::new().unwrap();
+        let ids = ClipboardOperationIdSource::new();
+        let mut controller = ClipboardOperationController::<u64, u64>::new(ids, wake.handle());
+        let id = ClipboardOperationId(9);
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        controller.active = Some(ActiveOperation {
+            id,
+            context: 31,
+            receiver,
+        });
+        drop(ClipboardProducerExitGuard::new(id, sender, wake.handle()));
+        wait_for_wake(&wake);
+        assert_eq!(
+            controller.poll(),
+            ClipboardPoll::Disconnected { id, context: 31 }
+        );
+    }
+
+    #[test]
+    fn spawn_failure_installs_no_active_identity_and_returns_context() {
+        let (wake, mut controller) = controller::<u64, u64>();
+        let failure = controller
+            .try_submit_with_spawner(
+                41,
+                || 1,
+                |_job| Err(std::io::Error::other("injected spawn failure")),
+            )
+            .unwrap_err();
+        assert_eq!(
+            failure.into_parts(),
+            (
+                ClipboardSubmitError::SpawnFailed {
+                    reason: "injected spawn failure".to_string(),
+                },
+                41,
+            )
+        );
+        assert!(!controller.is_active());
+        let mut pollfd = libc::pollfd {
+            fd: wake.poll_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd and the runtime wake descriptor are valid for this non-blocking poll.
+        assert_eq!(unsafe { libc::poll(&mut pollfd, 1, 0) }, 0);
+        assert_eq!(
+            controller
+                .try_submit(42, "test-after-spawn-failure", || 2)
+                .unwrap(),
+            ClipboardOperationId(2)
+        );
+    }
+
+    #[test]
+    fn identity_mismatch_restores_active_context_and_disables_controller() {
+        let (_wake, mut controller) = controller::<u64, u64>();
+        let active_id = ClipboardOperationId(3);
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        controller.active = Some(ActiveOperation {
+            id: active_id,
+            context: 43,
+            receiver,
+        });
+        sender
+            .try_send(ProducerMessage::Ready {
+                id: ClipboardOperationId(4),
+                outcome: 99,
+            })
+            .unwrap();
+        assert!(matches!(
+            controller.poll(),
+            ClipboardPoll::ProducerFailed {
+                id,
+                context: 43,
+                ..
+            } if id == active_id
+        ));
+        let failure = controller
+            .try_submit(44, "test-unhealthy", || 1)
+            .unwrap_err();
+        assert_eq!(failure.into_parts().0, ClipboardSubmitError::Unhealthy);
+    }
+
+    #[test]
+    fn maximum_identity_is_used_once_without_wrapping() {
+        let (wake, mut controller) = controller::<u64, u64>();
+        *controller.ids.next.lock().unwrap() = Some(u64::MAX);
+        let id = controller.try_submit(1, "test-max-id", || 2).unwrap();
+        assert_eq!(id, ClipboardOperationId(u64::MAX));
+        wait_for_wake(&wake);
+        assert!(matches!(controller.poll(), ClipboardPoll::Ready { .. }));
+        let failure = controller
+            .try_submit(3, "test-exhausted", || 4)
+            .unwrap_err();
+        assert_eq!(
+            failure.into_parts().0,
+            ClipboardSubmitError::IdentityExhausted
+        );
+    }
+
+    #[derive(Clone, Debug)]
+    struct DropContext(Arc<AtomicUsize>);
+
+    impl Drop for DropContext {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn dropping_pending_controller_releases_event_context_immediately() {
+        let (_wake, mut controller) = controller::<DropContext, u64>();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let (release_tx, release_rx) = mpsc::channel();
+        controller
+            .try_submit(DropContext(drops.clone()), "test-drop-pending", move || {
+                let _ = release_rx.recv();
+                1
+            })
+            .unwrap();
+        drop(controller);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        release_tx.send(()).unwrap();
+    }
+
+    #[test]
+    fn dropping_completed_unread_controller_releases_event_context() {
+        let (wake, mut controller) = controller::<DropContext, u64>();
+        let drops = Arc::new(AtomicUsize::new(0));
+        controller
+            .try_submit(DropContext(drops.clone()), "test-drop-completed", || 1)
+            .unwrap();
+        wait_for_wake(&wake);
+        drop(controller);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/backend/wayland/clipboard/mod.rs
+++ b/src/backend/wayland/clipboard/mod.rs
@@ -11,10 +11,14 @@ pub(in crate::backend::wayland) use transfer::{
     FailedLocalSelectionProbe, PasteAction, TransferEffect, TransferPlan, TransferWarning,
 };
 
+mod completion;
 mod file_list;
 mod image;
 mod system;
 pub(in crate::backend::wayland) mod transfer;
+pub(in crate::backend::wayland) use completion::{
+    ClipboardOperationController, ClipboardOperationIdSource, ClipboardPoll,
+};
 
 pub(super) const WAYSCRIBER_SELECTION_MIME: &str = "application/vnd.wayscriber.selection+json";
 

--- a/src/backend/wayland/clipboard/transfer/tests.rs
+++ b/src/backend/wayland/clipboard/transfer/tests.rs
@@ -38,6 +38,92 @@ fn timeout_uses_fresh_fallback_action_instead_of_captured_shapes() {
 }
 
 #[test]
+fn clipboard_terminal_outcomes_keep_their_existing_event_loop_policy() {
+    let warning_cases = [
+        (
+            ClipboardPasteResult::ClipboardEmpty,
+            TransferWarning::ClipboardEmpty,
+        ),
+        (
+            ClipboardPasteResult::NoSupportedMime {
+                offered: vec!["text/plain".to_string()],
+            },
+            TransferWarning::UnsupportedContent,
+        ),
+        (
+            ClipboardPasteResult::DecodeFailed("bad image".to_string()),
+            TransferWarning::DecodeFailed,
+        ),
+        (
+            ClipboardPasteResult::TooLarge { limit: 1024 },
+            TransferWarning::TooLarge { limit: 1024 },
+        ),
+    ];
+    for (result, expected_warning) in warning_cases {
+        let completion = ClipboardPasteCompletion {
+            request: request_with_fallback_generation(Some(7)),
+            result,
+        };
+        let plan = plan_paste_completion(completion, Some(42), None);
+        assert!(matches!(
+            plan.action,
+            PasteAction::ShowWarning {
+                warning,
+                block_feedback: true,
+                ..
+            } if warning == expected_warning
+        ));
+    }
+
+    let failure = plan_paste_completion(
+        ClipboardPasteCompletion {
+            request: request_with_fallback_generation(Some(7)),
+            result: ClipboardPasteResult::ClipboardError("disconnected".to_string()),
+        },
+        Some(42),
+        None,
+    );
+    assert!(matches!(
+        failure.action,
+        PasteAction::TryFreshLocalFallbackOrWarn {
+            missing_warning: TransferWarning::ClipboardError,
+            ..
+        }
+    ));
+
+    let image = plan_paste_completion(
+        ClipboardPasteCompletion {
+            request: request_with_fallback_generation(Some(7)),
+            result: ClipboardPasteResult::Image(crate::draw::EmbeddedImage {
+                mime_type: "image/png".to_string(),
+                width: 1,
+                height: 1,
+                bytes: vec![0, 0, 0, 255],
+            }),
+        },
+        Some(42),
+        None,
+    );
+    assert!(matches!(
+        image.action,
+        PasteAction::ApplyExternalImage { .. }
+    ));
+}
+
+#[test]
+fn stale_domain_request_is_rejected_after_transport_matching() {
+    let completion = ClipboardPasteCompletion {
+        request: request_with_fallback_generation(None),
+        result: ClipboardPasteResult::ClipboardEmpty,
+    };
+    let plan = plan_paste_completion(completion, Some(99), None);
+    assert!(matches!(
+        plan.action,
+        PasteAction::StaleCompletion { request_id: 42 }
+    ));
+}
+
+#[test]
 fn same_instance_nonmatching_generation_does_not_apply_private_selection() {
     let request = request_with_fallback_generation(Some(7));
     let completion = ClipboardPasteCompletion {

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -57,6 +57,7 @@ use crate::{
         types::CaptureType,
     },
     config::{Action, Config},
+    input::state::ClipboardPasteRequest,
     input::{DrawingState, EraserMode, InputState, Tool, ZoomAction},
     session::SessionOptions,
     ui::toolbar::{ToolbarBindingHints, ToolbarEvent, ToolbarSnapshot},
@@ -66,7 +67,10 @@ use self::data::{MoveDrag, StateData};
 pub use self::data::{MoveDragKind, OverlaySuppression, XdgFrozenFullscreenState};
 use super::{
     capture::{CapturePreflightRequest, CaptureState, PendingPdfExport},
-    clipboard::{ClipboardPasteCompletion, ClipboardPublishCompletion},
+    clipboard::{
+        ClipboardOperationController, ClipboardOperationIdSource, ClipboardPasteCompletion,
+        ClipboardPublishCompletion,
+    },
     frozen::FrozenState,
     overlay_passthrough::set_surface_clickthrough,
     session::SessionState,
@@ -142,6 +146,7 @@ pub(in crate::backend::wayland) struct WaylandStateInit {
     pub capture_manager: CaptureManager,
     pub session_options: Option<SessionOptions>,
     pub persistence: crate::backend::wayland::session::PersistenceController,
+    pub runtime_wake: crate::backend::wayland::RuntimeWakeHandle,
     pub tokio_handle: tokio::runtime::Handle,
     pub exit_after_capture_mode: ExitAfterCaptureMode,
     pub frozen_enabled: bool,
@@ -184,8 +189,9 @@ pub(super) struct WaylandState {
 
     // Input state
     pub(super) input_state: InputState,
-    pub(super) clipboard_publish_rx: Option<std::sync::mpsc::Receiver<ClipboardPublishCompletion>>,
-    pub(super) clipboard_paste_rx: Option<std::sync::mpsc::Receiver<ClipboardPasteCompletion>>,
+    pub(super) clipboard_publish: ClipboardOperationController<u64, ClipboardPublishCompletion>,
+    pub(super) clipboard_paste:
+        ClipboardOperationController<ClipboardPasteRequest, ClipboardPasteCompletion>,
     /// GTK toolbar frontend; `None` means the built-in bars are in charge.
     pub(super) gtk_toolbar: Option<crate::toolbar_gtk::GtkToolbarBridge>,
     pub(super) onboarding: crate::onboarding::OnboardingStore,

--- a/src/backend/wayland/state/clipboard.rs
+++ b/src/backend/wayland/state/clipboard.rs
@@ -2,12 +2,11 @@
 
 use super::WaylandState;
 use crate::backend::wayland::clipboard::{
-    self, ClipboardPasteCompletion, ClipboardPasteResult, ClipboardPublishCompletion,
-    FailedLocalSelectionProbe, PasteAction, TransferEffect, TransferPlan, TransferWarning,
-    transfer,
+    self, ClipboardPasteCompletion, ClipboardPasteResult, ClipboardPoll,
+    ClipboardPublishCompletion, FailedLocalSelectionProbe, PasteAction, TransferEffect,
+    TransferPlan, TransferWarning, transfer,
 };
 use crate::input::state::{ClipboardPasteRequest, UiToastKind};
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 mod session_paste;
@@ -16,7 +15,7 @@ use session_paste::{PastePersistenceDecision, SessionPasteWarning};
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn drain_clipboard_requests(&mut self) {
-        if self.clipboard_publish_rx.is_none()
+        if !self.clipboard_publish.is_active()
             && let Some(request) = self.input_state.take_pending_selection_clipboard_publish()
         {
             self.start_selection_clipboard_publish(request.generation, request.payload_json);
@@ -28,36 +27,109 @@ impl WaylandState {
     }
 
     pub(in crate::backend::wayland) fn poll_clipboard_publish_completion(&mut self) {
-        let Some(rx) = &self.clipboard_publish_rx else {
-            return;
-        };
-        let Ok(completion) = rx.try_recv() else {
-            return;
-        };
-        self.clipboard_publish_rx = None;
-        self.apply_selection_clipboard_publish_completion(completion);
+        match self.clipboard_publish.poll() {
+            ClipboardPoll::Idle | ClipboardPoll::Pending { .. } => {}
+            ClipboardPoll::Ready {
+                id,
+                context: generation,
+                outcome,
+            } => {
+                if outcome.generation == generation {
+                    self.apply_selection_clipboard_publish_completion(outcome);
+                } else {
+                    log::error!(
+                        "Clipboard publish operation {id} returned generation {}, expected {generation}",
+                        outcome.generation
+                    );
+                    self.apply_selection_clipboard_publish_completion(
+                        failed_clipboard_publish_completion(generation),
+                    );
+                }
+            }
+            ClipboardPoll::ProducerFailed {
+                id,
+                context: generation,
+                reason,
+            } => {
+                log::warn!("Clipboard publish operation {id} failed: {reason}");
+                self.apply_selection_clipboard_publish_completion(
+                    failed_clipboard_publish_completion(generation),
+                );
+            }
+            ClipboardPoll::Disconnected {
+                id,
+                context: generation,
+            } => {
+                log::warn!("Clipboard publish operation {id} disconnected");
+                self.apply_selection_clipboard_publish_completion(
+                    failed_clipboard_publish_completion(generation),
+                );
+            }
+        }
     }
 
     pub(in crate::backend::wayland) fn poll_clipboard_paste_completion(&mut self) {
-        let Some(rx) = &self.clipboard_paste_rx else {
-            return;
-        };
-        let Ok(completion) = rx.try_recv() else {
-            return;
-        };
-        self.clipboard_paste_rx = None;
-        self.apply_clipboard_paste_completion(completion);
+        match self.clipboard_paste.poll() {
+            ClipboardPoll::Idle | ClipboardPoll::Pending { .. } => {}
+            ClipboardPoll::Ready {
+                id,
+                context: request,
+                outcome,
+            } => {
+                if outcome.request.id == request.id {
+                    self.apply_clipboard_paste_completion(ClipboardPasteCompletion {
+                        request,
+                        result: outcome.result,
+                    });
+                } else {
+                    log::error!(
+                        "Clipboard paste operation {id} returned request {}, expected {}",
+                        outcome.request.id,
+                        request.id
+                    );
+                    self.apply_clipboard_paste_completion(failed_clipboard_paste_completion(
+                        request,
+                        "clipboard producer returned a mismatched request",
+                    ));
+                }
+            }
+            ClipboardPoll::ProducerFailed {
+                id,
+                context: request,
+                reason,
+            } => {
+                log::warn!("Clipboard paste operation {id} failed: {reason}");
+                self.apply_clipboard_paste_completion(failed_clipboard_paste_completion(
+                    request, &reason,
+                ));
+            }
+            ClipboardPoll::Disconnected {
+                id,
+                context: request,
+            } => {
+                log::warn!("Clipboard paste operation {id} disconnected");
+                self.apply_clipboard_paste_completion(failed_clipboard_paste_completion(
+                    request,
+                    "clipboard producer disconnected",
+                ));
+            }
+        }
     }
 
     fn start_selection_clipboard_publish(&mut self, generation: u64, payload_json: String) {
         self.suppress_focus_exit_for(Duration::from_millis(1500));
-        let (tx, rx) = mpsc::channel();
-        self.clipboard_publish_rx = Some(rx);
-        std::thread::spawn(move || {
-            let completion =
-                transfer::resolve_selection_clipboard_publish(generation, payload_json);
-            let _ = tx.send(completion);
-        });
+        if let Err(failure) =
+            self.clipboard_publish
+                .try_submit(generation, "clipboard-publish", move || {
+                    transfer::resolve_selection_clipboard_publish(generation, payload_json)
+                })
+        {
+            let (error, generation) = failure.into_parts();
+            log::warn!("Could not submit clipboard publish operation: {error}");
+            self.apply_selection_clipboard_publish_completion(failed_clipboard_publish_completion(
+                generation,
+            ));
+        }
     }
 
     fn apply_selection_clipboard_publish_completion(
@@ -269,19 +341,31 @@ impl WaylandState {
 
     fn start_system_clipboard_read(&mut self, request: ClipboardPasteRequest) {
         log::info!("Reading system clipboard for paste request {}", request.id);
-        let (tx, rx) = mpsc::channel();
-        self.clipboard_paste_rx = Some(rx);
-        std::thread::spawn(move || {
-            let started = Instant::now();
-            let result = transfer::resolve_system_clipboard();
-            log::info!(
-                "System clipboard read for paste request {} completed in {:?}: {}",
-                request.id,
-                started.elapsed(),
-                result.summary()
+        let context = request.clone();
+        if let Err(failure) =
+            self.clipboard_paste
+                .try_submit(context, "clipboard-paste", move || {
+                    let started = Instant::now();
+                    let result = transfer::resolve_system_clipboard();
+                    log::info!(
+                        "System clipboard read for paste request {} completed in {:?}: {}",
+                        request.id,
+                        started.elapsed(),
+                        result.summary()
+                    );
+                    ClipboardPasteCompletion { request, result }
+                })
+        {
+            let (error, request) = failure.into_parts();
+            log::warn!(
+                "Could not submit clipboard paste operation for request {}: {error}",
+                request.id
             );
-            let _ = tx.send(ClipboardPasteCompletion { request, result });
-        });
+            self.apply_clipboard_paste_completion(failed_clipboard_paste_completion(
+                request,
+                &error.to_string(),
+            ));
+        }
     }
 
     fn apply_transfer_effect(&mut self, effect: TransferEffect) {
@@ -390,5 +474,68 @@ impl WaylandState {
                 "Wayscriber clipboard selection could not be read.",
             ),
         }
+    }
+}
+
+fn failed_clipboard_publish_completion(generation: u64) -> ClipboardPublishCompletion {
+    ClipboardPublishCompletion {
+        generation,
+        fingerprint: None,
+        copied: false,
+        warning: Some(TransferWarning::PublishUnavailable),
+    }
+}
+
+fn failed_clipboard_paste_completion(
+    request: ClipboardPasteRequest,
+    reason: &str,
+) -> ClipboardPasteCompletion {
+    ClipboardPasteCompletion {
+        request,
+        result: ClipboardPasteResult::ClipboardError(reason.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod transport_tests {
+    use super::*;
+    use crate::input::state::PasteAnchor;
+    use crate::util::Rect;
+
+    fn request(id: u64) -> ClipboardPasteRequest {
+        ClipboardPasteRequest {
+            id,
+            target_board_id: "board".to_string(),
+            target_page_index: 2,
+            target_page_generation: 3,
+            anchor: PasteAnchor::VisibleCenter { x: 10, y: 20 },
+            visible_canvas_rect: Rect::new(0, 0, 100, 100).unwrap(),
+            screen_size: (100, 100),
+            selection_clipboard_generation_at_request: 4,
+            local_selection_fallback_generation: Some(5),
+        }
+    }
+
+    #[test]
+    fn publish_transport_failure_preserves_generation_without_sync_probe() {
+        let completion = failed_clipboard_publish_completion(17);
+        assert_eq!(completion.generation, 17);
+        assert_eq!(completion.fingerprint, None);
+        assert!(!completion.copied);
+        assert_eq!(
+            completion.warning,
+            Some(TransferWarning::PublishUnavailable)
+        );
+    }
+
+    #[test]
+    fn paste_transport_failure_preserves_original_request_context() {
+        let original = request(19);
+        let completion = failed_clipboard_paste_completion(original.clone(), "disconnected");
+        assert_eq!(completion.request, original);
+        assert!(matches!(
+            completion.result,
+            ClipboardPasteResult::ClipboardError(ref reason) if reason == "disconnected"
+        ));
     }
 }

--- a/src/backend/wayland/state/clipboard.rs
+++ b/src/backend/wayland/state/clipboard.rs
@@ -21,7 +21,10 @@ impl WaylandState {
             self.start_selection_clipboard_publish(request.generation, request.payload_json);
         }
 
-        if let Some(request) = self.input_state.take_pending_clipboard_paste_request() {
+        if let Some(request) = take_pending_clipboard_paste_if_idle(
+            &mut self.input_state,
+            self.clipboard_paste.is_active(),
+        ) {
             self.start_clipboard_paste(request);
         }
     }
@@ -496,10 +499,19 @@ fn failed_clipboard_paste_completion(
     }
 }
 
+fn take_pending_clipboard_paste_if_idle(
+    input_state: &mut crate::input::InputState,
+    clipboard_paste_active: bool,
+) -> Option<ClipboardPasteRequest> {
+    (!clipboard_paste_active)
+        .then(|| input_state.take_pending_clipboard_paste_request())
+        .flatten()
+}
+
 #[cfg(test)]
 mod transport_tests {
     use super::*;
-    use crate::input::state::PasteAnchor;
+    use crate::input::state::{PasteAnchor, test_support::make_test_input_state};
     use crate::util::Rect;
 
     fn request(id: u64) -> ClipboardPasteRequest {
@@ -537,5 +549,24 @@ mod transport_tests {
             completion.result,
             ClipboardPasteResult::ClipboardError(ref reason) if reason == "disconnected"
         ));
+    }
+
+    #[test]
+    fn active_paste_transport_defers_the_newest_pending_request() {
+        let mut input_state = make_test_input_state();
+        let superseded = input_state.request_clipboard_paste();
+
+        assert!(
+            take_pending_clipboard_paste_if_idle(&mut input_state, true).is_none(),
+            "an active transport must not consume a newer paste request"
+        );
+
+        let newest = input_state.request_clipboard_paste();
+        assert_ne!(newest.id, superseded.id);
+        assert!(take_pending_clipboard_paste_if_idle(&mut input_state, true).is_none());
+        assert_eq!(
+            take_pending_clipboard_paste_if_idle(&mut input_state, false),
+            Some(newest)
+        );
     }
 }

--- a/src/backend/wayland/state/core/init.rs
+++ b/src/backend/wayland/state/core/init.rs
@@ -12,6 +12,7 @@ impl WaylandState {
             capture_manager,
             session_options,
             persistence,
+            runtime_wake,
             tokio_handle,
             exit_after_capture_mode,
             frozen_enabled,
@@ -86,6 +87,13 @@ impl WaylandState {
             WaylandState::ui_animation_interval_from_fps(config.performance.ui_animation_fps);
 
         let buffer_count = config.performance.buffer_count as usize;
+        let clipboard_operation_ids = ClipboardOperationIdSource::new();
+        let clipboard_publish = ClipboardOperationController::new(
+            clipboard_operation_ids.clone(),
+            runtime_wake.clone(),
+        );
+        let clipboard_paste =
+            ClipboardOperationController::new(clipboard_operation_ids, runtime_wake);
 
         Self {
             registry_state,
@@ -105,8 +113,8 @@ impl WaylandState {
             canvas_layer_cache: super::super::canvas_layer::CanvasLayerCache::new(),
             config,
             input_state,
-            clipboard_publish_rx: None,
-            clipboard_paste_rx: None,
+            clipboard_publish,
+            clipboard_paste,
             gtk_toolbar: None,
             onboarding,
             ui_animation_next_tick: None,


### PR DESCRIPTION
## Summary

- Replace the 25 ms clipboard polling timeout with runtime wake notifications.
- Route clipboard publish and paste work through identified, capacity-one completion controllers.
- Publish completion state before waking the Wayland event loop.
- Preserve operation context across success, panic, disconnect, spawn failure, and identity mismatch paths.
- Keep the newest paste request pending while an earlier clipboard read is active, instead of failing it as `Busy`.

## Why

Clipboard operations previously required periodic event-loop polling, adding unnecessary wakeups and up to 25 ms of completion latency.

Rapid consecutive paste requests could also discard the newer request while the first system clipboard read was active. The older completion would then become stale, potentially leaving neither request pasted.