### PR TITLE
Make configurator saves lossless and conflict-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +2813,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -3173,10 +3184,12 @@ dependencies = [
  "png",
  "schemars",
  "serde",
+ "serde_ignored",
  "serde_json",
  "smithay-client-toolkit 0.20.0",
  "tokio",
  "toml",
+ "toml_edit",
  "wayland-client",
  "wayland-protocols",
  "wayland-protocols-wlr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,9 @@ pangocairo = "0.22"
 log = { version = "0.4", features = ["std"] }
 anyhow = "1.0"
 toml = "1.1"
+toml_edit = "0.25"
 serde = { version = "1.0", features = ["derive"] }
+serde_ignored = "0.1"
 schemars = { version = "1.2", features = ["derive"], optional = true }
 libc = "0.2"
 flate2 = "1.0"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1076,7 +1076,7 @@ enable_vsync = false
 # 120 keeps pen latency low without uncapped CPU usage; set to 0 only for profiling
 max_fps_no_vsync = 120
 
-# UI animation frame rate (0 = unlimited)
+# UI animation frame rate (0-240; 0 = unlimited)
 # Higher values smooth UI effects at the cost of more redraws
 ui_animation_fps = 30
 

--- a/configurator/README.md
+++ b/configurator/README.md
@@ -1,6 +1,6 @@
 # Wayscriber Configurator (Iced)
 
-Native Rust desktop UI for editing `~/.config/wayscriber/config.toml`. The application is built on [`iced`](https://github.com/iced-rs/iced) and reuses the `wayscriber::Config` types directly, so validation, defaults, and backup behavior match the CLI.
+Native Rust desktop UI for editing `~/.config/wayscriber/config.toml`. The application is built on [`iced`](https://github.com/iced-rs/iced) and reuses the `wayscriber::Config` types directly, so validation, defaults, and backup behavior match the CLI. It also retains the original TOML document so comments, ordering, and settings unknown to this build survive a save.
 
 ## Prerequisites
 
@@ -18,13 +18,13 @@ The configurator uses Iced's software `tiny-skia` renderer on Wayland. It does
 not compile the GPU renderer or portal D-Bus implementation into the
 configurator binary.
 
-The window loads the current config, lets you tweak values across the tabbed sections, and writes changes back via `Config::save_with_backup()`.
+The window loads the current config, lets you tweak values across the tabbed sections, and writes changes back through the guarded `ConfigDocument` save interface.
 
 ### Handy actions
 
-- **Reload** – re-read `config.toml` from disk.
+- **Reload** – re-read `config.toml` from disk and refresh the guarded source revision. A transient load error leaves the last good document and current draft in place.
 - **Defaults** – drop in the built-in defaults without saving.
-- **Save** – validate inputs (including numeric ranges and color arrays) and write the TOML file. An existing file is backed up with a timestamp.
+- **Save** – validate inputs (including numeric ranges and color arrays), merge known changes into the source TOML, and write it atomically. An existing file is backed up with a timestamp. Save is refused if the file was created, deleted, retargeted through a symlink, or changed byte-for-byte after loading; reload before retrying. If a readable file cannot be parsed, the configurator offers a warning-marked defaults-based repair draft and backs up the unreadable source before saving it. Unknown settings are retained only when the TOML structure is parseable and safely separable; malformed content remains in the backup.
 - **Search** – filter tabs, sections, saved sessions, boards, render profiles, presets, and keybindings as you type. Press `Ctrl+F` to focus search and `Escape` to clear it.
 - Launch from the main overlay with the default `F11` keybinding (configurable inside the app).
 
@@ -35,6 +35,7 @@ The window loads the current config, lets you tweak values across the tabbed sec
 - **Keybindings** – per-action comma-separated shortcut lists that map to `KeybindingsConfig`.
 - **Session** – persistence settings plus named-session catalog management. Rename display labels, reveal files, and forget metadata without touching files. Clear Tool State preserves boards/history while removing persisted tool defaults. Duplicate, Move, Clear Tool State, and Clear are disabled while an overlay, manually started daemon, or background service is active.
 - Live dirty-state indicator plus status banner for success/error details.
+- Non-fatal warnings list unrecognized config paths. Those values are preserved for forward compatibility instead of being deleted.
 
 ## Building Releases
 

--- a/configurator/src/app/io.rs
+++ b/configurator/src/app/io.rs
@@ -1,22 +1,21 @@
-use std::{path::PathBuf, sync::Arc, time::SystemTime};
+use std::{path::PathBuf, sync::Arc};
 
-use wayscriber::config::Config;
+use wayscriber::config::{Config, ConfigDocument};
 
-pub(super) async fn load_config_from_disk() -> Result<Arc<Config>, String> {
-    Config::load()
-        .map(|loaded| Arc::new(loaded.config))
-        .map_err(|err| err.to_string())
+pub(super) async fn load_config_from_disk() -> Result<(Arc<ConfigDocument>, Option<String>), String>
+{
+    ConfigDocument::load_for_editing()
+        .map(|(document, warning)| (Arc::new(document), warning))
+        .map_err(|err| format!("{err:#}"))
 }
 
 pub(super) async fn save_config_to_disk(
+    document: Arc<ConfigDocument>,
     config: Config,
-) -> Result<(Option<PathBuf>, Arc<Config>), String> {
-    let backup = config.save_with_backup().map_err(|err| err.to_string())?;
-    Ok((backup, Arc::new(config)))
-}
-
-pub(super) fn load_config_mtime(path: &Option<PathBuf>) -> Option<SystemTime> {
-    let path = path.as_ref()?;
-    let metadata = std::fs::metadata(path).ok()?;
-    metadata.modified().ok()
+) -> Result<(Option<PathBuf>, Arc<ConfigDocument>), String> {
+    let outcome = document
+        .save_with_backup(config)
+        .map_err(|err| format!("{err:#}"))?;
+    let (document, backup) = outcome.into_parts();
+    Ok((backup, Arc::new(document)))
 }

--- a/configurator/src/app/search/summary.rs
+++ b/configurator/src/app/search/summary.rs
@@ -1,6 +1,8 @@
 use crate::app::state::ConfiguratorApp;
 use crate::models::{KeybindingsTabId, SearchQuery, TabId, UiTabId};
-use wayscriber::config::toolbar_item_definitions;
+use wayscriber::config::{
+    PERFORMANCE_FIELD_METADATA, PerformanceFieldGroup, toolbar_item_definitions,
+};
 
 use super::terms::*;
 use super::types::{AppSearchSummary, SearchArea, TabSearchSummary};
@@ -143,20 +145,30 @@ fn history_matches(query: &SearchQuery, summary: &mut TabSearchSummary) {
 }
 
 fn performance_matches(query: &SearchQuery, summary: &mut TabSearchSummary) {
-    add_area_if(
-        query,
-        summary,
-        TabId::Performance,
-        SearchArea::PerformanceRendering,
-        PERFORMANCE_RENDERING_TERMS,
-    );
-    add_area_if(
-        query,
-        summary,
-        TabId::Performance,
-        SearchArea::PerformanceAnimations,
-        PERFORMANCE_ANIMATION_TERMS,
-    );
+    for (group, area, identity) in [
+        (
+            PerformanceFieldGroup::Rendering,
+            SearchArea::PerformanceRendering,
+            "rendering",
+        ),
+        (
+            PerformanceFieldGroup::Animations,
+            SearchArea::PerformanceAnimations,
+            "animations",
+        ),
+    ] {
+        let mut parts = vec![identity];
+        for metadata in PERFORMANCE_FIELD_METADATA
+            .iter()
+            .filter(|metadata| metadata.group == group)
+        {
+            parts.extend([metadata.path, metadata.label, metadata.help]);
+            parts.extend_from_slice(metadata.search_terms);
+        }
+        if query.matches_parts_scoped_to_tab(TabId::Performance, parts) {
+            summary.add_area(area);
+        }
+    }
 }
 
 fn ui_matches(query: &SearchQuery, summary: &mut TabSearchSummary) {

--- a/configurator/src/app/search/terms.rs
+++ b/configurator/src/app/search/terms.rs
@@ -153,18 +153,6 @@ pub(super) const HISTORY_CUSTOM_TERMS: &[&str] = &[
     "steps",
     "delay",
 ];
-pub(super) const PERFORMANCE_RENDERING_TERMS: &[&str] = &[
-    "rendering",
-    "buffer",
-    "buffer count",
-    "buffer count 2 4",
-    "vsync",
-    "enable vsync",
-    "fps",
-    "max fps",
-    "max fps vsync off",
-];
-pub(super) const PERFORMANCE_ANIMATION_TERMS: &[&str] = &["animation", "ui animation fps"];
 pub(super) const UI_GENERAL_TERMS: &[&str] = &[
     "general ui",
     "preferred output",

--- a/configurator/src/app/search/tests.rs
+++ b/configurator/src/app/search/tests.rs
@@ -147,7 +147,13 @@ fn exact_drawing_color_and_font_labels_match_their_sections() {
 
 #[test]
 fn exact_performance_rendering_labels_match_rendering_section() {
-    for query in ["buffer count", "enable vsync", "max fps"] {
+    for query in [
+        "buffer count",
+        "enable vsync",
+        "max fps",
+        "performance buffer count",
+        "render performance buffer count",
+    ] {
         let (mut app, _task) = ConfiguratorApp::new_app();
         app.search_query = SearchQuery::new(query);
 

--- a/configurator/src/app/state.rs
+++ b/configurator/src/app/state.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
-use std::{path::PathBuf, sync::Arc, time::SystemTime};
+use std::{path::PathBuf, sync::Arc};
 
 use iced::Task;
-use wayscriber::config::{Config, PRESET_SLOTS_MAX};
+use wayscriber::config::{Config, ConfigDocument, PRESET_SLOTS_MAX};
 
 use crate::messages::Message;
 use crate::models::{
@@ -19,8 +19,8 @@ pub(crate) struct ConfiguratorApp {
     pub(crate) draft: ConfigDraft,
     pub(crate) baseline: ConfigDraft,
     pub(crate) defaults: ConfigDraft,
-    // Base config loaded from disk to preserve unknown fields when saving.
-    pub(crate) base_config: Arc<Config>,
+    // The source document owns typed config, lossless TOML, and the guarded save revision.
+    pub(crate) base_document: Option<Arc<ConfigDocument>>,
     pub(crate) status: StatusMessage,
     pub(crate) active_tab: TabId,
     pub(crate) active_ui_tab: UiTabId,
@@ -36,8 +36,6 @@ pub(crate) struct ConfiguratorApp {
     pub(crate) is_saving: bool,
     pub(crate) is_dirty: bool,
     pub(crate) defaults_reset_pending: bool,
-    pub(crate) config_path: Option<PathBuf>,
-    pub(crate) config_mtime: Option<SystemTime>,
     pub(crate) last_backup_path: Option<PathBuf>,
     pub(crate) daemon_status: Option<DaemonRuntimeStatus>,
     pub(crate) daemon_shortcut_input: String,
@@ -90,15 +88,13 @@ impl ConfiguratorApp {
         let baseline = defaults.clone();
         let override_mode = defaults.ui_toolbar_layout_mode;
         let boards_len = defaults.boards.items.len();
-        let config_path = Config::get_config_path().ok();
-        let base_config = Arc::new(default_config.clone());
         let desktop = DesktopEnvironment::detect_current();
 
         let mut app = Self {
             draft: baseline.clone(),
             baseline,
             defaults,
-            base_config,
+            base_document: None,
             status: StatusMessage::info("Loading configuration..."),
             active_tab: TabId::Daemon,
             active_ui_tab: UiTabId::Toolbar,
@@ -114,8 +110,6 @@ impl ConfiguratorApp {
             is_saving: false,
             is_dirty: false,
             defaults_reset_pending: false,
-            config_path,
-            config_mtime: None,
             last_backup_path: None,
             daemon_status: None,
             daemon_shortcut_input: desktop.default_shortcut_input().to_string(),
@@ -143,20 +137,6 @@ impl ConfiguratorApp {
         (app, command)
     }
 
-    pub(super) fn config_changed_on_disk(&self) -> bool {
-        let Some(last_modified) = self.config_mtime else {
-            return false;
-        };
-        let Some(path) = self.config_path.as_ref() else {
-            return false;
-        };
-
-        match std::fs::metadata(path).and_then(|meta| meta.modified()) {
-            Ok(modified) => modified > last_modified,
-            Err(_) => false,
-        }
-    }
-
     pub(super) fn refresh_dirty_flag(&mut self) {
         self.defaults_reset_pending = false;
         self.is_dirty = self.draft != self.baseline;
@@ -165,16 +145,7 @@ impl ConfiguratorApp {
 
 #[cfg(test)]
 mod tests {
-    use std::time::SystemTime;
-
     use super::*;
-
-    fn temp_config_path(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "wayscriber-configurator-state-{}-{name}.toml",
-            std::process::id()
-        ))
-    }
 
     #[test]
     fn refresh_dirty_flag_tracks_draft_vs_baseline() {
@@ -193,31 +164,5 @@ mod tests {
 
         assert!(app.search_input_focus_hint);
         assert!(app.startup_search_focus_pending);
-    }
-
-    #[test]
-    fn config_changed_on_disk_detects_newer_file() {
-        let (mut app, _cmd) = ConfiguratorApp::new_app();
-        let path = temp_config_path("mtime");
-        std::fs::write(&path, "test").expect("write config");
-
-        app.config_path = Some(path.clone());
-        app.config_mtime = Some(SystemTime::UNIX_EPOCH);
-
-        assert!(app.config_changed_on_disk());
-
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[test]
-    fn config_changed_on_disk_returns_false_without_path_or_mtime() {
-        let (mut app, _cmd) = ConfiguratorApp::new_app();
-        app.config_path = None;
-        app.config_mtime = Some(SystemTime::UNIX_EPOCH);
-        assert!(!app.config_changed_on_disk());
-
-        app.config_path = Some(temp_config_path("missing"));
-        app.config_mtime = None;
-        assert!(!app.config_changed_on_disk());
     }
 }

--- a/configurator/src/app/update/config.rs
+++ b/configurator/src/app/update/config.rs
@@ -2,36 +2,42 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use iced::Task;
-use wayscriber::config::Config;
+use wayscriber::config::ConfigDocument;
 
 use crate::messages::Message;
 use crate::models::ConfigDraft;
 
-use super::super::io::{load_config_from_disk, load_config_mtime, save_config_to_disk};
+use super::super::io::{load_config_from_disk, save_config_to_disk};
 use super::super::state::{ConfiguratorApp, StatusMessage};
 
 impl ConfiguratorApp {
     pub(super) fn handle_config_loaded(
         &mut self,
-        result: Result<Arc<Config>, String>,
+        result: Result<(Arc<ConfigDocument>, Option<String>), String>,
     ) -> Task<Message> {
         self.is_loading = false;
         match result {
-            Ok(config) => {
-                let draft = ConfigDraft::from_config(config.as_ref());
+            Ok((document, repair_warning)) => {
+                let draft = ConfigDraft::from_config(document.config());
                 self.draft = draft.clone();
                 self.baseline = draft;
-                self.base_config = config.clone();
+                self.base_document = Some(document.clone());
                 self.override_mode = self.draft.ui_toolbar_layout_mode;
                 self.boards_collapsed = vec![false; self.draft.boards.items.len()];
                 self.color_picker_open = None;
                 self.color_picker_advanced.clear();
                 self.color_picker_hex.clear();
                 self.sync_all_color_picker_hex();
-                self.config_mtime = load_config_mtime(&self.config_path);
                 self.is_dirty = false;
                 self.defaults_reset_pending = false;
-                self.status = StatusMessage::success("Configuration loaded from disk.");
+                self.status = repair_warning.map_or_else(
+                    || config_document_status(&document, "Configuration loaded from disk."),
+                    |warning| {
+                        StatusMessage::warning(format!(
+                            "The configuration could not be parsed, so built-in defaults were loaded for repair. Saving will create a backup before replacing the unreadable configuration with this draft. Unknown settings are retained only when the TOML structure is parseable and they can be separated safely; malformed TOML content remains only in the backup.\n{warning}"
+                        ))
+                    },
+                );
             }
             Err(err) => {
                 self.status =
@@ -92,18 +98,19 @@ impl ConfiguratorApp {
             return Task::none();
         }
         self.defaults_reset_pending = false;
-        if self.config_changed_on_disk() {
-            self.status =
-                StatusMessage::error("Configuration changed on disk. Reload before saving.");
+        let Some(document) = self.base_document.clone() else {
+            self.status = StatusMessage::error(
+                "Configuration has not loaded successfully. Reload before saving.",
+            );
             return Task::none();
-        }
+        };
 
-        match self.draft.to_config(self.base_config.as_ref()) {
+        match self.draft.to_config(document.config()) {
             Ok(mut config) => {
                 config.validate_and_clamp();
                 self.is_saving = true;
                 self.status = StatusMessage::info("Saving configuration...");
-                Task::perform(save_config_to_disk(config), Message::ConfigSaved)
+                Task::perform(save_config_to_disk(document, config), Message::ConfigSaved)
             }
             Err(errors) => {
                 let message = errors
@@ -121,17 +128,16 @@ impl ConfiguratorApp {
 
     pub(super) fn handle_config_saved(
         &mut self,
-        result: Result<(Option<PathBuf>, Arc<Config>), String>,
+        result: Result<(Option<PathBuf>, Arc<ConfigDocument>), String>,
     ) -> Task<Message> {
         self.is_saving = false;
         match result {
-            Ok((backup, saved_config)) => {
-                let draft = ConfigDraft::from_config(saved_config.as_ref());
+            Ok((backup, saved_document)) => {
+                let draft = ConfigDraft::from_config(saved_document.config());
                 self.last_backup_path = backup.clone();
                 self.draft = draft.clone();
                 self.baseline = draft;
-                self.base_config = saved_config.clone();
-                self.config_mtime = load_config_mtime(&self.config_path);
+                self.base_document = Some(saved_document.clone());
                 self.boards_collapsed = vec![false; self.draft.boards.items.len()];
                 self.color_picker_open = None;
                 self.color_picker_advanced.clear();
@@ -143,7 +149,7 @@ impl ConfiguratorApp {
                 if let Some(path) = backup {
                     msg.push_str(&format!("\nBackup created at {}", path.display()));
                 }
-                self.status = StatusMessage::success(msg);
+                self.status = config_document_status(&saved_document, &msg);
             }
             Err(err) => {
                 self.status = StatusMessage::error(format!("Failed to save configuration: {err}"));
@@ -154,11 +160,34 @@ impl ConfiguratorApp {
     }
 }
 
+fn config_document_status(document: &ConfigDocument, success: &str) -> StatusMessage {
+    if document.diagnostics().is_empty() {
+        return StatusMessage::success(success);
+    }
+
+    let shown = document
+        .diagnostics()
+        .iter()
+        .take(8)
+        .map(|diagnostic| diagnostic.path())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let remaining = document.diagnostics().len().saturating_sub(8);
+    let suffix = if remaining == 0 {
+        String::new()
+    } else {
+        format!(", and {remaining} more")
+    };
+    StatusMessage::warning(format!(
+        "{success}\nUnrecognized settings were preserved: {shown}{suffix}."
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
-    use std::time::SystemTime;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use super::*;
     use crate::models::{ColorPickerId, ToggleField};
@@ -173,11 +202,17 @@ mod tests {
         }
     }
 
-    fn temp_config_path(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "wayscriber-configurator-update-config-{}-{name}.toml",
-            std::process::id()
-        ))
+    static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_config_document(name: &str, contents: &str) -> (PathBuf, Arc<ConfigDocument>) {
+        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "wayscriber-configurator-update-config-{}-{sequence}-{name}.toml",
+            std::process::id(),
+        ));
+        std::fs::write(&path, contents).expect("write test config");
+        let document = ConfigDocument::load_from_path(&path).expect("load test config document");
+        (path, Arc::new(document))
     }
 
     #[test]
@@ -186,7 +221,8 @@ mod tests {
         app.color_picker_open = Some(ColorPickerId::StatusBarBg);
         app.is_dirty = true;
 
-        let _ = app.handle_config_loaded(Ok(Arc::new(Config::default())));
+        let (path, document) = temp_config_document("loaded", "");
+        let _ = app.handle_config_loaded(Ok((document, None)));
 
         assert!(!app.is_loading);
         assert!(!app.is_dirty);
@@ -196,64 +232,112 @@ mod tests {
             &app.status,
             "Configuration loaded from disk."
         ));
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
     fn handle_config_loaded_uses_startup_search_focus_fallback_once() {
         let (mut app, _cmd) = ConfiguratorApp::new_app();
 
-        let _ = app.handle_config_loaded(Ok(Arc::new(Config::default())));
+        let (first_path, first) = temp_config_document("focus-first", "");
+        let _ = app.handle_config_loaded(Ok((first, None)));
 
         assert!(app.search_input_focus_hint);
         assert!(!app.startup_search_focus_pending);
 
         app.search_input_focus_hint = false;
-        let _ = app.handle_config_loaded(Ok(Arc::new(Config::default())));
+        let (second_path, second) = temp_config_document("focus-second", "");
+        let _ = app.handle_config_loaded(Ok((second, None)));
 
         assert!(!app.search_input_focus_hint);
+        let _ = std::fs::remove_file(first_path);
+        let _ = std::fs::remove_file(second_path);
     }
 
     #[test]
-    fn handle_config_loaded_error_updates_status() {
+    fn handle_config_loaded_error_preserves_the_last_good_document_and_draft() {
         let (mut app, _cmd) = ConfiguratorApp::new_app();
+        let (path, document) = temp_config_document("before-reload-error", "");
+        let _ = app.handle_config_loaded(Ok((document.clone(), None)));
+        app.draft.capture_enabled = !app.draft.capture_enabled;
+        let draft = app.draft.clone();
+
         let _ = app.handle_config_loaded(Err("broken".to_string()));
 
         assert!(!app.is_loading);
+        assert!(Arc::ptr_eq(
+            app.base_document.as_ref().expect("last good document"),
+            &document
+        ));
+        assert_eq!(app.draft, draft);
         assert!(status_contains(
             &app.status,
             "Failed to load config from disk: broken"
         ));
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
-    fn handle_save_requested_blocks_when_config_changed_on_disk() {
+    fn handle_config_loaded_repair_document_allows_saving() {
         let (mut app, _cmd) = ConfiguratorApp::new_app();
-        let path = temp_config_path("mtime");
-        std::fs::write(&path, "x").expect("write config");
-        app.config_path = Some(path.clone());
-        app.config_mtime = Some(SystemTime::UNIX_EPOCH);
+        let (path, document) = temp_config_document("repair", "");
+
+        let _ = app.handle_config_loaded(Ok((
+            document,
+            Some("invalid type: string, expected u32".to_string()),
+        )));
+
+        assert!(app.base_document.is_some());
+        assert!(matches!(app.status, StatusMessage::Warning(_)));
+        assert!(status_contains(&app.status, "loaded for repair"));
+        assert!(status_contains(
+            &app.status,
+            "malformed TOML content remains only in the backup"
+        ));
+        let _ = app.handle_save_requested();
+        assert!(app.is_saving);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn handle_config_loaded_surfaces_preserved_unknown_settings() {
+        let (mut app, _cmd) = ConfiguratorApp::new_app();
+        let (path, document) =
+            temp_config_document("unknown", "future_configurator_option = true\n");
+
+        let _ = app.handle_config_loaded(Ok((document, None)));
+
+        assert!(matches!(app.status, StatusMessage::Warning(_)));
+        assert!(status_contains(&app.status, "future_configurator_option"));
+        assert!(status_contains(&app.status, "were preserved"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn handle_save_requested_blocks_without_loaded_document() {
+        let (mut app, _cmd) = ConfiguratorApp::new_app();
 
         let _ = app.handle_save_requested();
 
         assert!(!app.is_saving);
         assert!(status_contains(
             &app.status,
-            "Configuration changed on disk. Reload before saving."
+            "Configuration has not loaded successfully"
         ));
-        let _ = std::fs::remove_file(path);
     }
 
     #[test]
     fn handle_save_requested_sets_saving_for_valid_draft() {
         let (mut app, _cmd) = ConfiguratorApp::new_app();
         app.is_saving = false;
-        app.config_path = None;
-        app.config_mtime = None;
+        let (path, document) = temp_config_document("save-request", "");
+        let _ = app.handle_config_loaded(Ok((document, None)));
 
         let _ = app.handle_save_requested();
 
         assert!(app.is_saving);
         assert!(status_contains(&app.status, "Saving configuration..."));
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]
@@ -301,8 +385,9 @@ mod tests {
         app.is_dirty = true;
         app.draft.capture_enabled = !app.draft.capture_enabled;
         let backup = PathBuf::from("/tmp/wayscriber-config.bak");
+        let (path, document) = temp_config_document("saved", "");
 
-        let _ = app.handle_config_saved(Ok((Some(backup.clone()), Arc::new(Config::default()))));
+        let _ = app.handle_config_saved(Ok((Some(backup.clone()), document)));
 
         assert!(!app.is_saving);
         assert!(!app.is_dirty);
@@ -312,5 +397,6 @@ mod tests {
             &app.status,
             "Configuration saved successfully."
         ));
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/configurator/src/app/update/fields.rs
+++ b/configurator/src/app/update/fields.rs
@@ -1,5 +1,5 @@
 use iced::Task;
-use wayscriber::config::{ToolbarItemId, ToolbarItemOrderGroup};
+use wayscriber::config::{PerformanceFieldId, ToolbarItemId, ToolbarItemOrderGroup};
 
 use crate::messages::Message;
 use crate::models::{
@@ -380,7 +380,8 @@ impl ConfiguratorApp {
 
     pub(super) fn handle_buffer_count_changed(&mut self, count: u32) -> Task<Message> {
         self.status = StatusMessage::idle();
-        self.draft.performance_buffer_count = count;
+        self.draft
+            .set_performance_choice(PerformanceFieldId::BufferCount, count);
         self.refresh_dirty_flag();
         Task::none()
     }

--- a/configurator/src/app/view/boards/mod.rs
+++ b/configurator/src/app/view/boards/mod.rs
@@ -91,11 +91,17 @@ impl ConfiguratorApp {
                 .push(row![add_button].spacing(8));
         }
 
-        if (show_general || show_all) && self.base_config.boards.is_none() {
+        let loaded_legacy_boards = self
+            .base_document
+            .as_ref()
+            .is_some_and(|document| document.config().boards.is_none());
+        if (show_general || show_all) && loaded_legacy_boards {
             column = column.push(
-                text("Legacy [board] settings detected. Saving will write [boards].")
-                    .size(12)
-                    .style(theme::Text::Color(iced::Color::from_rgb(0.6, 0.6, 0.6))),
+                text(
+                    "Legacy [board] settings detected. Editing board settings will write [boards].",
+                )
+                .size(12)
+                .style(theme::Text::Color(iced::Color::from_rgb(0.6, 0.6, 0.6))),
             );
         }
 

--- a/configurator/src/app/view/mod.rs
+++ b/configurator/src/app/view/mod.rs
@@ -17,6 +17,7 @@ mod widgets;
 
 use iced::widget::{Column, Row, Space, button, column, container, row, rule, text, text_input};
 use iced::{Element, Length};
+use wayscriber::config::Config;
 
 use crate::messages::Message;
 use crate::models::TabId;
@@ -199,7 +200,12 @@ impl ConfiguratorApp {
     fn footer_view(&self) -> Element<'_, Message> {
         let mut info = Column::new().spacing(4);
 
-        if let Some(path) = &self.config_path {
+        let config_path = self
+            .base_document
+            .as_ref()
+            .map(|document| document.source_path().to_path_buf())
+            .or_else(|| Config::get_config_path().ok());
+        if let Some(path) = config_path {
             info = info.push(text(format!("Config path: {}", path.display())).size(14));
         }
         if let Some(path) = &self.last_backup_path {

--- a/configurator/src/app/view/performance.rs
+++ b/configurator/src/app/view/performance.rs
@@ -1,5 +1,6 @@
 use iced::widget::{column, pick_list, row, scrollable, text};
 use iced::{Element, Length};
+use wayscriber::config::{PerformanceFieldId, performance_field_metadata};
 
 use crate::app::scroll::CONTENT_SCROLL_ID;
 use crate::messages::Message;
@@ -17,8 +18,24 @@ impl ConfiguratorApp {
         &self,
         search: Option<&TabSearchSummary>,
     ) -> Element<'_, Message> {
+        let buffer_metadata = performance_field_metadata(PerformanceFieldId::BufferCount);
+        let vsync_metadata = performance_field_metadata(PerformanceFieldId::EnableVsync);
+        let max_fps_metadata = performance_field_metadata(PerformanceFieldId::MaxFpsNoVsync);
+        let animation_metadata = performance_field_metadata(PerformanceFieldId::UiAnimationFps);
+        let buffer_counts = buffer_metadata
+            .constraint
+            .unsigned_choices()
+            .expect("buffer count metadata must declare choices");
+        let max_fps_range = max_fps_metadata
+            .constraint
+            .unsigned_range()
+            .expect("max FPS metadata must declare a range");
+        let animation_range = animation_metadata
+            .constraint
+            .unsigned_range()
+            .expect("animation FPS metadata must declare a range");
         let buffer_pick = pick_list(
-            vec![2u32, 3, 4],
+            buffer_counts,
             Some(self.draft.performance_buffer_count),
             Message::BufferCountChanged,
         );
@@ -40,41 +57,48 @@ impl ConfiguratorApp {
             content = content
                 .push(text("Rendering").size(16))
                 .push(labeled_control(
-                    "Buffer count (2-4)",
+                    buffer_metadata.label,
                     buffer_control,
                     self.defaults.performance_buffer_count.to_string(),
                     self.draft.performance_buffer_count != self.defaults.performance_buffer_count,
                 ))
+                .push(text(buffer_metadata.help).size(12))
                 .push(toggle_row(
-                    "Enable VSync",
+                    vsync_metadata.label,
                     self.draft.performance_enable_vsync,
                     self.defaults.performance_enable_vsync,
                     ToggleField::PerformanceVsync,
                 ))
-                .push(text("Synchronizes rendering with display refresh. Prevents tearing but adds slight input latency.").size(12))
+                .push(text(vsync_metadata.help).size(12))
                 .push(labeled_input_with_feedback(
-                    "Max FPS (VSync off)",
+                    max_fps_metadata.label,
                     &self.draft.performance_max_fps_no_vsync,
                     &self.defaults.performance_max_fps_no_vsync,
                     TextField::PerformanceMaxFpsNoVsync,
-                    Some("Default 120; try 144/240 on high-refresh displays; 0 = unlimited"),
-                    validate_u32_range(&self.draft.performance_max_fps_no_vsync, 0, 1000),
-                ))
-                .push(text("Caps frame rate when VSync is disabled. 120 FPS keeps drawing latency low without uncapped CPU/GPU usage; use 0 only for profiling.").size(12));
+                    Some(max_fps_metadata.help),
+                    validate_u32_range(
+                        &self.draft.performance_max_fps_no_vsync,
+                        max_fps_range.0,
+                        max_fps_range.1,
+                    ),
+                ));
         }
 
         if show_animation {
             content = content
                 .push(text("Animations").size(16))
                 .push(labeled_input_with_feedback(
-                    "UI Animation FPS",
+                    animation_metadata.label,
                     &self.draft.performance_ui_animation_fps,
                     &self.defaults.performance_ui_animation_fps,
                     TextField::PerformanceUiAnimationFps,
-                    Some("0 = unlimited, recommended: 30-60"),
-                    validate_u32_range(&self.draft.performance_ui_animation_fps, 0, 1000),
-                ))
-                .push(text("Controls how often UI animations tick (fade effects, toasts, click highlights). Higher values = smoother animations but more CPU usage. Does not affect input responsiveness.").size(12));
+                    Some(animation_metadata.help),
+                    validate_u32_range(
+                        &self.draft.performance_ui_animation_fps,
+                        animation_range.0,
+                        animation_range.1,
+                    ),
+                ));
         }
 
         scrollable(content).id(CONTENT_SCROLL_ID).into()

--- a/configurator/src/messages.rs
+++ b/configurator/src/messages.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use wayscriber::config::{Config, ToolbarItemId, ToolbarItemOrderGroup};
+use wayscriber::config::{ConfigDocument, ToolbarItemId, ToolbarItemOrderGroup};
 
 use crate::models::{
     BoardBackgroundOption, BoardItemTextField, BoardItemToggleField, ColorMode, ColorPickerId,
@@ -22,13 +22,13 @@ use crate::models::{PressureThicknessEditModeOption, PressureThicknessEntryModeO
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    ConfigLoaded(Result<Arc<Config>, String>),
+    ConfigLoaded(Result<(Arc<ConfigDocument>, Option<String>), String>),
     ReloadRequested,
     ResetToDefaultsRequested,
     ResetToDefaultsConfirmed,
     ResetToDefaultsCanceled,
     SaveRequested,
-    ConfigSaved(Result<(Option<PathBuf>, Arc<Config>), String>),
+    ConfigSaved(Result<(Option<PathBuf>, Arc<ConfigDocument>), String>),
     DaemonStatusLoaded(u64, Result<DaemonRuntimeStatus, String>),
     DaemonShortcutInputChanged(String),
     DaemonActionRequested(DaemonAction),

--- a/configurator/src/models/config/mod.rs
+++ b/configurator/src/models/config/mod.rs
@@ -1,6 +1,7 @@
 mod boards;
 mod draft;
 mod parse;
+mod performance_fields;
 mod presets;
 mod quick_colors;
 mod render_profiles;

--- a/configurator/src/models/config/parse.rs
+++ b/configurator/src/models/config/parse.rs
@@ -118,17 +118,3 @@ pub(super) fn parse_u64_field<F>(
         Err(err) => errors.push(FormError::new(field, err.to_string())),
     }
 }
-
-pub(super) fn parse_u32_field<F>(
-    value: &str,
-    field: &'static str,
-    errors: &mut Vec<FormError>,
-    apply: F,
-) where
-    F: FnOnce(u32),
-{
-    match value.trim().parse::<u32>() {
-        Ok(parsed) => apply(parsed),
-        Err(err) => errors.push(FormError::new(field, err.to_string())),
-    }
-}

--- a/configurator/src/models/config/performance_fields.rs
+++ b/configurator/src/models/config/performance_fields.rs
@@ -1,0 +1,146 @@
+use wayscriber::config::{PerformanceFieldId, ScalarConstraint, performance_field_metadata};
+
+use super::ConfigDraft;
+use crate::models::error::FormError;
+
+pub(super) fn validate_performance_u32(
+    id: PerformanceFieldId,
+    value: u32,
+    errors: &mut Vec<FormError>,
+) -> Option<u32> {
+    let metadata = performance_field_metadata(id);
+    if metadata.constraint.accepts_u32(value) {
+        return Some(value);
+    }
+
+    let expected = match metadata.constraint {
+        ScalarConstraint::Unsigned { min, max } => format!("Expected {min}-{max}"),
+        ScalarConstraint::UnsignedChoice(values) => format!(
+            "Expected one of {}",
+            values
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        ScalarConstraint::Boolean => "Expected a boolean".to_string(),
+    };
+    errors.push(FormError::new(metadata.path, expected));
+    None
+}
+
+pub(super) fn parse_performance_u32(
+    id: PerformanceFieldId,
+    input: &str,
+    errors: &mut Vec<FormError>,
+) -> Option<u32> {
+    let metadata = performance_field_metadata(id);
+    match input.trim().parse::<u32>() {
+        Ok(value) => validate_performance_u32(id, value, errors),
+        Err(error) => {
+            errors.push(FormError::new(metadata.path, error.to_string()));
+            None
+        }
+    }
+}
+
+impl ConfigDraft {
+    pub(super) fn set_performance_bool(&mut self, id: PerformanceFieldId, value: bool) {
+        match id {
+            PerformanceFieldId::EnableVsync => self.performance_enable_vsync = value,
+            PerformanceFieldId::BufferCount
+            | PerformanceFieldId::MaxFpsNoVsync
+            | PerformanceFieldId::UiAnimationFps => {
+                unreachable!("non-boolean Performance field routed through boolean setter")
+            }
+        }
+    }
+
+    pub(super) fn set_performance_text(&mut self, id: PerformanceFieldId, value: String) {
+        match id {
+            PerformanceFieldId::MaxFpsNoVsync => self.performance_max_fps_no_vsync = value,
+            PerformanceFieldId::UiAnimationFps => self.performance_ui_animation_fps = value,
+            PerformanceFieldId::BufferCount | PerformanceFieldId::EnableVsync => {
+                unreachable!("non-text Performance field routed through text setter")
+            }
+        }
+    }
+
+    pub(crate) fn set_performance_choice(&mut self, id: PerformanceFieldId, value: u32) {
+        match id {
+            PerformanceFieldId::BufferCount => self.performance_buffer_count = value,
+            PerformanceFieldId::EnableVsync
+            | PerformanceFieldId::MaxFpsNoVsync
+            | PerformanceFieldId::UiAnimationFps => {
+                unreachable!("non-choice Performance field routed through choice setter")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wayscriber::config::{PERFORMANCE_FIELD_METADATA, PerformanceFieldId, ScalarConstraint};
+
+    use super::*;
+
+    #[test]
+    fn every_performance_descriptor_routes_through_a_typed_binding() {
+        let mut draft = ConfigDraft::from_config(&wayscriber::config::Config::default());
+        for metadata in PERFORMANCE_FIELD_METADATA {
+            match metadata.constraint {
+                ScalarConstraint::Boolean => {
+                    draft.set_performance_bool(metadata.id, true);
+                }
+                ScalarConstraint::Unsigned { min, .. } => {
+                    draft.set_performance_text(metadata.id, min.to_string());
+                }
+                ScalarConstraint::UnsignedChoice(values) => {
+                    draft.set_performance_choice(metadata.id, values[0]);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn typed_bindings_update_each_performance_draft_field() {
+        let mut draft = ConfigDraft::from_config(&wayscriber::config::Config::default());
+        draft.set_performance_choice(PerformanceFieldId::BufferCount, 4);
+        draft.set_toggle(crate::models::ToggleField::PerformanceVsync, true);
+        draft.set_text(
+            crate::models::TextField::PerformanceMaxFpsNoVsync,
+            "144".to_string(),
+        );
+        draft.set_text(
+            crate::models::TextField::PerformanceUiAnimationFps,
+            "60".to_string(),
+        );
+
+        assert_eq!(draft.performance_buffer_count, 4);
+        assert!(draft.performance_enable_vsync);
+        assert_eq!(draft.performance_max_fps_no_vsync, "144");
+        assert_eq!(draft.performance_ui_animation_fps, "60");
+    }
+
+    #[test]
+    fn conversion_rejects_values_outside_shared_performance_constraints() {
+        let base = wayscriber::config::Config::default();
+        let mut draft = ConfigDraft::from_config(&base);
+        draft.performance_buffer_count = 5;
+        draft.performance_ui_animation_fps = "241".to_string();
+
+        let errors = draft
+            .to_config(&base)
+            .expect_err("out-of-range Performance values must remain actionable");
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.field == "performance.buffer_count")
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.field == "performance.ui_animation_fps")
+        );
+    }
+}

--- a/configurator/src/models/config/quick_colors.rs
+++ b/configurator/src/models/config/quick_colors.rs
@@ -57,11 +57,26 @@ impl QuickColorsDraft {
         }
 
         if errors.len() == initial_error_count {
-            if next_entries == config.effective_entries() {
-                config.replace_entries_preserving_source(next_entries);
-            } else {
-                config.set_entries(next_entries);
+            let effective_entries = config.effective_entries();
+            if next_entries == effective_entries {
+                return;
             }
+
+            let persist_len = if next_entries.len() != effective_entries.len() {
+                next_entries.len()
+            } else {
+                let source_len = config
+                    .configured_entry_count()
+                    .unwrap_or(config.entries.len());
+                let changed_len = next_entries
+                    .iter()
+                    .zip(&effective_entries)
+                    .rposition(|(next, previous)| next != previous)
+                    .map_or(0, |index| index + 1);
+                source_len.max(changed_len).min(next_entries.len())
+            };
+            next_entries.truncate(persist_len);
+            config.set_entries(next_entries);
         }
     }
 

--- a/configurator/src/models/config/setters.rs
+++ b/configurator/src/models/config/setters.rs
@@ -5,8 +5,8 @@ use super::super::fields::{
 };
 use super::draft::ConfigDraft;
 use wayscriber::config::{
-    ToolbarItemId, ToolbarItemOrderGroup, ToolbarSectionFlag, section_flag_for_item,
-    set_section_visibility,
+    PerformanceFieldId, ToolbarItemId, ToolbarItemOrderGroup, ToolbarSectionFlag,
+    section_flag_for_item, set_section_visibility,
 };
 
 impl ConfigDraft {
@@ -155,7 +155,9 @@ impl ConfigDraft {
             ToggleField::DrawingFillEnabled => {
                 self.drawing_default_fill_enabled = value;
             }
-            ToggleField::PerformanceVsync => self.performance_enable_vsync = value,
+            ToggleField::PerformanceVsync => {
+                self.set_performance_bool(PerformanceFieldId::EnableVsync, value);
+            }
             ToggleField::UiShowStatusBar => self.ui_show_status_bar = value,
             ToggleField::UiShowFrozenBadge => self.ui_show_frozen_badge = value,
             ToggleField::UiShowCapabilitiesWarning => self.ui_show_capabilities_warning = value,
@@ -309,8 +311,12 @@ impl ConfigDraft {
             TextField::DrawingUndoStackLimit => self.drawing_undo_stack_limit = value,
             TextField::ArrowLength => self.arrow_length = value,
             TextField::ArrowAngle => self.arrow_angle = value,
-            TextField::PerformanceMaxFpsNoVsync => self.performance_max_fps_no_vsync = value,
-            TextField::PerformanceUiAnimationFps => self.performance_ui_animation_fps = value,
+            TextField::PerformanceMaxFpsNoVsync => {
+                self.set_performance_text(PerformanceFieldId::MaxFpsNoVsync, value);
+            }
+            TextField::PerformanceUiAnimationFps => {
+                self.set_performance_text(PerformanceFieldId::UiAnimationFps, value);
+            }
             TextField::HistoryUndoAllDelayMs => self.history_undo_all_delay_ms = value,
             TextField::HistoryRedoAllDelayMs => self.history_redo_all_delay_ms = value,
             TextField::HistoryCustomUndoDelayMs => self.history_custom_undo_delay_ms = value,

--- a/configurator/src/models/config/tests.rs
+++ b/configurator/src/models/config/tests.rs
@@ -29,11 +29,11 @@ fn config_draft_round_trips_toolbar_rebind_modifier() {
 use super::super::{ColorMode, NamedColorOption};
 use super::{ConfigDraft, RenderProfileSelectionOption};
 use wayscriber::config::{
-    ColorSpec, Config, PdfFitMode, PdfLabelContentMode, PdfLabelPosition, PdfOrientation,
-    PdfPageSize, PdfTransparentBackground, PresetToolStatesConfig, QuickColorConfig,
-    RenderColorMappingConfig, RenderProfileConfig, RenderProfileExportMode, ToolPresetConfig,
-    ToolbarItemOrderConfig, ToolbarItemOrderGroup, ToolbarItemsConfig, ToolbarSectionFlag,
-    XdgFocusLossBehavior, toolbar_item_ids as ids,
+    ColorSpec, Config, ConfigDocument, PdfFitMode, PdfLabelContentMode, PdfLabelPosition,
+    PdfOrientation, PdfPageSize, PdfTransparentBackground, PresetToolStatesConfig,
+    QuickColorConfig, RenderColorMappingConfig, RenderProfileConfig, RenderProfileExportMode,
+    ToolPresetConfig, ToolbarItemOrderConfig, ToolbarItemOrderGroup, ToolbarItemsConfig,
+    ToolbarSectionFlag, XdgFocusLossBehavior, toolbar_item_ids as ids,
 };
 use wayscriber::input::{DragTool, PerToolDrawingSettings, Tool};
 
@@ -57,6 +57,81 @@ fn config_draft_to_config_reports_errors() {
     assert!(fields.contains(&"drawing.default_thickness"));
     assert!(fields.contains(&"ui.click_highlight.duration_ms"));
     assert!(fields.contains(&"drawing.default_color"));
+}
+
+#[test]
+fn sparse_configurator_no_op_save_remains_byte_for_byte_sparse() {
+    let temp = crate::test_temp::tempdir().expect("create temp directory");
+    let path = temp.path().join("config.toml");
+    let original = "config_revision = 1\n# intentionally sparse\n";
+    std::fs::write(&path, original).expect("write sparse config");
+    let document = ConfigDocument::load_from_path(&path).expect("load sparse config");
+    let draft = ConfigDraft::from_config(document.config());
+    let updated = draft
+        .to_config(document.config())
+        .expect("convert untouched sparse draft");
+
+    document
+        .save_with_backup(updated)
+        .expect("save untouched sparse draft");
+
+    assert_eq!(
+        std::fs::read_to_string(path).expect("read sparse config"),
+        original
+    );
+}
+
+#[test]
+fn config_draft_round_trips_precise_floats_without_truncation() {
+    let mut config = Config::default();
+    config.drawing.default_thickness = 1.234_567_890_123_45;
+    config.ui.toolbar.top_offset = -9.876_543_210_987_65;
+    config.export.pdf.custom_width = 812.345_678_901_234;
+
+    let draft = ConfigDraft::from_config(&config);
+    let round_trip = draft
+        .to_config(&config)
+        .expect("precise floats should round trip");
+
+    assert_eq!(
+        round_trip.drawing.default_thickness.to_bits(),
+        config.drawing.default_thickness.to_bits()
+    );
+    assert_eq!(
+        round_trip.ui.toolbar.top_offset.to_bits(),
+        config.ui.toolbar.top_offset.to_bits()
+    );
+    assert_eq!(
+        round_trip.export.pdf.custom_width.to_bits(),
+        config.export.pdf.custom_width.to_bits()
+    );
+}
+
+#[test]
+fn sparse_configurator_edit_adds_only_the_edited_field_path() {
+    let temp = crate::test_temp::tempdir().expect("create temp directory");
+    let path = temp.path().join("config.toml");
+    std::fs::write(&path, "# intentionally sparse\n").expect("write sparse config");
+    let document = ConfigDocument::load_from_path(&path).expect("load sparse config");
+    let mut draft = ConfigDraft::from_config(document.config());
+    draft.performance_max_fps_no_vsync = "144".to_string();
+    let updated = draft
+        .to_config(document.config())
+        .expect("convert sparse draft edit");
+
+    document
+        .save_with_backup(updated)
+        .expect("save sparse draft edit");
+
+    let saved = std::fs::read_to_string(path).expect("read sparse config");
+    assert!(saved.contains("# intentionally sparse"));
+    assert!(saved.contains("[performance]"));
+    assert!(saved.contains("max_fps_no_vsync = 144"));
+    assert!(saved.find("# intentionally sparse").unwrap() < saved.find("[performance]").unwrap());
+    assert!(!saved.contains("[drawing]"));
+    assert!(!saved.contains("[drawing.drag_tools"));
+    assert!(!saved.contains("[boards]"));
+    assert!(!saved.contains("[[boards.items]]"));
 }
 
 #[test]
@@ -116,6 +191,46 @@ fn config_draft_preserves_implicit_quick_color_defaults() {
 
     assert_eq!(saved.drawing.quick_colors.configured_entry_count(), None);
     assert!(saved.drawing.quick_colors.is_implicit_default());
+}
+
+#[test]
+fn config_draft_preserves_sparse_explicit_quick_colors_without_padding_the_file() {
+    let temp = crate::test_temp::tempdir().expect("create temp directory");
+    let path = temp.path().join("config.toml");
+    let original = r#"config_revision = 1
+[[drawing.quick_colors]]
+label = "Only configured color"
+color = "blue"
+"#;
+    std::fs::write(&path, original).expect("write sparse quick colors");
+    let document = ConfigDocument::load_from_path(&path).expect("load sparse quick colors");
+    assert_eq!(
+        document
+            .config()
+            .drawing
+            .quick_colors
+            .configured_entry_count(),
+        Some(1)
+    );
+
+    let draft = ConfigDraft::from_config(document.config());
+    assert_eq!(draft.drawing_quick_colors.entries.len(), 8);
+    let updated = draft
+        .to_config(document.config())
+        .expect("untouched sparse quick colors should round trip");
+    assert_eq!(
+        updated.drawing.quick_colors.configured_entry_count(),
+        Some(1)
+    );
+    assert_eq!(updated.drawing.quick_colors.entries.len(), 1);
+
+    document
+        .save_with_backup(updated)
+        .expect("save sparse quick colors");
+    assert_eq!(
+        std::fs::read_to_string(path).expect("read sparse quick colors"),
+        original
+    );
 }
 
 #[test]

--- a/configurator/src/models/config/to_config/boards.rs
+++ b/configurator/src/models/config/to_config/boards.rs
@@ -4,6 +4,11 @@ use wayscriber::config::Config;
 
 impl ConfigDraft {
     pub(super) fn apply_boards(&self, config: &mut Config, errors: &mut Vec<FormError>) {
+        if config.boards.is_none()
+            && self.boards == super::super::boards::BoardsDraft::from_config(config)
+        {
+            return;
+        }
         let boards = self.boards.to_config(errors);
         config.boards = Some(boards);
     }

--- a/configurator/src/models/config/to_config/drawing.rs
+++ b/configurator/src/models/config/to_config/drawing.rs
@@ -6,6 +6,8 @@ use wayscriber::input::{DragBindableTool, DragTool};
 
 impl ConfigDraft {
     pub(super) fn apply_drawing(&self, config: &mut Config, errors: &mut Vec<FormError>) {
+        let materialize_drag_tools = config.drawing.drag_tools.is_some()
+            || config.drawing.effective_drag_tools() != self.drawing_drag_tools;
         match self.drawing_color.to_color_spec() {
             Ok(color) => config.drawing.default_color = color,
             Err(err) => errors.push(err),
@@ -68,7 +70,7 @@ impl ConfigDraft {
             self.drawing_drag_tools.left.tab_drag_tool,
             DragBindableTool::Ellipse,
         );
-        config.drawing.drag_tools = Some(self.drawing_drag_tools.clone());
+        config.drawing.drag_tools = materialize_drag_tools.then(|| self.drawing_drag_tools.clone());
         parse_field(
             &self.drawing_hit_test_tolerance,
             "drawing.hit_test_tolerance",

--- a/configurator/src/models/config/to_config/performance.rs
+++ b/configurator/src/models/config/to_config/performance.rs
@@ -1,23 +1,31 @@
 use super::super::draft::ConfigDraft;
-use super::super::parse::parse_u32_field;
+use super::super::performance_fields::{parse_performance_u32, validate_performance_u32};
 use crate::models::error::FormError;
-use wayscriber::config::Config;
+use wayscriber::config::{Config, PerformanceFieldId};
 
 impl ConfigDraft {
     pub(super) fn apply_performance(&self, config: &mut Config, errors: &mut Vec<FormError>) {
-        config.performance.buffer_count = self.performance_buffer_count;
+        if let Some(value) = validate_performance_u32(
+            PerformanceFieldId::BufferCount,
+            self.performance_buffer_count,
+            errors,
+        ) {
+            config.performance.buffer_count = value;
+        }
         config.performance.enable_vsync = self.performance_enable_vsync;
-        parse_u32_field(
+        if let Some(value) = parse_performance_u32(
+            PerformanceFieldId::MaxFpsNoVsync,
             &self.performance_max_fps_no_vsync,
-            "performance.max_fps_no_vsync",
             errors,
-            |value| config.performance.max_fps_no_vsync = value,
-        );
-        parse_u32_field(
+        ) {
+            config.performance.max_fps_no_vsync = value;
+        }
+        if let Some(value) = parse_performance_u32(
+            PerformanceFieldId::UiAnimationFps,
             &self.performance_ui_animation_fps,
-            "performance.ui_animation_fps",
             errors,
-            |value| config.performance.ui_animation_fps = value,
-        );
+        ) {
+            config.performance.ui_animation_fps = value;
+        }
     }
 }

--- a/configurator/src/models/util.rs
+++ b/configurator/src/models/util.rs
@@ -5,14 +5,7 @@ pub fn parse_f64(input: &str) -> Result<f64, String> {
 }
 
 pub fn format_float(value: f64) -> String {
-    if value.fract() == 0.0 {
-        format!("{:.0}", value)
-    } else {
-        format!("{:.3}", value)
-            .trim_end_matches('0')
-            .trim_end_matches('.')
-            .to_string()
-    }
+    value.to_string()
 }
 
 #[cfg(test)]
@@ -26,10 +19,13 @@ mod tests {
     }
 
     #[test]
-    fn format_float_trims_trailing_zeroes() {
+    fn format_float_uses_shortest_lossless_representation() {
         assert_eq!(format_float(12.0), "12");
         assert_eq!(format_float(12.340), "12.34");
         assert_eq!(format_float(12.300), "12.3");
-        assert_eq!(format_float(12.3456), "12.346");
+        assert_eq!(format_float(12.3456), "12.3456");
+
+        let precise = 1.234_567_890_123_45;
+        assert_eq!(parse_f64(&format_float(precise)).unwrap(), precise);
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -9,11 +9,29 @@ wayscriber supports customization through a TOML configuration file located at:
 
 All settings are optional. If the configuration file doesn't exist or settings are missing, sensible defaults will be used.
 
+When the graphical configurator edits an existing file, it preserves TOML comments, section order,
+and unrecognized settings. Unrecognized paths produce a warning but remain in the file for forward
+compatibility. Known values are still validated and migrations are written under their canonical
+names. The configurator tracks the exact loaded contents rather than relying on modification time;
+if the file is created, deleted, retargeted through a symlink, or changed by another editor, reload
+it before saving. A save does not expand omitted, unchanged defaults; when a setting that was
+omitted is edited, only that changed setting and its required table path are added.
+The first save for a missing file is sparse as well: it writes the migration revision marker and
+only values changed from the built-in defaults.
+
+If the graphical configurator can read the file but cannot parse its TOML or known value types, it
+opens a clearly marked repair draft using built-in defaults. Saving that draft first creates a
+backup of the unreadable source, retains unknown keys that can be separated safely when the TOML
+structure itself was parseable, and replaces the unreadable known configuration. A transient reload
+error leaves the last good document and unsaved draft in place; its revision guard still prevents
+overwriting a changed file.
+
 ## Configuration File Location
 
 The configuration file should be placed at:
 - Linux: `~/.config/wayscriber/config.toml`
-- The directory will be created automatically when you first create the config file
+- The directory will be created automatically when you first create the config file. If the config
+  path is a dangling symlink, missing parent directories for its final target are created as well.
 
 ## Example Configuration
 
@@ -317,7 +335,7 @@ enable_vsync = false
 # 120 keeps pen latency low without uncapped CPU usage; set to 0 only for profiling
 max_fps_no_vsync = 120
 
-# UI animation frame rate (0 = unlimited)
+# UI animation frame rate (0-240; 0 = unlimited)
 # Higher values smooth UI effects at the cost of more redraws
 ui_animation_fps = 30
 ```
@@ -340,7 +358,7 @@ ui_animation_fps = 30
 **UI Animation FPS:**
 - **30** (default): Smooth enough for most effects
 - **0**: Unlimited (renders every frame while animations are active)
-- Higher values improve smoothness at the cost of extra redraws
+- Values through **240** improve smoothness at the cost of extra redraws; larger values are clamped
 
 **Defaults:**
 - Buffer count: 3 (triple buffering)

--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -139,6 +139,16 @@ Notifications are sent via `notification::send_notification_async`, keeping all 
 ## 6. Configuration
 
 - **`src/config/`** handles loading `config.toml`, validating fields, and building the keybinding map.
+- **`ConfigDocument`** is the configurator-facing edit owner. It keeps validated `Config`, the
+  lossless TOML source, unknown-path diagnostics, source path, and exact source revision behind one
+  interface. Guarded saves merge known fields while retaining comments and unsupported settings,
+  then reuse the normal backup and durable atomic-write policy. Its editor load path can expose a
+  backup-protected defaults-based repair document for readable but invalid config, while true I/O
+  failures leave the configurator's last good document untouched. Runtime callers can continue
+  using the typed `Config::load()` and `Config::save*()` interfaces.
+- The Performance section is the first bounded scalar-metadata slice: core config owns its field
+  IDs, paths, labels, help/search terms, and numeric constraints while the configurator keeps typed
+  draft fields and messages.
 
 ---
 

--- a/src/config/document.rs
+++ b/src/config/document.rs
@@ -1,0 +1,404 @@
+//! Lossless configuration document ownership for editing clients.
+
+mod merge;
+
+use super::io::{create_config_backup, prepare_config_parent, write_config_text_atomic};
+use super::{Config, ConfigSource};
+use crate::durable_io::{OverwriteMode, resolve_symlink_chain};
+use anyhow::{Context, Result, anyhow, bail};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use toml_edit::DocumentMut;
+
+use merge::{
+    conservative_repair_source_document, merge_config_document, repair_source_document,
+    serialize_config_document,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigDiagnosticKind {
+    UnknownSetting,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigDiagnostic {
+    kind: ConfigDiagnosticKind,
+    path: String,
+}
+
+impl ConfigDiagnostic {
+    pub fn kind(&self) -> ConfigDiagnosticKind {
+        self.kind
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+impl fmt::Display for ConfigDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            ConfigDiagnosticKind::UnknownSetting => {
+                write!(formatter, "unrecognized setting `{}`", self.path)
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum SourceRevision {
+    Missing {
+        followed_links: Arc<[(PathBuf, PathBuf)]>,
+    },
+    Present {
+        bytes: Arc<[u8]>,
+        followed_links: Arc<[(PathBuf, PathBuf)]>,
+    },
+}
+
+impl fmt::Debug for SourceRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing { followed_links } => formatter
+                .debug_struct("Missing")
+                .field("followed_links", followed_links)
+                .finish(),
+            Self::Present {
+                bytes,
+                followed_links,
+            } => formatter
+                .debug_struct("Present")
+                .field("byte_len", &bytes.len())
+                .field("followed_links", followed_links)
+                .finish(),
+        }
+    }
+}
+
+impl SourceRevision {
+    fn read(path: &Path) -> Result<Self> {
+        let (final_path, followed_links) = resolve_symlink_chain(path)
+            .with_context(|| format!("Failed to resolve config source {}", path.display()))?;
+        let followed_links: Arc<[(PathBuf, PathBuf)]> = followed_links.into();
+        let metadata = match fs::symlink_metadata(&final_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Ok(Self::Missing { followed_links });
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to inspect config source {}", final_path.display())
+                });
+            }
+        };
+
+        if !metadata.is_file() {
+            bail!(
+                "Config source {} is not a regular file",
+                final_path.display()
+            );
+        }
+        let bytes = fs::read(&final_path)
+            .with_context(|| format!("Failed to read config from {}", final_path.display()))?;
+        Ok(Self::Present {
+            bytes: Arc::from(bytes.into_boxed_slice()),
+            followed_links,
+        })
+    }
+
+    fn bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Missing { .. } => None,
+            Self::Present { bytes, .. } => Some(bytes),
+        }
+    }
+
+    fn overwrite_mode(&self) -> OverwriteMode {
+        match self {
+            Self::Missing { .. } => OverwriteMode::CreateNew,
+            Self::Present { .. } => OverwriteMode::Replace,
+        }
+    }
+
+    fn destination_path<'a>(&'a self, source_path: &'a Path) -> &'a Path {
+        match self {
+            Self::Missing { followed_links } | Self::Present { followed_links, .. } => {
+                followed_links
+                    .last()
+                    .map_or(source_path, |(_, target)| target.as_path())
+            }
+        }
+    }
+
+    fn after_write(&self, bytes: &[u8]) -> Self {
+        let followed_links = match self {
+            Self::Missing { followed_links } | Self::Present { followed_links, .. } => {
+                Arc::clone(followed_links)
+            }
+        };
+        Self::Present {
+            bytes: Arc::from(bytes),
+            followed_links,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ConfigDocument {
+    config: Config,
+    document: DocumentMut,
+    source_path: PathBuf,
+    source: ConfigSource,
+    revision: SourceRevision,
+    diagnostics: Vec<ConfigDiagnostic>,
+    repair_mode: bool,
+}
+
+impl ConfigDocument {
+    pub fn load() -> Result<Self> {
+        Self::load_from_path(Config::get_config_path()?)
+    }
+
+    pub fn load_from_path(path: impl Into<PathBuf>) -> Result<Self> {
+        let source_path = path.into();
+        let revision = SourceRevision::read(&source_path)?;
+        Self::from_revision(source_path, revision)
+    }
+
+    /// Loads a document for an interactive editor, falling back to a repairable
+    /// default draft when the file exists but its contents cannot be parsed.
+    ///
+    /// The returned warning contains the original parse failure. Saving the
+    /// fallback document remains revision-guarded and creates a backup first.
+    pub fn load_for_editing() -> Result<(Self, Option<String>)> {
+        Self::load_for_editing_from_path(Config::get_config_path()?)
+    }
+
+    pub fn load_for_editing_from_path(path: impl Into<PathBuf>) -> Result<(Self, Option<String>)> {
+        let source_path = path.into();
+        let revision = SourceRevision::read(&source_path)?;
+        match Self::from_revision(source_path.clone(), revision.clone()) {
+            Ok(document) => Ok((document, None)),
+            Err(error) if revision.bytes().is_some() => {
+                let document = revision
+                    .bytes()
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .and_then(|input| input.parse::<DocumentMut>().ok())
+                    .unwrap_or_default();
+                Ok((
+                    Self {
+                        config: Config::default(),
+                        document,
+                        source_path,
+                        source: ConfigSource::Primary,
+                        revision,
+                        diagnostics: Vec::new(),
+                        repair_mode: true,
+                    },
+                    Some(format!("{error:#}")),
+                ))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn from_revision(source_path: PathBuf, revision: SourceRevision) -> Result<Self> {
+        match revision.bytes() {
+            Some(bytes) => {
+                let input = std::str::from_utf8(bytes).with_context(|| {
+                    format!("Config at {} is not valid UTF-8", source_path.display())
+                })?;
+                let document = input.parse::<DocumentMut>().with_context(|| {
+                    format!("Failed to parse config from {}", source_path.display())
+                })?;
+                let (config, diagnostics) = parse_typed_config(input).with_context(|| {
+                    format!("Failed to parse config from {}", source_path.display())
+                })?;
+                Ok(Self {
+                    config,
+                    document,
+                    source_path,
+                    source: ConfigSource::Primary,
+                    revision,
+                    diagnostics,
+                    repair_mode: false,
+                })
+            }
+            None => {
+                let config = Config::default();
+                let document = DocumentMut::new();
+                Ok(Self {
+                    config,
+                    document,
+                    source_path,
+                    source: ConfigSource::Default,
+                    revision,
+                    diagnostics: Vec::new(),
+                    repair_mode: false,
+                })
+            }
+        }
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub fn source(&self) -> &ConfigSource {
+        &self.source
+    }
+
+    pub fn source_path(&self) -> &Path {
+        &self.source_path
+    }
+
+    pub fn diagnostics(&self) -> &[ConfigDiagnostic] {
+        &self.diagnostics
+    }
+
+    pub fn save_with_backup(&self, mut config: Config) -> Result<ConfigDocumentSaveOutcome> {
+        config.validate_and_clamp();
+        let repair_source = self
+            .repair_mode
+            .then(|| repair_source_document(&self.document, &self.config, &config))
+            .transpose()?;
+        let source = repair_source.as_ref().unwrap_or(&self.document);
+        let mut merged = merge_config_document(source, &self.config, &config)?;
+        let mut output = merged.to_string();
+        let parsed = parse_typed_config(&output);
+        let (saved_config, diagnostics) = match parsed {
+            Ok(parsed) => parsed,
+            Err(_) if self.repair_mode => {
+                let conservative =
+                    conservative_repair_source_document(&self.document, &self.config, &config)?;
+                merged = merge_config_document(&conservative, &self.config, &config)?;
+                output = merged.to_string();
+                parse_typed_config(&output)
+                    .context("Repaired config failed its validation parse before save")?
+            }
+            Err(error) => {
+                return Err(error).context("Merged config failed its validation parse before save");
+            }
+        };
+
+        self.ensure_source_unchanged()?;
+        prepare_config_parent(self.revision.destination_path(&self.source_path))?;
+        let backup_path = if matches!(self.revision, SourceRevision::Present { .. }) {
+            Some(create_config_backup(&self.source_path)?)
+        } else {
+            None
+        };
+        self.ensure_source_unchanged()?;
+        write_config_text_atomic(&self.source_path, &output, self.revision.overwrite_mode())?;
+        let revision = self.revision.after_write(output.as_bytes());
+
+        Ok(ConfigDocumentSaveOutcome {
+            document: Self {
+                config: saved_config,
+                document: merged,
+                source_path: self.source_path.clone(),
+                source: ConfigSource::Primary,
+                revision,
+                diagnostics,
+                repair_mode: false,
+            },
+            backup_path,
+        })
+    }
+
+    fn ensure_source_unchanged(&self) -> Result<()> {
+        let current = SourceRevision::read(&self.source_path)?;
+        if current != self.revision {
+            bail!(
+                "Configuration changed on disk at {}. Reload before saving.",
+                self.source_path.display()
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ConfigDocumentSaveOutcome {
+    document: ConfigDocument,
+    backup_path: Option<PathBuf>,
+}
+
+impl ConfigDocumentSaveOutcome {
+    pub fn document(&self) -> &ConfigDocument {
+        &self.document
+    }
+
+    pub fn backup_path(&self) -> Option<&Path> {
+        self.backup_path.as_deref()
+    }
+
+    pub fn into_parts(self) -> (ConfigDocument, Option<PathBuf>) {
+        (self.document, self.backup_path)
+    }
+}
+
+fn parse_typed_config(input: &str) -> Result<(Config, Vec<ConfigDiagnostic>)> {
+    let deserializer = toml::Deserializer::parse(input).context("Failed to parse TOML")?;
+    let mut ignored = BTreeSet::new();
+    let mut config: Config = serde_ignored::deserialize(deserializer, |path| {
+        let path = path.to_string();
+        if !is_known_feature_gated_path(&path) {
+            ignored.insert(path);
+        }
+    })
+    .map_err(|error| anyhow!(error))?;
+    config.validate_and_clamp();
+    collect_flattened_unknown_paths(input, &config, &mut ignored)?;
+    let diagnostics = ignored
+        .into_iter()
+        .map(|path| ConfigDiagnostic {
+            kind: ConfigDiagnosticKind::UnknownSetting,
+            path,
+        })
+        .collect();
+    Ok((config, diagnostics))
+}
+
+fn collect_flattened_unknown_paths(
+    input: &str,
+    config: &Config,
+    ignored: &mut BTreeSet<String>,
+) -> Result<()> {
+    let source = input
+        .parse::<DocumentMut>()
+        .context("Failed to inspect flattened config fields")?;
+    let known = serialize_config_document(config)?;
+    let Some(source_keybindings) = source
+        .get("keybindings")
+        .and_then(toml_edit::Item::as_table_like)
+    else {
+        return Ok(());
+    };
+    let Some(known_keybindings) = known
+        .get("keybindings")
+        .and_then(toml_edit::Item::as_table_like)
+    else {
+        return Ok(());
+    };
+
+    for (key, _) in source_keybindings.iter() {
+        if !known_keybindings.contains_key(key) {
+            ignored.insert(format!("keybindings.{key}"));
+        }
+    }
+    Ok(())
+}
+
+fn is_known_feature_gated_path(_path: &str) -> bool {
+    #[cfg(not(tablet))]
+    if _path == "tablet" || _path.starts_with("tablet.") {
+        return true;
+    }
+    false
+}

--- a/src/config/document.rs
+++ b/src/config/document.rs
@@ -12,7 +12,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, TableLike};
 
 use merge::{
     conservative_repair_source_document, merge_config_document, repair_source_document,
@@ -152,6 +152,7 @@ impl SourceRevision {
 pub struct ConfigDocument {
     config: Config,
     document: DocumentMut,
+    known_document: DocumentMut,
     source_path: PathBuf,
     source: ConfigSource,
     revision: SourceRevision,
@@ -190,10 +191,13 @@ impl ConfigDocument {
                     .and_then(|bytes| std::str::from_utf8(bytes).ok())
                     .and_then(|input| input.parse::<DocumentMut>().ok())
                     .unwrap_or_default();
+                let config = Config::default();
+                let known_document = serialize_config_document(&config)?;
                 Ok((
                     Self {
-                        config: Config::default(),
+                        config,
                         document,
+                        known_document,
                         source_path,
                         source: ConfigSource::Primary,
                         revision,
@@ -216,25 +220,28 @@ impl ConfigDocument {
                 let document = input.parse::<DocumentMut>().with_context(|| {
                     format!("Failed to parse config from {}", source_path.display())
                 })?;
-                let (config, diagnostics) = parse_typed_config(input).with_context(|| {
+                let parsed = parse_typed_config(input).with_context(|| {
                     format!("Failed to parse config from {}", source_path.display())
                 })?;
                 Ok(Self {
-                    config,
+                    config: parsed.config,
                     document,
+                    known_document: parsed.known_document,
                     source_path,
                     source: ConfigSource::Primary,
                     revision,
-                    diagnostics,
+                    diagnostics: parsed.diagnostics,
                     repair_mode: false,
                 })
             }
             None => {
                 let config = Config::default();
                 let document = DocumentMut::new();
+                let known_document = serialize_config_document(&config)?;
                 Ok(Self {
                     config,
                     document,
+                    known_document,
                     source_path,
                     source: ConfigSource::Default,
                     revision,
@@ -268,15 +275,21 @@ impl ConfigDocument {
             .then(|| repair_source_document(&self.document, &self.config, &config))
             .transpose()?;
         let source = repair_source.as_ref().unwrap_or(&self.document);
-        let mut merged = merge_config_document(source, &self.config, &config)?;
+        let mut merged =
+            merge_config_document(source, &self.config, &config, &self.known_document)?;
         let mut output = merged.to_string();
         let parsed = parse_typed_config(&output);
-        let (saved_config, diagnostics) = match parsed {
+        let parsed = match parsed {
             Ok(parsed) => parsed,
             Err(_) if self.repair_mode => {
                 let conservative =
                     conservative_repair_source_document(&self.document, &self.config, &config)?;
-                merged = merge_config_document(&conservative, &self.config, &config)?;
+                merged = merge_config_document(
+                    &conservative,
+                    &self.config,
+                    &config,
+                    &self.known_document,
+                )?;
                 output = merged.to_string();
                 parse_typed_config(&output)
                     .context("Repaired config failed its validation parse before save")?
@@ -299,12 +312,13 @@ impl ConfigDocument {
 
         Ok(ConfigDocumentSaveOutcome {
             document: Self {
-                config: saved_config,
+                config: parsed.config,
                 document: merged,
+                known_document: parsed.known_document,
                 source_path: self.source_path.clone(),
                 source: ConfigSource::Primary,
                 revision,
-                diagnostics,
+                diagnostics: parsed.diagnostics,
                 repair_mode: false,
             },
             backup_path,
@@ -343,9 +357,20 @@ impl ConfigDocumentSaveOutcome {
     }
 }
 
-fn parse_typed_config(input: &str) -> Result<(Config, Vec<ConfigDiagnostic>)> {
-    let deserializer = toml::Deserializer::parse(input).context("Failed to parse TOML")?;
+struct ParsedConfig {
+    config: Config,
+    known_document: DocumentMut,
+    diagnostics: Vec<ConfigDiagnostic>,
+}
+
+fn parse_typed_config(input: &str) -> Result<ParsedConfig> {
     let mut ignored = BTreeSet::new();
+    let mut editor_input = input
+        .parse::<DocumentMut>()
+        .context("Failed to parse TOML")?;
+    strip_unknown_strict_export_fields(&mut editor_input, &mut ignored);
+    let editor_input = editor_input.to_string();
+    let deserializer = toml::Deserializer::parse(&editor_input).context("Failed to parse TOML")?;
     let mut config: Config = serde_ignored::deserialize(deserializer, |path| {
         let path = path.to_string();
         if !is_known_feature_gated_path(&path) {
@@ -353,6 +378,7 @@ fn parse_typed_config(input: &str) -> Result<(Config, Vec<ConfigDiagnostic>)> {
         }
     })
     .map_err(|error| anyhow!(error))?;
+    let known_document = serialize_config_document(&config)?;
     config.validate_and_clamp();
     collect_flattened_unknown_paths(input, &config, &mut ignored)?;
     let diagnostics = ignored
@@ -362,7 +388,83 @@ fn parse_typed_config(input: &str) -> Result<(Config, Vec<ConfigDiagnostic>)> {
             path,
         })
         .collect();
-    Ok((config, diagnostics))
+    Ok(ParsedConfig {
+        config,
+        known_document,
+        diagnostics,
+    })
+}
+
+fn strip_unknown_strict_export_fields(document: &mut DocumentMut, ignored: &mut BTreeSet<String>) {
+    strip_unknown_fields_at_path(document, &["export"], &["pdf"], ignored);
+    strip_unknown_fields_at_path(
+        document,
+        &["export", "pdf"],
+        &[
+            "filename_template",
+            "all_boards_filename_template",
+            "page_size",
+            "orientation",
+            "fit",
+            "transparent_background",
+            "custom_width",
+            "custom_height",
+            "content_source_padding",
+            "labels",
+        ],
+        ignored,
+    );
+    strip_unknown_fields_at_path(
+        document,
+        &["export", "pdf", "labels"],
+        &[
+            "enabled",
+            "position",
+            "content",
+            "template",
+            "font_family",
+            "font_size",
+            "margin",
+            "padding_x",
+            "padding_y",
+            "text_color",
+            "background_enabled",
+            "background_color",
+        ],
+        ignored,
+    );
+}
+
+fn strip_unknown_fields_at_path(
+    document: &mut DocumentMut,
+    path: &[&str],
+    known_fields: &[&str],
+    ignored: &mut BTreeSet<String>,
+) {
+    let Some(table) = table_like_at_path_mut(document.as_table_mut(), path) else {
+        return;
+    };
+    let unknown = table
+        .iter()
+        .map(|(key, _)| key.to_string())
+        .filter(|key| !known_fields.contains(&key.as_str()))
+        .collect::<Vec<_>>();
+    let prefix = path.join(".");
+    for key in unknown {
+        table.remove(&key);
+        ignored.insert(format!("{prefix}.{key}"));
+    }
+}
+
+fn table_like_at_path_mut<'a>(
+    table: &'a mut dyn TableLike,
+    path: &[&str],
+) -> Option<&'a mut dyn TableLike> {
+    let Some((head, tail)) = path.split_first() else {
+        return Some(table);
+    };
+    let child = table.get_mut(head)?.as_table_like_mut()?;
+    table_like_at_path_mut(child, tail)
 }
 
 fn collect_flattened_unknown_paths(

--- a/src/config/document/merge.rs
+++ b/src/config/document/merge.rs
@@ -1,0 +1,685 @@
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Key, Table, TableLike, Value};
+
+use super::super::Config;
+use crate::input::boards::BoundaryBoardIdSet;
+use crate::render_profiles::normalize_profile_id;
+
+pub(super) fn merge_config_document(
+    source: &DocumentMut,
+    previous: &Config,
+    updated: &Config,
+) -> Result<DocumentMut> {
+    let updated_revision = updated.config_revision;
+    let previous = serialize_config_document(previous)?;
+    let updated = serialize_config_document(updated)?;
+    let mut merged = source.clone();
+    let source_was_empty = merged.as_table().is_empty();
+    let empty_source_contents = source_was_empty.then(|| merged.trailing().clone());
+
+    canonicalize_aliases(&mut merged);
+    if !merged.contains_key("config_revision") && updated_revision > 0 {
+        merged.insert("config_revision", toml_edit::value(updated_revision as i64));
+    }
+    merge_table_like(
+        merged.as_table_mut(),
+        Some(previous.as_table()),
+        updated.as_table(),
+        "",
+    );
+    if let Some(contents) = empty_source_contents
+        && !merged.as_table().is_empty()
+    {
+        merged.as_table_mut().decor_mut().set_prefix(contents);
+        merged.set_trailing("");
+    }
+    Ok(merged)
+}
+
+pub(super) fn serialize_config_document(config: &Config) -> Result<DocumentMut> {
+    let text = toml::to_string_pretty(config).context("Failed to serialize config")?;
+    text.parse::<DocumentMut>()
+        .context("Failed to build editable config document")
+}
+
+pub(super) fn repair_source_document(
+    source: &DocumentMut,
+    previous: &Config,
+    updated: &Config,
+) -> Result<DocumentMut> {
+    let previous = serialize_config_document(previous)?;
+    let updated = serialize_config_document(updated)?;
+    let mut repair_source = source.clone();
+    canonicalize_aliases(&mut repair_source);
+    remove_known_content(
+        repair_source.as_table_mut(),
+        Some(previous.as_table()),
+        updated.as_table(),
+    );
+    Ok(repair_source)
+}
+
+pub(super) fn conservative_repair_source_document(
+    source: &DocumentMut,
+    previous: &Config,
+    updated: &Config,
+) -> Result<DocumentMut> {
+    let previous = serialize_config_document(previous)?;
+    let updated = serialize_config_document(updated)?;
+    let mut repair_source = source.clone();
+    canonicalize_aliases(&mut repair_source);
+    for key in known_keys(Some(previous.as_table()), updated.as_table()) {
+        repair_source.remove(&key);
+    }
+    Ok(repair_source)
+}
+
+fn remove_known_content(
+    raw: &mut dyn TableLike,
+    previous: Option<&dyn TableLike>,
+    updated: &dyn TableLike,
+) {
+    for key in known_keys(previous, updated) {
+        let previous_item = previous.and_then(|table| table.get(&key));
+        let updated_item = updated.get(&key);
+        let known_tables = previous_item
+            .into_iter()
+            .chain(updated_item)
+            .filter_map(Item::as_table_like)
+            .collect::<Vec<_>>();
+        let all_known_items_are_tables = previous_item
+            .into_iter()
+            .chain(updated_item)
+            .all(|item| item.as_table_like().is_some());
+
+        if all_known_items_are_tables
+            && let Some(raw_table) = raw.get_mut(&key).and_then(Item::as_table_like_mut)
+        {
+            let previous_table = previous_item.and_then(Item::as_table_like);
+            let updated_table = updated_item
+                .and_then(Item::as_table_like)
+                .or_else(|| known_tables.first().copied())
+                .expect("a known table-like item is available");
+            remove_known_content(raw_table, previous_table, updated_table);
+        } else {
+            raw.remove(&key);
+        }
+    }
+}
+
+fn known_keys(previous: Option<&dyn TableLike>, updated: &dyn TableLike) -> Vec<String> {
+    let mut keys = previous
+        .into_iter()
+        .flat_map(TableLike::iter)
+        .map(|(key, _)| key.to_string())
+        .collect::<Vec<_>>();
+    for (key, _) in updated.iter() {
+        if !keys.iter().any(|known| known == key) {
+            keys.push(key.to_string());
+        }
+    }
+    keys
+}
+
+fn canonicalize_aliases(document: &mut DocumentMut) {
+    rename_key_at_path(
+        document.as_table_mut(),
+        &["ui"],
+        "show_page_badge_with_status_bar",
+        "show_floating_badge_always",
+    );
+    rename_key_at_path(
+        document.as_table_mut(),
+        &["render_profiles"],
+        "items",
+        "profiles",
+    );
+    rename_key_at_path(
+        document.as_table_mut(),
+        &["ui", "toolbar", "mode_overrides"],
+        "full",
+        "regular",
+    );
+}
+
+fn rename_key_at_path(root: &mut Table, path: &[&str], alias: &str, canonical: &str) {
+    let Some(table) = table_like_at_path_mut(root, path) else {
+        return;
+    };
+    if table.contains_key(canonical) || !table.contains_key(alias) {
+        return;
+    }
+
+    let names = table
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect::<Vec<_>>();
+    let mut entries = Vec::with_capacity(names.len());
+    for name in names {
+        let Some(mut key) = table.key(&name).cloned() else {
+            continue;
+        };
+        let Some(item) = table.remove(&name) else {
+            continue;
+        };
+        if name == alias {
+            let mut renamed = Key::new(canonical);
+            *renamed.leaf_decor_mut() = key.leaf_decor().clone();
+            *renamed.dotted_decor_mut() = key.dotted_decor().clone();
+            key = renamed;
+        }
+        entries.push((key, item));
+    }
+
+    for (key, item) in entries {
+        table.entry_format(&key).or_insert(item);
+    }
+}
+
+fn table_like_at_path_mut<'a>(
+    table: &'a mut dyn TableLike,
+    path: &[&str],
+) -> Option<&'a mut dyn TableLike> {
+    let Some((head, tail)) = path.split_first() else {
+        return Some(table);
+    };
+    let child = table.get_mut(head)?.as_table_like_mut()?;
+    table_like_at_path_mut(child, tail)
+}
+
+fn merge_table_like(
+    raw: &mut dyn TableLike,
+    previous: Option<&dyn TableLike>,
+    updated: &dyn TableLike,
+    path: &str,
+) {
+    for key in known_keys(previous, updated) {
+        let previous_item = previous.and_then(|table| table.get(&key));
+        let item_path = if path.is_empty() {
+            key.clone()
+        } else {
+            format!("{path}.{key}")
+        };
+        match updated.get(&key) {
+            Some(updated_item) => match raw.get_mut(&key) {
+                Some(raw_item) => merge_item(raw_item, previous_item, updated_item, &item_path),
+                None => {
+                    if let Some(item) = changed_item(previous_item, updated_item, &item_path) {
+                        raw.insert(&key, item);
+                    }
+                }
+            },
+            None if previous_item.is_some() => {
+                raw.remove(&key);
+            }
+            None => {}
+        }
+    }
+}
+
+fn changed_item(previous: Option<&Item>, updated: &Item, path: &str) -> Option<Item> {
+    let Some(previous) = previous else {
+        return Some(updated.clone());
+    };
+    if items_semantically_equal(previous, updated) {
+        return None;
+    }
+
+    let (Some(previous_table), Some(updated_table)) =
+        (previous.as_table_like(), updated.as_table_like())
+    else {
+        return Some(updated.clone());
+    };
+    let mut changed = updated.clone();
+    let changed_table = changed
+        .as_table_like_mut()
+        .expect("a cloned table-like item remains table-like");
+    changed_table.clear();
+    merge_table_like(changed_table, Some(previous_table), updated_table, path);
+    (!changed_table.is_empty()).then_some(changed)
+}
+
+fn items_semantically_equal(left: &Item, right: &Item) -> bool {
+    if let (Some(left), Some(right)) = (left.as_table_like(), right.as_table_like()) {
+        return tables_semantically_equal(left, right);
+    }
+    if let (Some(left), Some(right)) = (left.as_array_of_tables(), right.as_array_of_tables()) {
+        return left.len() == right.len()
+            && left
+                .iter()
+                .zip(right.iter())
+                .all(|(left, right)| tables_semantically_equal(left, right));
+    }
+    match (left.as_value(), right.as_value()) {
+        (Some(left), Some(right)) => values_semantically_equal(left, right),
+        _ => left.to_string() == right.to_string(),
+    }
+}
+
+fn tables_semantically_equal(left: &dyn TableLike, right: &dyn TableLike) -> bool {
+    left.len() == right.len()
+        && left.iter().all(|(key, left_item)| {
+            right
+                .get(key)
+                .is_some_and(|right_item| items_semantically_equal(left_item, right_item))
+        })
+}
+
+fn merge_item(raw: &mut Item, previous: Option<&Item>, updated: &Item, path: &str) {
+    if let (Item::Value(Value::Array(raw)), Item::ArrayOfTables(updated)) = (&mut *raw, updated) {
+        let previous = previous
+            .and_then(Item::as_array_of_tables)
+            .cloned()
+            .map(ArrayOfTables::into_array);
+        let updated = updated.clone().into_array();
+        if merge_inline_array_of_tables(raw, previous.as_ref(), &updated, path) {
+            return;
+        }
+    }
+
+    if let (Some(raw_table), Some(updated_table)) =
+        (raw.as_table_like_mut(), updated.as_table_like())
+    {
+        merge_table_like(
+            raw_table,
+            previous.and_then(Item::as_table_like),
+            updated_table,
+            path,
+        );
+        return;
+    }
+
+    match (raw, updated) {
+        (Item::ArrayOfTables(raw), Item::ArrayOfTables(updated)) => merge_array_of_tables(
+            raw,
+            previous.and_then(Item::as_array_of_tables),
+            updated,
+            path,
+        ),
+        (Item::Value(raw), Item::Value(updated)) => {
+            merge_value(raw, previous.and_then(Item::as_value), updated, path);
+        }
+        (raw, updated) => replace_item_preserving_decor(raw, updated),
+    }
+}
+
+fn merge_value(raw: &mut Value, previous: Option<&Value>, updated: &Value, path: &str) {
+    match (raw, updated) {
+        (Value::InlineTable(raw), Value::InlineTable(updated)) => merge_table_like(
+            raw,
+            previous
+                .and_then(Value::as_inline_table)
+                .map(|table| table as _),
+            updated,
+            path,
+        ),
+        (Value::Array(raw), Value::Array(updated)) => {
+            let previous = previous.and_then(Value::as_array);
+            while raw.len() > updated.len() {
+                raw.remove(raw.len() - 1);
+            }
+            for index in 0..updated.len() {
+                let updated_value = updated
+                    .get(index)
+                    .expect("array index is bounded by updated length");
+                if let Some(raw_value) = raw.get_mut(index) {
+                    merge_value(
+                        raw_value,
+                        previous.and_then(|values| values.get(index)),
+                        updated_value,
+                        path,
+                    );
+                } else {
+                    raw.push_formatted(updated_value.clone());
+                }
+            }
+        }
+        (raw, updated) => {
+            if previous.is_some_and(|previous| values_semantically_equal(previous, updated))
+                && values_semantically_equal(raw, updated)
+            {
+                return;
+            }
+            let decor = raw.decor().clone();
+            *raw = updated.clone();
+            *raw.decor_mut() = decor;
+        }
+    }
+}
+
+fn merge_array_of_tables(
+    raw: &mut ArrayOfTables,
+    previous: Option<&ArrayOfTables>,
+    updated: &ArrayOfTables,
+    path: &str,
+) {
+    let raw_tables = raw.clone().into_iter().collect::<Vec<_>>();
+    let group_position = raw_tables.iter().filter_map(Table::position).min();
+    let previous_tables = previous
+        .map(|tables| tables.iter().collect::<Vec<_>>())
+        .unwrap_or_default();
+    let updated_tables = updated.iter().collect::<Vec<_>>();
+    let raw_table_refs = raw_tables
+        .iter()
+        .map(|table| table as &dyn TableLike)
+        .collect::<Vec<_>>();
+    let previous_table_refs = previous_tables
+        .iter()
+        .map(|table| *table as &dyn TableLike)
+        .collect::<Vec<_>>();
+    let updated_table_refs = updated_tables
+        .iter()
+        .map(|table| *table as &dyn TableLike)
+        .collect::<Vec<_>>();
+    let matches = plan_table_merges(
+        &raw_table_refs,
+        &previous_table_refs,
+        &updated_table_refs,
+        path,
+    );
+    let mut available = raw_tables.into_iter().map(Some).collect::<Vec<_>>();
+    let mut rebuilt = ArrayOfTables::new();
+
+    for (index, updated_table) in updated_tables.iter().copied().enumerate() {
+        let previous_table = matches.updated_previous[index]
+            .and_then(|index| previous_tables.get(index).copied())
+            .map(|table| table as _);
+        let mut merged_table = matches.raw_for_updated[index]
+            .and_then(|index| available.get_mut(index))
+            .and_then(Option::take)
+            .unwrap_or_else(|| updated_table.clone());
+
+        merge_table_like(&mut merged_table, previous_table, updated_table, path);
+        set_table_tree_position(&mut merged_table, group_position);
+        rebuilt.push(merged_table);
+    }
+    for index in matches.preserved_raw {
+        if let Some(mut table) = available.get_mut(index).and_then(Option::take) {
+            set_table_tree_position(&mut table, group_position);
+            rebuilt.push(table);
+        }
+    }
+
+    *raw = rebuilt;
+}
+
+struct TableMergePlan {
+    updated_previous: Vec<Option<usize>>,
+    raw_for_updated: Vec<Option<usize>>,
+    preserved_raw: Vec<usize>,
+}
+
+fn plan_table_merges(
+    raw: &[&dyn TableLike],
+    previous: &[&dyn TableLike],
+    updated: &[&dyn TableLike],
+    path: &str,
+) -> TableMergePlan {
+    let updated_previous = match_table_indices(updated, previous, path);
+    let previous_raw = match_table_indices(previous, raw, path);
+    let raw_for_updated = updated_previous
+        .iter()
+        .map(|previous_index| {
+            previous_index
+                .and_then(|index| previous_raw.get(index))
+                .copied()
+                .flatten()
+        })
+        .collect();
+    let preserved_raw = (0..raw.len())
+        .filter(|index| {
+            !previous_raw
+                .iter()
+                .flatten()
+                .any(|matched| matched == index)
+        })
+        .collect();
+    TableMergePlan {
+        updated_previous,
+        raw_for_updated,
+        preserved_raw,
+    }
+}
+
+fn match_table_indices(
+    targets: &[&dyn TableLike],
+    candidates: &[&dyn TableLike],
+    path: &str,
+) -> Vec<Option<usize>> {
+    let target_ids = table_id_keys(targets, path);
+    let candidate_ids = table_id_keys(candidates, path);
+    let mut matches = vec![None; targets.len()];
+    let mut candidate_used = vec![false; candidates.len()];
+
+    for (target_index, target_id) in target_ids.iter().enumerate() {
+        let Some(target_id) = target_id else {
+            continue;
+        };
+        let target_occurrences = target_ids
+            .iter()
+            .filter(|candidate| candidate.as_ref() == Some(target_id))
+            .count();
+        let candidate_indices = candidate_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(index, candidate)| {
+                (candidate.as_ref() == Some(target_id)).then_some(index)
+            })
+            .collect::<Vec<_>>();
+        if target_occurrences == 1 && candidate_indices.len() == 1 {
+            let candidate_index = candidate_indices[0];
+            matches[target_index] = Some(candidate_index);
+            candidate_used[candidate_index] = true;
+        }
+    }
+
+    for (target_index, target) in targets.iter().enumerate() {
+        if matches[target_index].is_some() {
+            continue;
+        }
+        let candidate_indices = candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(index, candidate)| {
+                (!candidate_used[index] && tables_semantically_equal(*target, *candidate))
+                    .then_some(index)
+            })
+            .collect::<Vec<_>>();
+        if candidate_indices.len() == 1 {
+            let candidate_index = candidate_indices[0];
+            matches[target_index] = Some(candidate_index);
+            candidate_used[candidate_index] = true;
+        }
+    }
+
+    let unmatched_targets = matches
+        .iter()
+        .enumerate()
+        .filter_map(|(index, matched)| matched.is_none().then_some(index))
+        .collect::<Vec<_>>();
+    let unmatched_candidates = candidate_used
+        .iter()
+        .enumerate()
+        .filter_map(|(index, used)| (!used).then_some(index));
+    for (target_index, candidate_index) in unmatched_targets.into_iter().zip(unmatched_candidates) {
+        matches[target_index] = Some(candidate_index);
+    }
+    matches
+}
+
+fn table_id_keys(tables: &[&dyn TableLike], path: &str) -> Vec<Option<String>> {
+    match path {
+        "render_profiles.profiles" => normalized_render_profile_ids(tables),
+        "boards.items" => normalized_board_ids(tables),
+        _ => tables
+            .iter()
+            .map(|table| literal_table_id(*table))
+            .collect(),
+    }
+}
+
+fn normalized_render_profile_ids(tables: &[&dyn TableLike]) -> Vec<Option<String>> {
+    let mut seen = HashSet::new();
+    tables
+        .iter()
+        .enumerate()
+        .map(|(index, table)| {
+            let raw_id = table.get("id")?.as_value()?.as_str()?;
+            let mut id = normalize_profile_id(raw_id);
+            if id.is_empty() {
+                id = format!("profile-{}", index + 1);
+            }
+            let base = id.clone();
+            let mut suffix = 2;
+            while seen.contains(&id) {
+                id = format!("{base}-{suffix}");
+                suffix += 1;
+            }
+            seen.insert(id.clone());
+            Some(id)
+        })
+        .collect()
+}
+
+fn normalized_board_ids(tables: &[&dyn TableLike]) -> Vec<Option<String>> {
+    let mut seen = BoundaryBoardIdSet::new();
+    tables
+        .iter()
+        .enumerate()
+        .map(|(index, table)| {
+            let raw_id = table.get("id")?.as_value()?.as_str()?;
+            Some(seen.normalize_unique(raw_id, index).value)
+        })
+        .collect()
+}
+
+fn literal_table_id(table: &dyn TableLike) -> Option<String> {
+    let id = table.get("id")?.as_value()?.as_str()?.trim();
+    if id.is_empty() {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+fn merge_inline_array_of_tables(
+    raw: &mut Array,
+    previous: Option<&Array>,
+    updated: &Array,
+    path: &str,
+) -> bool {
+    let raw_values = raw.iter().cloned().collect::<Vec<_>>();
+    let previous_values = previous
+        .map(|array| array.iter().collect::<Vec<_>>())
+        .unwrap_or_default();
+    let updated_values = updated.iter().collect::<Vec<_>>();
+    let Some(raw_tables) = inline_tables(&raw_values) else {
+        return false;
+    };
+    let Some(previous_tables) = inline_table_refs(&previous_values) else {
+        return false;
+    };
+    let Some(updated_tables) = inline_table_refs(&updated_values) else {
+        return false;
+    };
+
+    let matches = plan_table_merges(&raw_tables, &previous_tables, &updated_tables, path);
+    let mut available = raw_values.into_iter().map(Some).collect::<Vec<_>>();
+    let mut rebuilt = Vec::with_capacity(updated_values.len() + matches.preserved_raw.len());
+
+    for (index, updated_value) in updated_values.iter().copied().enumerate() {
+        let previous_table =
+            matches.updated_previous[index].and_then(|index| previous_tables.get(index).copied());
+        let mut merged_value = matches.raw_for_updated[index]
+            .and_then(|index| available.get_mut(index))
+            .and_then(Option::take)
+            .unwrap_or_else(|| updated_value.clone());
+        let merged_table = merged_value
+            .as_inline_table_mut()
+            .expect("validated inline-table array contains inline tables");
+        merge_table_like(merged_table, previous_table, updated_tables[index], path);
+        rebuilt.push(merged_value);
+    }
+    for index in matches.preserved_raw {
+        if let Some(value) = available.get_mut(index).and_then(Option::take) {
+            rebuilt.push(value);
+        }
+    }
+
+    raw.clear();
+    for value in rebuilt {
+        raw.push_formatted(value);
+    }
+    true
+}
+
+fn inline_tables(values: &[Value]) -> Option<Vec<&dyn TableLike>> {
+    values
+        .iter()
+        .map(|value| value.as_inline_table().map(|table| table as &dyn TableLike))
+        .collect()
+}
+
+fn inline_table_refs<'a>(values: &'a [&'a Value]) -> Option<Vec<&'a dyn TableLike>> {
+    values
+        .iter()
+        .map(|value| value.as_inline_table().map(|table| table as &dyn TableLike))
+        .collect()
+}
+
+fn set_table_tree_position(table: &mut Table, position: Option<isize>) {
+    table.set_position(position);
+    for (_, item) in table.iter_mut() {
+        match item {
+            Item::Table(table) => set_table_tree_position(table, position),
+            Item::ArrayOfTables(tables) => {
+                for table in tables.iter_mut() {
+                    set_table_tree_position(table, position);
+                }
+            }
+            Item::None | Item::Value(_) => {}
+        }
+    }
+}
+
+fn values_semantically_equal(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::String(left), Value::String(right)) => left.value() == right.value(),
+        (Value::Integer(left), Value::Integer(right)) => left.value() == right.value(),
+        (Value::Float(left), Value::Float(right)) => {
+            left.value().to_bits() == right.value().to_bits()
+        }
+        (Value::Integer(integer), Value::Float(float))
+        | (Value::Float(float), Value::Integer(integer)) => {
+            (*integer.value() as f64).to_bits() == float.value().to_bits()
+        }
+        (Value::Boolean(left), Value::Boolean(right)) => left.value() == right.value(),
+        (Value::Datetime(left), Value::Datetime(right)) => left.value() == right.value(),
+        (Value::Array(left), Value::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right.iter())
+                    .all(|(left, right)| values_semantically_equal(left, right))
+        }
+        (Value::InlineTable(left), Value::InlineTable(right)) => {
+            tables_semantically_equal(left, right)
+        }
+        _ => false,
+    }
+}
+
+fn replace_item_preserving_decor(raw: &mut Item, updated: &Item) {
+    let mut replacement = updated.clone();
+    match (&mut *raw, &mut replacement) {
+        (Item::Value(raw), Item::Value(replacement)) => {
+            *replacement.decor_mut() = raw.decor().clone();
+        }
+        (Item::Table(raw), Item::Table(replacement)) => {
+            *replacement.decor_mut() = raw.decor().clone();
+        }
+        _ => {}
+    }
+    *raw = replacement;
+}

--- a/src/config/document/merge.rs
+++ b/src/config/document/merge.rs
@@ -11,6 +11,7 @@ pub(super) fn merge_config_document(
     source: &DocumentMut,
     previous: &Config,
     updated: &Config,
+    known_document: &DocumentMut,
 ) -> Result<DocumentMut> {
     let updated_revision = updated.config_revision;
     let previous = serialize_config_document(previous)?;
@@ -27,6 +28,7 @@ pub(super) fn merge_config_document(
         merged.as_table_mut(),
         Some(previous.as_table()),
         updated.as_table(),
+        Some(known_document.as_table()),
         "",
     );
     if let Some(contents) = empty_source_contents
@@ -70,7 +72,7 @@ pub(super) fn conservative_repair_source_document(
     let updated = serialize_config_document(updated)?;
     let mut repair_source = source.clone();
     canonicalize_aliases(&mut repair_source);
-    for key in known_keys(Some(previous.as_table()), updated.as_table()) {
+    for key in known_keys(Some(previous.as_table()), updated.as_table(), None) {
         repair_source.remove(&key);
     }
     Ok(repair_source)
@@ -81,7 +83,7 @@ fn remove_known_content(
     previous: Option<&dyn TableLike>,
     updated: &dyn TableLike,
 ) {
-    for key in known_keys(previous, updated) {
+    for key in known_keys(previous, updated, None) {
         let previous_item = previous.and_then(|table| table.get(&key));
         let updated_item = updated.get(&key);
         let known_tables = previous_item
@@ -109,13 +111,22 @@ fn remove_known_content(
     }
 }
 
-fn known_keys(previous: Option<&dyn TableLike>, updated: &dyn TableLike) -> Vec<String> {
+fn known_keys(
+    previous: Option<&dyn TableLike>,
+    updated: &dyn TableLike,
+    known: Option<&dyn TableLike>,
+) -> Vec<String> {
     let mut keys = previous
         .into_iter()
         .flat_map(TableLike::iter)
         .map(|(key, _)| key.to_string())
         .collect::<Vec<_>>();
     for (key, _) in updated.iter() {
+        if !keys.iter().any(|known| known == key) {
+            keys.push(key.to_string());
+        }
+    }
+    for (key, _) in known.into_iter().flat_map(TableLike::iter) {
         if !keys.iter().any(|known| known == key) {
             keys.push(key.to_string());
         }
@@ -193,10 +204,12 @@ fn merge_table_like(
     raw: &mut dyn TableLike,
     previous: Option<&dyn TableLike>,
     updated: &dyn TableLike,
+    known: Option<&dyn TableLike>,
     path: &str,
 ) {
-    for key in known_keys(previous, updated) {
+    for key in known_keys(previous, updated, known) {
         let previous_item = previous.and_then(|table| table.get(&key));
+        let known_item = known.and_then(|table| table.get(&key));
         let item_path = if path.is_empty() {
             key.clone()
         } else {
@@ -204,14 +217,20 @@ fn merge_table_like(
         };
         match updated.get(&key) {
             Some(updated_item) => match raw.get_mut(&key) {
-                Some(raw_item) => merge_item(raw_item, previous_item, updated_item, &item_path),
+                Some(raw_item) => merge_item(
+                    raw_item,
+                    previous_item,
+                    updated_item,
+                    known_item,
+                    &item_path,
+                ),
                 None => {
                     if let Some(item) = changed_item(previous_item, updated_item, &item_path) {
                         raw.insert(&key, item);
                     }
                 }
             },
-            None if previous_item.is_some() => {
+            None if previous_item.is_some() || known_item.is_some() => {
                 raw.remove(&key);
             }
             None => {}
@@ -237,7 +256,13 @@ fn changed_item(previous: Option<&Item>, updated: &Item, path: &str) -> Option<I
         .as_table_like_mut()
         .expect("a cloned table-like item remains table-like");
     changed_table.clear();
-    merge_table_like(changed_table, Some(previous_table), updated_table, path);
+    merge_table_like(
+        changed_table,
+        Some(previous_table),
+        updated_table,
+        None,
+        path,
+    );
     (!changed_table.is_empty()).then_some(changed)
 }
 
@@ -267,7 +292,13 @@ fn tables_semantically_equal(left: &dyn TableLike, right: &dyn TableLike) -> boo
         })
 }
 
-fn merge_item(raw: &mut Item, previous: Option<&Item>, updated: &Item, path: &str) {
+fn merge_item(
+    raw: &mut Item,
+    previous: Option<&Item>,
+    updated: &Item,
+    known: Option<&Item>,
+    path: &str,
+) {
     if let (Item::Value(Value::Array(raw)), Item::ArrayOfTables(updated)) = (&mut *raw, updated) {
         let previous = previous
             .and_then(Item::as_array_of_tables)
@@ -286,6 +317,7 @@ fn merge_item(raw: &mut Item, previous: Option<&Item>, updated: &Item, path: &st
             raw_table,
             previous.and_then(Item::as_table_like),
             updated_table,
+            known.and_then(Item::as_table_like),
             path,
         );
         return;
@@ -299,13 +331,25 @@ fn merge_item(raw: &mut Item, previous: Option<&Item>, updated: &Item, path: &st
             path,
         ),
         (Item::Value(raw), Item::Value(updated)) => {
-            merge_value(raw, previous.and_then(Item::as_value), updated, path);
+            merge_value(
+                raw,
+                previous.and_then(Item::as_value),
+                updated,
+                known.and_then(Item::as_value),
+                path,
+            );
         }
         (raw, updated) => replace_item_preserving_decor(raw, updated),
     }
 }
 
-fn merge_value(raw: &mut Value, previous: Option<&Value>, updated: &Value, path: &str) {
+fn merge_value(
+    raw: &mut Value,
+    previous: Option<&Value>,
+    updated: &Value,
+    known: Option<&Value>,
+    path: &str,
+) {
     match (raw, updated) {
         (Value::InlineTable(raw), Value::InlineTable(updated)) => merge_table_like(
             raw,
@@ -313,6 +357,9 @@ fn merge_value(raw: &mut Value, previous: Option<&Value>, updated: &Value, path:
                 .and_then(Value::as_inline_table)
                 .map(|table| table as _),
             updated,
+            known
+                .and_then(Value::as_inline_table)
+                .map(|table| table as _),
             path,
         ),
         (Value::Array(raw), Value::Array(updated)) => {
@@ -329,6 +376,9 @@ fn merge_value(raw: &mut Value, previous: Option<&Value>, updated: &Value, path:
                         raw_value,
                         previous.and_then(|values| values.get(index)),
                         updated_value,
+                        known
+                            .and_then(Value::as_array)
+                            .and_then(|values| values.get(index)),
                         path,
                     );
                 } else {
@@ -356,7 +406,8 @@ fn merge_array_of_tables(
     path: &str,
 ) {
     let raw_tables = raw.clone().into_iter().collect::<Vec<_>>();
-    let group_position = raw_tables.iter().filter_map(Table::position).min();
+    let raw_positions = raw_tables.iter().map(Table::position).collect::<Vec<_>>();
+    let group_position = raw_positions.iter().flatten().copied().min();
     let previous_tables = previous
         .map(|tables| tables.iter().collect::<Vec<_>>())
         .unwrap_or_default();
@@ -379,6 +430,12 @@ fn merge_array_of_tables(
         &updated_table_refs,
         path,
     );
+    let mut last_raw_index = None;
+    let preserve_entry_positions = matches.raw_for_updated.iter().flatten().all(|index| {
+        let preserves_order = last_raw_index.is_none_or(|last| *index > last);
+        last_raw_index = Some(*index);
+        preserves_order
+    });
     let mut available = raw_tables.into_iter().map(Some).collect::<Vec<_>>();
     let mut rebuilt = ArrayOfTables::new();
 
@@ -386,23 +443,72 @@ fn merge_array_of_tables(
         let previous_table = matches.updated_previous[index]
             .and_then(|index| previous_tables.get(index).copied())
             .map(|table| table as _);
-        let mut merged_table = matches.raw_for_updated[index]
+        let raw_index = matches.raw_for_updated[index];
+        let original_table = raw_index
+            .and_then(|index| available.get(index))
+            .and_then(Option::as_ref)
+            .cloned();
+        let mut merged_table = raw_index
             .and_then(|index| available.get_mut(index))
             .and_then(Option::take)
             .unwrap_or_else(|| updated_table.clone());
 
-        merge_table_like(&mut merged_table, previous_table, updated_table, path);
-        set_table_tree_position(&mut merged_table, group_position);
+        merge_table_like(&mut merged_table, previous_table, updated_table, None, path);
+        let position = if preserve_entry_positions {
+            retained_table_position(
+                index,
+                &matches.raw_for_updated,
+                &raw_positions,
+                group_position,
+            )
+        } else {
+            group_position
+        };
+        if !preserve_entry_positions || raw_index.is_none() {
+            set_table_tree_position(&mut merged_table, position);
+        } else if let Some(original_table) = original_table.as_ref() {
+            position_new_table_children(&mut merged_table, original_table);
+        }
         rebuilt.push(merged_table);
     }
     for index in matches.preserved_raw {
         if let Some(mut table) = available.get_mut(index).and_then(Option::take) {
-            set_table_tree_position(&mut table, group_position);
+            let position = preserve_entry_positions
+                .then(|| raw_positions.get(index).copied().flatten())
+                .flatten()
+                .or(group_position);
+            if !preserve_entry_positions {
+                set_table_tree_position(&mut table, position);
+            }
             rebuilt.push(table);
         }
     }
 
     *raw = rebuilt;
+}
+
+fn retained_table_position(
+    updated_index: usize,
+    raw_for_updated: &[Option<usize>],
+    raw_positions: &[Option<isize>],
+    group_position: Option<isize>,
+) -> Option<isize> {
+    raw_for_updated[updated_index]
+        .and_then(|index| raw_positions.get(index).copied().flatten())
+        .or_else(|| {
+            raw_for_updated[..updated_index]
+                .iter()
+                .rev()
+                .flatten()
+                .find_map(|index| raw_positions.get(*index).copied().flatten())
+        })
+        .or_else(|| {
+            raw_for_updated[updated_index + 1..]
+                .iter()
+                .flatten()
+                .find_map(|index| raw_positions.get(*index).copied().flatten())
+        })
+        .or(group_position)
 }
 
 struct TableMergePlan {
@@ -598,7 +704,13 @@ fn merge_inline_array_of_tables(
         let merged_table = merged_value
             .as_inline_table_mut()
             .expect("validated inline-table array contains inline tables");
-        merge_table_like(merged_table, previous_table, updated_tables[index], path);
+        merge_table_like(
+            merged_table,
+            previous_table,
+            updated_tables[index],
+            None,
+            path,
+        );
         rebuilt.push(merged_value);
     }
     for index in matches.preserved_raw {
@@ -636,6 +748,33 @@ fn set_table_tree_position(table: &mut Table, position: Option<isize>) {
             Item::ArrayOfTables(tables) => {
                 for table in tables.iter_mut() {
                     set_table_tree_position(table, position);
+                }
+            }
+            Item::None | Item::Value(_) => {}
+        }
+    }
+}
+
+fn position_new_table_children(table: &mut Table, original: &Table) {
+    let parent_position = table.position();
+    for (key, item) in table.iter_mut() {
+        match item {
+            Item::Table(child) => {
+                if let Some(original_child) = original.get(key.get()).and_then(Item::as_table) {
+                    position_new_table_children(child, original_child);
+                } else {
+                    set_table_tree_position(child, parent_position);
+                }
+            }
+            Item::ArrayOfTables(tables) => {
+                if original
+                    .get(key.get())
+                    .and_then(Item::as_array_of_tables)
+                    .is_none()
+                {
+                    for child in tables.iter_mut() {
+                        set_table_tree_position(child, parent_position);
+                    }
                 }
             }
             Item::None | Item::Value(_) => {}

--- a/src/config/field_metadata.rs
+++ b/src/config/field_metadata.rs
@@ -1,0 +1,143 @@
+//! Shared metadata for the first declarative configurator field slice.
+//!
+//! Performance is deliberately the only section represented here. The configurator keeps its
+//! typed draft and messages while sharing user-facing field identity and constraints with core
+//! config validation.
+
+pub const PERFORMANCE_BUFFER_COUNT_MIN: u32 = 2;
+pub const PERFORMANCE_BUFFER_COUNT_MAX: u32 = 4;
+pub const PERFORMANCE_BUFFER_COUNTS: &[u32] = &[2, 3, 4];
+pub const PERFORMANCE_UI_ANIMATION_FPS_MAX: u32 = 240;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PerformanceFieldId {
+    BufferCount,
+    EnableVsync,
+    MaxFpsNoVsync,
+    UiAnimationFps,
+}
+
+impl PerformanceFieldId {
+    pub const ALL: [Self; 4] = [
+        Self::BufferCount,
+        Self::EnableVsync,
+        Self::MaxFpsNoVsync,
+        Self::UiAnimationFps,
+    ];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerformanceFieldGroup {
+    Rendering,
+    Animations,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarConstraint {
+    Boolean,
+    Unsigned { min: u32, max: u32 },
+    UnsignedChoice(&'static [u32]),
+}
+
+impl ScalarConstraint {
+    pub const fn accepts_u32(self, value: u32) -> bool {
+        match self {
+            Self::Boolean => false,
+            Self::Unsigned { min, max } => value >= min && value <= max,
+            Self::UnsignedChoice(values) => {
+                let mut index = 0;
+                while index < values.len() {
+                    if values[index] == value {
+                        return true;
+                    }
+                    index += 1;
+                }
+                false
+            }
+        }
+    }
+
+    pub const fn unsigned_range(self) -> Option<(u32, u32)> {
+        match self {
+            Self::Unsigned { min, max } => Some((min, max)),
+            Self::Boolean | Self::UnsignedChoice(_) => None,
+        }
+    }
+
+    pub const fn unsigned_choices(self) -> Option<&'static [u32]> {
+        match self {
+            Self::UnsignedChoice(values) => Some(values),
+            Self::Boolean | Self::Unsigned { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PerformanceFieldMetadata {
+    pub id: PerformanceFieldId,
+    pub path: &'static str,
+    pub group: PerformanceFieldGroup,
+    pub label: &'static str,
+    pub help: &'static str,
+    pub search_terms: &'static [&'static str],
+    pub constraint: ScalarConstraint,
+}
+
+pub const PERFORMANCE_FIELD_METADATA: &[PerformanceFieldMetadata] = &[
+    PerformanceFieldMetadata {
+        id: PerformanceFieldId::BufferCount,
+        path: "performance.buffer_count",
+        group: PerformanceFieldGroup::Rendering,
+        label: "Buffer count (2-4)",
+        help: "2 uses less memory; 3 is recommended; 4 adds another queued buffer.",
+        search_terms: &["rendering", "buffer", "double triple quad buffering"],
+        constraint: ScalarConstraint::UnsignedChoice(PERFORMANCE_BUFFER_COUNTS),
+    },
+    PerformanceFieldMetadata {
+        id: PerformanceFieldId::EnableVsync,
+        path: "performance.enable_vsync",
+        group: PerformanceFieldGroup::Rendering,
+        label: "Enable VSync",
+        help: "Synchronizes rendering with display refresh to prevent tearing, with some input latency.",
+        search_terms: &["rendering", "vsync", "tearing", "display refresh"],
+        constraint: ScalarConstraint::Boolean,
+    },
+    PerformanceFieldMetadata {
+        id: PerformanceFieldId::MaxFpsNoVsync,
+        path: "performance.max_fps_no_vsync",
+        group: PerformanceFieldGroup::Rendering,
+        label: "Max FPS (VSync off)",
+        help: "Caps frame rate when VSync is off. Default 120; try 144 or 240 on high-refresh displays; 0 means unlimited.",
+        search_terms: &["rendering", "fps", "frame rate", "vsync off", "unlimited"],
+        constraint: ScalarConstraint::Unsigned {
+            min: 0,
+            max: u32::MAX,
+        },
+    },
+    PerformanceFieldMetadata {
+        id: PerformanceFieldId::UiAnimationFps,
+        path: "performance.ui_animation_fps",
+        group: PerformanceFieldGroup::Animations,
+        label: "UI Animation FPS",
+        help: "Controls UI effect ticks without changing input responsiveness; 30-60 is recommended, 0 means unlimited.",
+        search_terms: &[
+            "animation",
+            "ui",
+            "fps",
+            "effects",
+            "toasts",
+            "click highlights",
+        ],
+        constraint: ScalarConstraint::Unsigned {
+            min: 0,
+            max: PERFORMANCE_UI_ANIMATION_FPS_MAX,
+        },
+    },
+];
+
+pub fn performance_field_metadata(id: PerformanceFieldId) -> &'static PerformanceFieldMetadata {
+    PERFORMANCE_FIELD_METADATA
+        .iter()
+        .find(|metadata| metadata.id == id)
+        .expect("every PerformanceFieldId must have metadata")
+}

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 /// Represents the source used to load configuration data.
 #[derive(Debug, Clone)]
 pub enum ConfigSource {
-    /// Configuration file loaded from the Wayscriber config path.
+    /// Configuration file loaded from the selected config path.
     Primary,
     /// Defaults were used because no configuration file was found.
     Default,
@@ -95,25 +95,14 @@ impl Config {
 
     fn write_config(&self, create_backup: bool) -> Result<Option<PathBuf>> {
         let config_path = Self::get_config_path()?;
-
-        if let Some(parent) = config_path.parent() {
-            fs::create_dir_all(parent).context("Failed to create config directory")?;
-        }
-
+        prepare_config_parent(&config_path)?;
         let backup_path = if create_backup && config_path.exists() {
-            Some(Self::create_backup(&config_path)?)
+            Some(create_config_backup(&config_path)?)
         } else {
             None
         };
-
         let config_str = toml::to_string_pretty(self).context("Failed to serialize config")?;
-
-        crate::durable_io::write_text_atomic(
-            &config_path,
-            &config_str,
-            AtomicWriteOptions::user_config_file(),
-        )
-        .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+        write_config_text_atomic(&config_path, &config_str, OverwriteMode::Replace)?;
 
         if let Some(path) = &backup_path {
             info!(
@@ -140,29 +129,6 @@ impl Config {
     #[allow(dead_code)]
     pub fn save_with_backup(&self) -> Result<Option<PathBuf>> {
         self.write_config(true)
-    }
-
-    fn create_backup(path: &Path) -> Result<PathBuf> {
-        let timestamp = format_with_template(now_local(), "%Y%m%d_%H%M%S");
-        let filename = match path.file_name().and_then(|name| name.to_str()) {
-            Some(name) => format!("{name}.{}.bak", timestamp),
-            None => format!("config.toml.{}.bak", timestamp),
-        };
-
-        let backup_path = path
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .join(filename);
-
-        fs::copy(path, &backup_path).with_context(|| {
-            format!(
-                "Failed to create config backup from {} to {}",
-                path.display(),
-                backup_path.display()
-            )
-        })?;
-
-        Ok(backup_path)
     }
 
     /// Creates a default configuration file with documentation comments.
@@ -207,4 +173,42 @@ impl Config {
         info!("Created default config at {}", config_path.display());
         Ok(())
     }
+}
+
+pub(super) fn prepare_config_parent(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("Failed to create config directory")?;
+    }
+    Ok(())
+}
+
+pub(super) fn create_config_backup(path: &Path) -> Result<PathBuf> {
+    let timestamp = format_with_template(now_local(), "%Y%m%d_%H%M%S");
+    let filename = match path.file_name().and_then(|name| name.to_str()) {
+        Some(name) => format!("{name}.{}.bak", timestamp),
+        None => format!("config.toml.{}.bak", timestamp),
+    };
+    let backup_path = path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(filename);
+    fs::copy(path, &backup_path).with_context(|| {
+        format!(
+            "Failed to create config backup from {} to {}",
+            path.display(),
+            backup_path.display()
+        )
+    })?;
+    Ok(backup_path)
+}
+
+pub(super) fn write_config_text_atomic(
+    path: &Path,
+    contents: &str,
+    overwrite: OverwriteMode,
+) -> Result<()> {
+    let mut options = AtomicWriteOptions::user_config_file();
+    options.overwrite = overwrite;
+    crate::durable_io::write_text_atomic(path, contents, options)
+        .with_context(|| format!("Failed to write config to {}", path.display()))
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,8 @@ pub mod keybindings;
 pub mod types;
 
 mod core;
+mod document;
+mod field_metadata;
 mod io;
 mod paths;
 #[cfg(feature = "config-schema")]
@@ -30,7 +32,15 @@ pub use action_meta::{
     action_meta, action_meta_iter, action_short_label,
 };
 pub use core::{CURRENT_CONFIG_REVISION, Config};
+pub use document::{
+    ConfigDiagnostic, ConfigDiagnosticKind, ConfigDocument, ConfigDocumentSaveOutcome,
+};
 pub use enums::{RadialMenuMouseBinding, StatusPosition, XdgFocusLossBehavior};
+pub use field_metadata::{
+    PERFORMANCE_BUFFER_COUNT_MAX, PERFORMANCE_BUFFER_COUNT_MIN, PERFORMANCE_BUFFER_COUNTS,
+    PERFORMANCE_FIELD_METADATA, PERFORMANCE_UI_ANIMATION_FPS_MAX, PerformanceFieldGroup,
+    PerformanceFieldId, PerformanceFieldMetadata, ScalarConstraint, performance_field_metadata,
+};
 #[allow(unused_imports)]
 pub use io::{ConfigSource, LoadedConfig};
 pub use keybindings::{Action, KeyBinding, KeybindingsConfig};

--- a/src/config/tests/document.rs
+++ b/src/config/tests/document.rs
@@ -1,0 +1,1242 @@
+use super::super::*;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct TempConfig {
+    root: PathBuf,
+    path: PathBuf,
+}
+
+impl TempConfig {
+    fn new(name: &str) -> Self {
+        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "wayscriber-config-document-{}-{sequence}-{name}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("create temporary config directory");
+        let path = root.join("config.toml");
+        Self { root, path }
+    }
+
+    fn write(&self, contents: &str) {
+        fs::write(&self.path, contents).expect("write temporary config");
+    }
+}
+
+impl Drop for TempConfig {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn diagnostic_paths(document: &ConfigDocument) -> Vec<&str> {
+    document
+        .diagnostics()
+        .iter()
+        .map(ConfigDiagnostic::path)
+        .collect()
+}
+
+#[test]
+fn document_save_preserves_comments_order_unknowns_and_validates_known_values() {
+    let temp = TempConfig::new("golden");
+    temp.write(
+        r#"# user header
+future_root = "keep" # future root inline
+
+[performance] # performance header
+buffer_count = 99 # keep buffer explanation
+enable_vsync = false
+max_fps_no_vsync = 120
+ui_animation_fps = 999 # clamp this known value
+future_knob = 7 # preserve nested unknown
+
+# user trailing comment
+"#,
+    );
+
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load document");
+    let paths = diagnostic_paths(&document);
+    assert!(paths.iter().any(|path| path.ends_with("future_root")));
+    assert!(
+        paths
+            .iter()
+            .any(|path| path.ends_with("performance.future_knob"))
+    );
+    assert_eq!(document.config().performance.buffer_count, 4);
+    assert_eq!(document.config().performance.ui_animation_fps, 240);
+
+    let mut updated = document.config().clone();
+    updated.performance.max_fps_no_vsync = 144;
+    let outcome = document
+        .save_with_backup(updated)
+        .expect("save merged document");
+    let saved = fs::read_to_string(&temp.path).expect("read merged document");
+
+    for preserved in [
+        "# user header",
+        "future_root = \"keep\" # future root inline",
+        "[performance] # performance header",
+        "# keep buffer explanation",
+        "future_knob = 7 # preserve nested unknown",
+        "# user trailing comment",
+    ] {
+        assert!(
+            saved.contains(preserved),
+            "missing preserved text: {preserved}"
+        );
+    }
+    assert!(saved.find("future_root").unwrap() < saved.find("[performance]").unwrap());
+    assert!(saved.contains("buffer_count = 4 # keep buffer explanation"));
+    assert!(saved.contains("max_fps_no_vsync = 144"));
+    assert!(saved.contains("ui_animation_fps = 240 # clamp this known value"));
+    assert_eq!(
+        diagnostic_paths(outcome.document()),
+        diagnostic_paths(&document)
+    );
+}
+
+#[test]
+fn document_save_removes_omitted_known_option_without_removing_unknown_neighbor() {
+    let temp = TempConfig::new("optional");
+    temp.write(
+        r#"[ui]
+preferred_output = "DP-1"
+future_output_policy = "keep"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load document");
+    let mut updated = document.config().clone();
+    updated.ui.preferred_output = None;
+
+    document
+        .save_with_backup(updated)
+        .expect("save optional removal");
+    let saved = fs::read_to_string(&temp.path).expect("read saved config");
+    assert!(!saved.contains("preferred_output"));
+    assert!(saved.contains("future_output_policy = \"keep\""));
+}
+
+#[test]
+fn no_op_save_does_not_materialize_omitted_defaults() {
+    let temp = TempConfig::new("omitted-defaults");
+    let original =
+        "config_revision = 1\n# intentionally sparse\n[performance]\nmax_fps_no_vsync = 120\n";
+    temp.write(original);
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load sparse document");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save sparse document without changes");
+
+    assert_eq!(
+        fs::read_to_string(&temp.path).expect("read sparse document"),
+        original
+    );
+}
+
+#[test]
+fn changing_an_omitted_value_inserts_only_that_value() {
+    let temp = TempConfig::new("sparse-change");
+    temp.write("# intentionally sparse\n");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load sparse document");
+    let mut updated = document.config().clone();
+    updated.performance.max_fps_no_vsync = 144;
+
+    document
+        .save_with_backup(updated)
+        .expect("save one change to sparse document");
+
+    let saved = fs::read_to_string(&temp.path).expect("read sparse document");
+    assert!(saved.contains("# intentionally sparse"));
+    assert!(saved.contains("[performance]"));
+    assert!(saved.contains("max_fps_no_vsync = 144"));
+    assert!(saved.find("# intentionally sparse").unwrap() < saved.find("[performance]").unwrap());
+    assert!(!saved.contains("buffer_count"));
+    assert!(!saved.contains("[drawing]"));
+    assert!(!saved.contains("[session]"));
+}
+
+#[test]
+fn first_save_for_missing_config_stays_sparse() {
+    let temp = TempConfig::new("missing-sparse");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load missing document");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save missing document");
+
+    let saved = fs::read_to_string(&temp.path).expect("read newly created document");
+    assert_eq!(
+        saved,
+        format!("config_revision = {CURRENT_CONFIG_REVISION}\n")
+    );
+}
+
+#[test]
+fn editing_load_can_repair_typed_parse_failure_without_losing_unknown_keys() {
+    let temp = TempConfig::new("repair-invalid-config");
+    let original = r#"future_root = "preserve me"
+[performance]
+buffer_count = "not a number"
+future_knob = 17
+"#;
+    temp.write(original);
+
+    assert!(ConfigDocument::load_from_path(&temp.path).is_err());
+    let (document, warning) =
+        ConfigDocument::load_for_editing_from_path(&temp.path).expect("load repairable document");
+    let warning = warning.expect("repair warning");
+    assert!(warning.contains("Failed to parse config"));
+
+    let outcome = document
+        .save_with_backup(document.config().clone())
+        .expect("repair invalid config");
+    let saved = fs::read_to_string(&temp.path).expect("read repaired config");
+    assert!(saved.contains("future_root = \"preserve me\""));
+    assert!(saved.contains("future_knob = 17"));
+    assert!(!saved.contains("buffer_count"));
+    assert!(saved.contains("config_revision = 1"));
+    let backup = outcome.backup_path().expect("repair backup");
+    assert_eq!(fs::read_to_string(backup).unwrap(), original);
+    ConfigDocument::load_from_path(&temp.path).expect("repaired config is valid");
+}
+
+#[test]
+fn editing_load_can_repair_malformed_toml_with_a_backup() {
+    let temp = TempConfig::new("repair-malformed-config");
+    let original = "[performance\nmax_fps_no_vsync = 144\n";
+    temp.write(original);
+
+    let (document, warning) = ConfigDocument::load_for_editing_from_path(&temp.path)
+        .expect("load malformed repair document");
+    assert!(warning.is_some());
+    let outcome = document
+        .save_with_backup(document.config().clone())
+        .expect("repair malformed config");
+
+    assert_eq!(
+        fs::read_to_string(&temp.path).unwrap(),
+        format!("config_revision = {CURRENT_CONFIG_REVISION}\n")
+    );
+    assert_eq!(
+        fs::read_to_string(outcome.backup_path().expect("repair backup")).unwrap(),
+        original
+    );
+}
+
+#[test]
+fn repair_mode_removes_invalid_known_collections_but_keeps_root_unknowns() {
+    let temp = TempConfig::new("repair-invalid-collection");
+    let original = r#"config_revision = 1
+future_root = "preserve me"
+
+[drawing]
+future_drawing_option = true
+
+[[drawing.quick_colors]]
+label = "Invalid"
+color = 42
+future_entry_option = "cannot be separated safely"
+"#;
+    temp.write(original);
+
+    let (document, warning) = ConfigDocument::load_for_editing_from_path(&temp.path)
+        .expect("load collection repair document");
+    assert!(warning.is_some());
+    document
+        .save_with_backup(document.config().clone())
+        .expect("repair invalid collection");
+
+    let saved = fs::read_to_string(&temp.path).unwrap();
+    assert!(saved.contains("future_root = \"preserve me\""));
+    assert!(!saved.contains("future_drawing_option"));
+    assert!(!saved.contains("quick_colors"));
+    assert!(!saved.contains("future_entry_option"));
+    ConfigDocument::load_from_path(&temp.path).expect("collection repair is valid");
+}
+
+#[test]
+fn save_persists_migration_revision_and_does_not_repeat_keybinding_migration() {
+    let temp = TempConfig::new("migration-revision");
+    temp.write(
+        r#"[keybindings]
+toggle_command_palette = ["Ctrl+K"]
+capture_full_screen = ["Ctrl+Shift+P"]
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load legacy shortcuts");
+    let mut updated = document.config().clone();
+    updated.keybindings.ui.toggle_command_palette = vec!["Ctrl+K".to_string()];
+    updated.keybindings.capture.capture_full_screen = vec!["Ctrl+Shift+P".to_string()];
+    document
+        .save_with_backup(updated)
+        .expect("save intentional legacy shortcut pair");
+
+    let saved = fs::read_to_string(&temp.path).expect("read migrated config");
+    assert!(saved.contains(&format!("config_revision = {CURRENT_CONFIG_REVISION}")));
+    let reloaded = ConfigDocument::load_from_path(&temp.path).expect("reload migrated config");
+    assert_eq!(
+        reloaded.config().keybindings.ui.toggle_command_palette,
+        ["Ctrl+K"]
+    );
+    assert_eq!(
+        reloaded.config().keybindings.capture.capture_full_screen,
+        ["Ctrl+Shift+P"]
+    );
+}
+
+#[test]
+fn inline_array_of_structs_preserves_representation_and_unknown_fields() {
+    let temp = TempConfig::new("inline-struct-array");
+    temp.write(
+        r#"config_revision = 1
+boards = { max_count = 2, default_board = "transparent", items = [{ id = "transparent", name = "Overlay", background = "transparent", future_owner = "keep" }] }
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load inline boards");
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save inline boards");
+
+    let saved = fs::read_to_string(&temp.path).expect("read inline boards");
+    assert!(saved.contains("boards = {"));
+    assert!(!saved.contains("[[boards.items]]"));
+    assert!(saved.contains("future_owner = \"keep\""));
+    toml::from_str::<Config>(&saved).expect("inline representation remains valid");
+}
+
+#[test]
+fn no_op_save_preserves_semantically_equal_scalar_formatting() {
+    let temp = TempConfig::new("scalar-formatting");
+    let original = "config_revision = 1\n[performance]\nmax_fps_no_vsync = 1_200\n";
+    temp.write(original);
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load precise scalar");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save precise scalar");
+
+    assert_eq!(fs::read_to_string(&temp.path).unwrap(), original);
+}
+
+#[test]
+fn no_op_save_preserves_integer_spelling_for_float_fields() {
+    let temp = TempConfig::new("integer-float-spelling");
+    let original = "config_revision = 1\n[drawing]\ndefault_thickness = 2\n";
+    temp.write(original);
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load integer-form float");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save integer-form float without changes");
+
+    assert_eq!(fs::read_to_string(&temp.path).unwrap(), original);
+}
+
+#[test]
+fn document_save_canonicalizes_key_aliases_and_preserves_their_comments() {
+    let temp = TempConfig::new("aliases");
+    temp.write(
+        r#"[ui]
+# floating badge alias comment
+show_page_badge_with_status_bar = true
+show_status_bar = false
+show_frozen_badge = true
+
+[ui.toolbar.mode_overrides.full]
+# regular layout alias comment
+show_presets = true
+
+[[render_profiles.items]]
+# profile alias comment
+id = "one"
+name = "One"
+future_profile_key = "keep"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load aliases");
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save canonical aliases");
+    let saved = fs::read_to_string(&temp.path).expect("read canonical aliases");
+
+    assert!(!saved.contains("show_page_badge_with_status_bar"));
+    assert!(saved.contains("show_floating_badge_always = true"));
+    assert!(
+        saved.find("show_floating_badge_always").unwrap() < saved.find("show_status_bar").unwrap()
+    );
+    assert!(saved.find("show_status_bar").unwrap() < saved.find("show_frozen_badge").unwrap());
+    assert!(!saved.contains("[ui.toolbar.mode_overrides.full]"));
+    assert!(saved.contains("[ui.toolbar.mode_overrides.regular]"));
+    assert!(!saved.contains("[[render_profiles.items]]"));
+    assert!(saved.contains("[[render_profiles.profiles]]"));
+    for comment in [
+        "# floating badge alias comment",
+        "# regular layout alias comment",
+        "# profile alias comment",
+    ] {
+        assert!(saved.contains(comment));
+    }
+    assert!(saved.contains("future_profile_key = \"keep\""));
+    toml::from_str::<Config>(&saved).expect("canonical output parses exactly once");
+}
+
+#[test]
+fn document_save_keeps_unknown_fields_with_stable_id_when_tables_reorder() {
+    let temp = TempConfig::new("stable-id");
+    temp.write(
+        r##"[[render_profiles.profiles]]
+id = "a"
+name = "A"
+future_owner = "owner-a"
+
+[[render_profiles.profiles]]
+id = "b"
+name = "B"
+future_owner = "owner-b"
+"##,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profiles");
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles.swap(0, 1);
+    document
+        .save_with_backup(updated)
+        .expect("save reordered profiles");
+
+    let saved = fs::read_to_string(&temp.path).expect("read reordered profiles");
+    let value: toml::Value = toml::from_str(&saved).expect("parse reordered profiles");
+    let profiles = value["render_profiles"]["profiles"]
+        .as_array()
+        .expect("profiles array");
+    assert_eq!(profiles[0]["id"].as_str(), Some("b"));
+    assert_eq!(profiles[0]["future_owner"].as_str(), Some("owner-b"));
+    assert_eq!(profiles[1]["id"].as_str(), Some("a"));
+    assert_eq!(profiles[1]["future_owner"].as_str(), Some("owner-a"));
+}
+
+#[test]
+fn profile_ids_that_differ_by_non_ascii_case_keep_distinct_metadata() {
+    let temp = TempConfig::new("non-ascii-stable-id");
+    temp.write(
+        r#"[[render_profiles.profiles]]
+id = "Ä"
+name = "Upper"
+future_owner = "owner-upper"
+
+[[render_profiles.profiles]]
+id = "ä"
+name = "Lower"
+future_owner = "owner-lower"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profiles");
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles.swap(0, 1);
+    document
+        .save_with_backup(updated)
+        .expect("save reordered profiles");
+
+    let saved = fs::read_to_string(&temp.path).expect("read reordered profiles");
+    let value: toml::Value = toml::from_str(&saved).expect("parse reordered profiles");
+    let profiles = value["render_profiles"]["profiles"]
+        .as_array()
+        .expect("profiles array");
+    assert_eq!(profiles[0]["id"].as_str(), Some("ä"));
+    assert_eq!(profiles[0]["future_owner"].as_str(), Some("owner-lower"));
+    assert_eq!(profiles[1]["id"].as_str(), Some("Ä"));
+    assert_eq!(profiles[1]["future_owner"].as_str(), Some("owner-upper"));
+}
+
+#[test]
+fn deduplicated_profile_ids_keep_entry_metadata_when_reordered() {
+    let temp = TempConfig::new("deduplicated-stable-id");
+    temp.write(
+        r#"[[render_profiles.profiles]]
+id = "duplicate"
+name = "First"
+future_owner = "owner-first"
+
+[[render_profiles.profiles]]
+id = "duplicate"
+name = "Second"
+future_owner = "owner-second"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profiles");
+    assert_eq!(
+        document.config().render_profiles.profiles[0].id,
+        "duplicate"
+    );
+    assert_eq!(
+        document.config().render_profiles.profiles[1].id,
+        "duplicate-2"
+    );
+
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles.swap(0, 1);
+    document
+        .save_with_backup(updated)
+        .expect("save reordered deduplicated profiles");
+
+    let saved = fs::read_to_string(&temp.path).expect("read reordered profiles");
+    let value: toml::Value = toml::from_str(&saved).expect("parse reordered profiles");
+    let profiles = value["render_profiles"]["profiles"]
+        .as_array()
+        .expect("profiles array");
+    assert_eq!(profiles[0]["id"].as_str(), Some("duplicate-2"));
+    assert_eq!(profiles[0]["future_owner"].as_str(), Some("owner-second"));
+    assert_eq!(profiles[1]["id"].as_str(), Some("duplicate"));
+    assert_eq!(profiles[1]["future_owner"].as_str(), Some("owner-first"));
+}
+
+#[test]
+fn nested_array_tables_stay_with_their_parent_after_reorder() {
+    let temp = TempConfig::new("nested-array-table-position");
+    temp.write(
+        r##"config_revision = 1
+[[render_profiles.profiles]]
+id = "a"
+name = "A"
+
+[[render_profiles.profiles.mappings]]
+from = "#111111"
+to = "#AAAAAA"
+future_owner = "mapping-a"
+
+[[render_profiles.profiles]]
+id = "b"
+name = "B"
+
+[[render_profiles.profiles.mappings]]
+from = "#222222"
+to = "#BBBBBB"
+future_owner = "mapping-b"
+"##,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load nested profiles");
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles.swap(0, 1);
+    document
+        .save_with_backup(updated)
+        .expect("save reordered nested profiles");
+
+    let saved = fs::read_to_string(&temp.path).expect("read nested profiles");
+    let value: toml::Value = toml::from_str(&saved).expect("parse nested profiles");
+    let profiles = value["render_profiles"]["profiles"].as_array().unwrap();
+    assert_eq!(profiles[0]["id"].as_str(), Some("b"));
+    assert_eq!(
+        profiles[0]["mappings"][0]["future_owner"].as_str(),
+        Some("mapping-b")
+    );
+    assert_eq!(profiles[1]["id"].as_str(), Some("a"));
+    assert_eq!(
+        profiles[1]["mappings"][0]["future_owner"].as_str(),
+        Some("mapping-a")
+    );
+}
+
+#[test]
+fn removing_stable_id_entry_keeps_metadata_with_retained_id() {
+    let temp = TempConfig::new("removed-stable-id");
+    temp.write(
+        r#"[[render_profiles.profiles]]
+id = "a"
+name = "A"
+future_owner = "owner-a"
+
+[[render_profiles.profiles]]
+id = "b"
+name = "B"
+future_owner = "owner-b"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profiles");
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles.remove(0);
+    document
+        .save_with_backup(updated)
+        .expect("save profiles after removal");
+
+    let saved = fs::read_to_string(&temp.path).expect("read profiles after removal");
+    let value: toml::Value = toml::from_str(&saved).expect("parse profiles after removal");
+    let profiles = value["render_profiles"]["profiles"]
+        .as_array()
+        .expect("profiles array");
+    assert_eq!(profiles.len(), 1);
+    assert_eq!(profiles[0]["id"].as_str(), Some("b"));
+    assert_eq!(profiles[0]["future_owner"].as_str(), Some("owner-b"));
+}
+
+#[test]
+fn adding_stable_id_entry_does_not_shift_retained_metadata() {
+    let temp = TempConfig::new("added-stable-id");
+    temp.write(
+        r#"[[render_profiles.profiles]]
+id = "a"
+name = "A"
+future_owner = "owner-a"
+
+[[render_profiles.profiles]]
+id = "b"
+name = "B"
+future_owner = "owner-b"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profiles");
+    let mut updated = document.config().clone();
+    let mut added = updated.render_profiles.profiles[0].clone();
+    added.id = "new".to_string();
+    added.name = "New".to_string();
+    updated.render_profiles.profiles.insert(0, added);
+    document
+        .save_with_backup(updated)
+        .expect("save profiles after insertion");
+
+    let saved = fs::read_to_string(&temp.path).expect("read profiles after insertion");
+    let value: toml::Value = toml::from_str(&saved).expect("parse profiles after insertion");
+    let profiles = value["render_profiles"]["profiles"]
+        .as_array()
+        .expect("profiles array");
+    assert_eq!(profiles.len(), 3);
+    assert_eq!(profiles[0]["id"].as_str(), Some("new"));
+    assert!(profiles[0].get("future_owner").is_none());
+    assert_eq!(profiles[1]["id"].as_str(), Some("a"));
+    assert_eq!(profiles[1]["future_owner"].as_str(), Some("owner-a"));
+    assert_eq!(profiles[2]["id"].as_str(), Some("b"));
+    assert_eq!(profiles[2]["future_owner"].as_str(), Some("owner-b"));
+}
+
+#[test]
+fn unknown_diagnostics_cover_flattened_and_array_of_table_paths() {
+    let temp = TempConfig::new("unknown-path-depth");
+    temp.write(
+        r#"[keybindings]
+future_action = ["Ctrl+Alt+F24"]
+
+[[render_profiles.profiles]]
+id = "one"
+name = "One"
+future_profile_key = true
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load unknown paths");
+    let paths = diagnostic_paths(&document);
+
+    assert!(
+        paths.iter().any(|path| path.contains("future_action")),
+        "flattened unknown keybinding should be diagnosed: {paths:?}"
+    );
+    assert!(
+        paths.iter().any(|path| path.contains("future_profile_key")),
+        "array entry unknown should be diagnosed: {paths:?}"
+    );
+}
+
+#[test]
+fn array_entry_id_edit_preserves_metadata_on_the_same_entry() {
+    let temp = TempConfig::new("edited-stable-id");
+    temp.write(
+        r#"[[render_profiles.profiles]]
+id = "old-id"
+name = "Profile"
+future_profile_key = "keep"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profile");
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles[0].id = "new-id".to_string();
+    document
+        .save_with_backup(updated)
+        .expect("save edited profile id");
+
+    let saved = fs::read_to_string(&temp.path).expect("read edited profile");
+    assert!(saved.contains("id = \"new-id\""));
+    assert!(saved.contains("future_profile_key = \"keep\""));
+}
+
+#[test]
+fn validated_id_normalization_preserves_entry_metadata() {
+    let temp = TempConfig::new("normalized-stable-id");
+    temp.write(
+        r#"[[render_profiles.profiles]]
+id = " Profile One "
+name = "Profile One"
+future_owner = "keep"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load profile");
+    assert_eq!(
+        document.config().render_profiles.profiles[0].id,
+        "profile one"
+    );
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save normalized profile id");
+
+    let saved = fs::read_to_string(&temp.path).expect("read normalized profile");
+    assert!(saved.contains("id = \"profile one\""));
+    assert!(saved.contains("future_owner = \"keep\""));
+}
+
+#[test]
+fn validation_added_entry_does_not_take_metadata_from_a_normalized_id() {
+    let temp = TempConfig::new("normalized-board-with-added-default");
+    temp.write(
+        r#"[boards]
+
+[[boards.items]]
+id = " WhiteBoard "
+name = "White board"
+background = { rgb = [1.0, 1.0, 1.0] }
+future_owner = "keep-with-whiteboard"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load boards");
+    assert_eq!(document.config().boards.as_ref().unwrap().items.len(), 2);
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save validated boards");
+
+    let saved = fs::read_to_string(&temp.path).expect("read validated boards");
+    let value: toml::Value = toml::from_str(&saved).expect("parse validated boards");
+    let boards = value["boards"]["items"].as_array().expect("boards array");
+    assert_eq!(boards[0]["id"].as_str(), Some("transparent"));
+    assert!(boards[0].get("future_owner").is_none());
+    assert_eq!(boards[1]["id"].as_str(), Some("whiteboard"));
+    assert_eq!(
+        boards[1]["future_owner"].as_str(),
+        Some("keep-with-whiteboard")
+    );
+}
+
+#[test]
+fn deduplicated_board_ids_keep_metadata_through_validation_reorder() {
+    let temp = TempConfig::new("deduplicated-board-reorder");
+    temp.write(
+        r#"[boards]
+max_count = 2
+default_board = "DUPLICATE"
+
+[[boards.items]]
+id = " Duplicate "
+name = "Color board"
+background = { rgb = [1.0, 1.0, 1.0] }
+future_owner = "owner-color"
+
+[[boards.items]]
+id = "other"
+name = "Other color board"
+background = { rgb = [0.5, 0.5, 0.5] }
+future_owner = "owner-other"
+
+[[boards.items]]
+id = "duplicate"
+name = "Overlay"
+background = "transparent"
+future_owner = "owner-overlay"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load boards");
+    let boards = &document.config().boards.as_ref().unwrap().items;
+    assert_eq!(boards[0].id, "duplicate-2");
+    assert_eq!(boards[1].id, "duplicate");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save validated boards");
+
+    let saved = fs::read_to_string(&temp.path).expect("read validated boards");
+    let value: toml::Value = toml::from_str(&saved).expect("parse validated boards");
+    let boards = value["boards"]["items"].as_array().expect("boards array");
+    assert_eq!(boards[0]["id"].as_str(), Some("duplicate-2"));
+    assert_eq!(boards[0]["future_owner"].as_str(), Some("owner-overlay"));
+    assert_eq!(boards[1]["id"].as_str(), Some("duplicate"));
+    assert_eq!(boards[1]["future_owner"].as_str(), Some("owner-color"));
+}
+
+#[test]
+fn validation_truncated_array_entries_survive_unrelated_save() {
+    let temp = TempConfig::new("validation-truncated-entry");
+    temp.write(
+        r#"config_revision = 1
+[boards]
+max_count = 1
+default_board = "transparent"
+
+[[boards.items]]
+id = "transparent"
+name = "Overlay"
+background = "transparent"
+
+[[boards.items]]
+id = "future-board"
+name = "Future board"
+background = { rgb = [0.2, 0.3, 0.4] }
+future_owner = "keep"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load truncated boards");
+    assert_eq!(document.config().boards.as_ref().unwrap().items.len(), 1);
+    let mut updated = document.config().clone();
+    updated.performance.max_fps_no_vsync = 144;
+    document
+        .save_with_backup(updated)
+        .expect("save unrelated performance edit");
+
+    let saved = fs::read_to_string(&temp.path).expect("read truncated boards");
+    assert!(saved.contains("id = \"future-board\""));
+    assert!(saved.contains("future_owner = \"keep\""));
+}
+
+#[test]
+fn idless_array_insertion_keeps_metadata_with_unchanged_entries() {
+    let temp = TempConfig::new("idless-array-insertion");
+    temp.write(
+        r#"config_revision = 1
+[[drawing.quick_colors]]
+label = "First"
+color = "red"
+future_owner = "first"
+
+[[drawing.quick_colors]]
+label = "Second"
+color = "blue"
+future_owner = "second"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load quick colors");
+    let mut updated = document.config().clone();
+    updated.drawing.quick_colors.entries.insert(
+        0,
+        QuickColorConfig {
+            label: "New".to_string(),
+            color: ColorSpec::Name("green".to_string()),
+        },
+    );
+    document
+        .save_with_backup(updated)
+        .expect("save inserted quick color");
+
+    let value: toml::Value = toml::from_str(&fs::read_to_string(&temp.path).unwrap()).unwrap();
+    let entries = value["drawing"]["quick_colors"].as_array().unwrap();
+    assert_eq!(entries[0]["label"].as_str(), Some("New"));
+    assert!(entries[0].get("future_owner").is_none());
+    assert_eq!(entries[1]["future_owner"].as_str(), Some("first"));
+    assert_eq!(entries[2]["future_owner"].as_str(), Some("second"));
+}
+
+#[test]
+fn positional_array_entries_keep_unknown_fields_when_known_values_change() {
+    let temp = TempConfig::new("positional-array");
+    temp.write(
+        r#"[[drawing.quick_colors]]
+label = "First"
+color = "red"
+future_palette_key = "first-owner"
+
+[[drawing.quick_colors]]
+label = "Second"
+color = "blue"
+future_palette_key = "second-owner"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load quick colors");
+    let mut updated = document.config().clone();
+    updated.drawing.quick_colors.entries[0].label = "Renamed".to_string();
+    document
+        .save_with_backup(updated)
+        .expect("save positional entries");
+
+    let saved = fs::read_to_string(&temp.path).expect("read positional entries");
+    let value: toml::Value = toml::from_str(&saved).expect("parse positional entries");
+    let entries = value["drawing"]["quick_colors"]
+        .as_array()
+        .expect("quick color array");
+    assert_eq!(entries[0]["label"].as_str(), Some("Renamed"));
+    assert_eq!(
+        entries[0]["future_palette_key"].as_str(),
+        Some("first-owner")
+    );
+    assert_eq!(
+        entries[1]["future_palette_key"].as_str(),
+        Some("second-owner")
+    );
+}
+
+#[test]
+fn scalar_array_edits_preserve_element_comments() {
+    let temp = TempConfig::new("scalar-array-comments");
+    temp.write(
+        r#"[keybindings]
+undo = [
+    "Ctrl+Z", # primary shortcut
+    "Alt+Backspace", # secondary shortcut
+]
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load keybinding array");
+    let mut updated = document.config().clone();
+    updated.keybindings.core.undo[1] = "Ctrl+U".to_string();
+    document
+        .save_with_backup(updated)
+        .expect("save keybinding array");
+
+    let saved = fs::read_to_string(&temp.path).expect("read keybinding array");
+    assert!(saved.contains("\"Ctrl+Z\", # primary shortcut"));
+    assert!(saved.contains("\"Ctrl+U\", # secondary shortcut"));
+}
+
+#[test]
+fn exact_revision_detects_same_timestamp_content_replacement() {
+    let temp = TempConfig::new("same-time");
+    temp.write("[performance]\nmax_fps_no_vsync = 120\n");
+    let original_modified = fs::metadata(&temp.path)
+        .and_then(|metadata| metadata.modified())
+        .expect("read original timestamp");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load document");
+    temp.write("[performance]\nmax_fps_no_vsync = 144\n");
+    fs::File::open(&temp.path)
+        .and_then(|file| file.set_times(fs::FileTimes::new().set_modified(original_modified)))
+        .expect("restore original timestamp");
+
+    let error = document
+        .save_with_backup(document.config().clone())
+        .expect_err("same-time content replacement must conflict");
+    assert!(error.to_string().contains("changed on disk"));
+    assert!(fs::read_to_string(&temp.path).unwrap().contains("144"));
+}
+
+#[test]
+fn exact_revision_detects_content_replacement_with_rolled_back_timestamp() {
+    let temp = TempConfig::new("rolled-back-time");
+    temp.write("[performance]\nmax_fps_no_vsync = 120\n");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load document");
+    temp.write("[performance]\nmax_fps_no_vsync = 165\n");
+    fs::File::open(&temp.path)
+        .and_then(|file| {
+            file.set_times(fs::FileTimes::new().set_modified(std::time::SystemTime::UNIX_EPOCH))
+        })
+        .expect("roll back replacement timestamp");
+
+    assert!(
+        document
+            .save_with_backup(document.config().clone())
+            .expect_err("older timestamp must not hide changed content")
+            .to_string()
+            .contains("changed on disk")
+    );
+}
+
+#[test]
+fn exact_revision_allows_timestamp_only_change() {
+    let temp = TempConfig::new("timestamp-only");
+    temp.write("[performance]\nmax_fps_no_vsync = 120\n");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load document");
+    fs::File::open(&temp.path)
+        .and_then(|file| {
+            file.set_times(fs::FileTimes::new().set_modified(std::time::SystemTime::UNIX_EPOCH))
+        })
+        .expect("roll back timestamp without changing content");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("timestamp-only change is safe");
+}
+
+#[test]
+fn exact_revision_detects_deletion_creation_and_unsupported_replacement() {
+    let deleted = TempConfig::new("deleted");
+    deleted.write("[performance]\nmax_fps_no_vsync = 120\n");
+    let deleted_document =
+        ConfigDocument::load_from_path(&deleted.path).expect("load deleted source");
+    fs::remove_file(&deleted.path).expect("delete source");
+    assert!(
+        deleted_document
+            .save_with_backup(deleted_document.config().clone())
+            .expect_err("deletion must conflict")
+            .to_string()
+            .contains("changed on disk")
+    );
+
+    let created = TempConfig::new("created");
+    let created_document =
+        ConfigDocument::load_from_path(&created.path).expect("load missing source");
+    created.write("external = true\n");
+    assert!(
+        created_document
+            .save_with_backup(created_document.config().clone())
+            .expect_err("creation must conflict")
+            .to_string()
+            .contains("changed on disk")
+    );
+
+    let replaced = TempConfig::new("directory-replacement");
+    replaced.write("[performance]\nmax_fps_no_vsync = 120\n");
+    let replaced_document =
+        ConfigDocument::load_from_path(&replaced.path).expect("load replaced source");
+    fs::remove_file(&replaced.path).expect("remove source");
+    fs::create_dir(&replaced.path).expect("replace source with directory");
+    assert!(
+        replaced_document
+            .save_with_backup(replaced_document.config().clone())
+            .expect_err("unsupported replacement must fail")
+            .to_string()
+            .contains("not a regular file")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn exact_revision_detects_changed_symlink_target_with_identical_content() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempConfig::new("symlink-target");
+    let first = temp.root.join("first.toml");
+    let second = temp.root.join("second.toml");
+    fs::write(&first, "[performance]\nmax_fps_no_vsync = 120\n").unwrap();
+    fs::write(&second, "[performance]\nmax_fps_no_vsync = 120\n").unwrap();
+    symlink(&first, &temp.path).expect("create source symlink");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load symlinked source");
+    fs::remove_file(&temp.path).expect("remove old symlink");
+    symlink(&second, &temp.path).expect("replace symlink target");
+
+    assert!(
+        document
+            .save_with_backup(document.config().clone())
+            .expect_err("symlink target replacement must conflict")
+            .to_string()
+            .contains("changed on disk")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dangling_symlink_loads_defaults_and_first_save_creates_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempConfig::new("dangling-symlink");
+    let target = temp.root.join("managed.toml");
+    symlink(&target, &temp.path).expect("create dangling symlink");
+
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load dangling symlink");
+    assert!(matches!(document.source(), ConfigSource::Default));
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save through dangling symlink");
+
+    assert!(target.is_file());
+    assert!(
+        fs::symlink_metadata(&temp.path)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        fs::read_to_string(target).unwrap(),
+        format!("config_revision = {CURRENT_CONFIG_REVISION}\n")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dangling_symlink_save_creates_missing_target_parent_directories() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempConfig::new("dangling-symlink-missing-target-parent");
+    let target = temp.root.join("managed/nested/config.toml");
+    symlink(&target, &temp.path).expect("create dangling symlink");
+
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load dangling symlink");
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save through dangling symlink with missing target parents");
+
+    assert_eq!(
+        fs::read_to_string(target).unwrap(),
+        format!("config_revision = {CURRENT_CONFIG_REVISION}\n")
+    );
+    assert!(
+        fs::symlink_metadata(&temp.path)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn document_save_follows_multi_level_symlink_chain() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempConfig::new("multi-level-symlink");
+    let target = temp.root.join("managed.toml");
+    let intermediate = temp.root.join("intermediate.toml");
+    fs::write(
+        &target,
+        "config_revision = 1\n[performance]\nmax_fps_no_vsync = 120\n",
+    )
+    .unwrap();
+    symlink(&target, &intermediate).unwrap();
+    symlink(&intermediate, &temp.path).unwrap();
+
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load symlink chain");
+    let mut updated = document.config().clone();
+    updated.performance.max_fps_no_vsync = 144;
+    document
+        .save_with_backup(updated)
+        .expect("save through symlink chain");
+
+    assert!(fs::read_to_string(target).unwrap().contains("144"));
+    assert!(
+        fs::symlink_metadata(&temp.path)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(intermediate)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn document_save_preserves_symlink_permissions_and_backs_up_source_contents() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = TempConfig::new("symlink-save");
+    let target = temp.root.join("managed.toml");
+    let original = "# managed config\n[performance]\nmax_fps_no_vsync = 120\n";
+    fs::write(&target, original).expect("write managed target");
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o600))
+        .expect("set managed permissions");
+    symlink(&target, &temp.path).expect("create config symlink");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load symlinked document");
+    let mut updated = document.config().clone();
+    updated.performance.max_fps_no_vsync = 144;
+
+    let outcome = document
+        .save_with_backup(updated)
+        .expect("save symlinked document");
+    let backup = outcome.backup_path().expect("existing source gets backup");
+    assert_eq!(fs::read_to_string(backup).unwrap(), original);
+    assert!(
+        fs::symlink_metadata(&temp.path)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::read_to_string(&target)
+            .unwrap()
+            .contains("max_fps_no_vsync = 144")
+    );
+    assert_eq!(
+        fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+}
+
+#[cfg(not(tablet))]
+#[test]
+fn disabled_tablet_section_round_trips_without_unknown_warning() {
+    let temp = TempConfig::new("disabled-tablet");
+    temp.write(
+        "[tablet]\nenabled = false\nfuture_tablet_setting = 12\n\n[performance]\nmax_fps_no_vsync = 120\n",
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load tablet section");
+    assert!(document.diagnostics().is_empty());
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save disabled tablet section");
+    let saved = fs::read_to_string(&temp.path).expect("read disabled tablet section");
+    assert!(saved.contains("[tablet]"));
+    assert!(saved.contains("enabled = false"));
+    assert!(saved.contains("future_tablet_setting = 12"));
+}
+
+#[cfg(tablet)]
+#[test]
+fn enabled_tablet_section_reports_and_preserves_nested_unknown_setting() {
+    let temp = TempConfig::new("enabled-tablet");
+    temp.write("[tablet]\nenabled = false\nfuture_tablet_setting = 12\n");
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load tablet section");
+    assert!(
+        diagnostic_paths(&document)
+            .iter()
+            .any(|path| path.ends_with("tablet.future_tablet_setting"))
+    );
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save enabled tablet section");
+    let saved = fs::read_to_string(&temp.path).expect("read enabled tablet section");
+    assert!(saved.contains("future_tablet_setting = 12"));
+}
+
+#[test]
+fn performance_metadata_is_unique_and_matches_example_and_docs() {
+    let mut ids = std::collections::HashSet::new();
+    let mut paths = std::collections::HashSet::new();
+    let example = include_str!("../../../config.example.toml");
+    let example_value: toml::Value = toml::from_str(example).expect("parse config example");
+    let docs = include_str!("../../../docs/CONFIG.md");
+
+    for metadata in PERFORMANCE_FIELD_METADATA {
+        assert!(ids.insert(metadata.id), "duplicate id: {:?}", metadata.id);
+        assert!(
+            paths.insert(metadata.path),
+            "duplicate path: {}",
+            metadata.path
+        );
+        assert!(value_at_path(&example_value, metadata.path).is_some());
+        assert!(
+            docs.contains(metadata.path.rsplit('.').next().unwrap()),
+            "docs missing {}",
+            metadata.path
+        );
+    }
+    assert_eq!(ids.len(), PerformanceFieldId::ALL.len());
+}
+
+#[test]
+fn performance_validation_uses_metadata_constraints() {
+    let mut config = Config::default();
+    config.performance.buffer_count = u32::MAX;
+    config.performance.ui_animation_fps = u32::MAX;
+    config.validate_and_clamp();
+
+    assert_eq!(
+        config.performance.buffer_count,
+        PERFORMANCE_BUFFER_COUNT_MAX
+    );
+    assert_eq!(
+        config.performance.ui_animation_fps,
+        PERFORMANCE_UI_ANIMATION_FPS_MAX
+    );
+    assert!(
+        performance_field_metadata(PerformanceFieldId::BufferCount)
+            .constraint
+            .accepts_u32(config.performance.buffer_count)
+    );
+    assert!(
+        performance_field_metadata(PerformanceFieldId::UiAnimationFps)
+            .constraint
+            .accepts_u32(config.performance.ui_animation_fps)
+    );
+}
+
+fn value_at_path<'a>(root: &'a toml::Value, path: &str) -> Option<&'a toml::Value> {
+    path.split('.')
+        .try_fold(root, |value, segment| value.get(segment))
+}

--- a/src/config/tests/document.rs
+++ b/src/config/tests/document.rs
@@ -122,6 +122,66 @@ future_output_policy = "keep"
 }
 
 #[test]
+fn document_load_and_save_tolerates_future_keys_in_strict_export_tables() {
+    let temp = TempConfig::new("future-export-keys");
+    let original = r#"config_revision = 1
+[export]
+future_format = "svg"
+
+[export.pdf]
+page_size = "a4"
+future_bleed = 12.5
+
+[export.pdf.labels]
+enabled = true
+future_font_weight = 600
+"#;
+    temp.write(original);
+
+    let document = ConfigDocument::load_from_path(&temp.path)
+        .expect("future export settings remain editor-compatible");
+    let paths = diagnostic_paths(&document);
+    for expected in [
+        "export.future_format",
+        "export.pdf.future_bleed",
+        "export.pdf.labels.future_font_weight",
+    ] {
+        assert!(
+            paths.iter().any(|path| path.ends_with(expected)),
+            "missing diagnostic for {expected}: {paths:?}"
+        );
+    }
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save config with future export settings");
+
+    assert_eq!(fs::read_to_string(&temp.path).unwrap(), original);
+}
+
+#[test]
+fn no_op_save_removes_known_option_discarded_by_validation() {
+    let temp = TempConfig::new("validated-away-known-option");
+    temp.write(
+        r#"config_revision = 1
+[render_profiles]
+active = "missing"
+future_profile_policy = "keep"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load render profiles");
+    assert!(document.config().render_profiles.active.is_none());
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save validated render profiles");
+
+    let saved = fs::read_to_string(&temp.path).expect("read validated render profiles");
+    assert!(!saved.contains("active ="));
+    assert!(saved.contains("future_profile_policy = \"keep\""));
+}
+
+#[test]
 fn no_op_save_does_not_materialize_omitted_defaults() {
     let temp = TempConfig::new("omitted-defaults");
     let original =
@@ -417,6 +477,95 @@ future_owner = "owner-b"
     assert_eq!(profiles[0]["future_owner"].as_str(), Some("owner-b"));
     assert_eq!(profiles[1]["id"].as_str(), Some("a"));
     assert_eq!(profiles[1]["future_owner"].as_str(), Some("owner-a"));
+}
+
+#[test]
+fn no_op_save_preserves_separated_array_table_positions() {
+    let temp = TempConfig::new("separated-array-table-positions");
+    let original = r#"config_revision = 1
+[[render_profiles.profiles]]
+id = "first"
+name = "First"
+
+[performance]
+max_fps_no_vsync = 144
+
+[[render_profiles.profiles]]
+id = "second"
+name = "Second"
+"#;
+    temp.write(original);
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load separated profiles");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save separated profiles without changes");
+
+    assert_eq!(fs::read_to_string(&temp.path).unwrap(), original);
+}
+
+#[test]
+fn no_op_save_preserves_separated_nested_array_table_positions() {
+    let temp = TempConfig::new("separated-nested-array-table-positions");
+    let original = r##"config_revision = 1
+[[render_profiles.profiles]]
+id = "first"
+name = "First"
+
+[performance]
+max_fps_no_vsync = 144
+
+[[render_profiles.profiles.mappings]]
+from = "#111111"
+to = "#AAAAAA"
+"##;
+    temp.write(original);
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load separated mapping");
+
+    document
+        .save_with_backup(document.config().clone())
+        .expect("save separated mapping without changes");
+
+    assert_eq!(fs::read_to_string(&temp.path).unwrap(), original);
+}
+
+#[test]
+fn adding_nested_array_table_keeps_it_with_the_edited_parent() {
+    let temp = TempConfig::new("added-nested-array-table-position");
+    temp.write(
+        r#"config_revision = 1
+[[render_profiles.profiles]]
+id = "first"
+name = "First"
+
+[performance]
+max_fps_no_vsync = 144
+
+[[render_profiles.profiles]]
+id = "second"
+name = "Second"
+"#,
+    );
+    let document = ConfigDocument::load_from_path(&temp.path).expect("load separated profiles");
+    let mut updated = document.config().clone();
+    updated.render_profiles.profiles[0]
+        .mappings
+        .push(RenderColorMappingConfig {
+            from: "#111111".to_string(),
+            to: "#AAAAAA".to_string(),
+        });
+
+    document
+        .save_with_backup(updated)
+        .expect("save added nested mapping");
+
+    let saved = fs::read_to_string(&temp.path).expect("read profiles with nested mapping");
+    let value: toml::Value = toml::from_str(&saved).expect("parse profiles with nested mapping");
+    let profiles = value["render_profiles"]["profiles"]
+        .as_array()
+        .expect("profiles array");
+    assert_eq!(profiles[0]["mappings"].as_array().unwrap().len(), 1);
+    assert!(profiles[1].get("mappings").is_none());
 }
 
 #[test]

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -1,3 +1,4 @@
+mod document;
 mod file_io;
 mod load;
 #[cfg(feature = "config-schema")]

--- a/src/config/tests/schema.rs
+++ b/src/config/tests/schema.rs
@@ -25,3 +25,43 @@ fn json_schema_includes_expected_sections() {
         assert!(properties.contains_key(key), "missing schema field {key}");
     }
 }
+
+#[test]
+fn performance_metadata_paths_exist_in_json_schema() {
+    let schema = Config::json_schema();
+    for metadata in PERFORMANCE_FIELD_METADATA {
+        assert!(
+            schema_contains_path(&schema, metadata.path),
+            "schema missing metadata path {}",
+            metadata.path
+        );
+    }
+}
+
+fn schema_contains_path(schema: &serde_json::Value, path: &str) -> bool {
+    let mut node = schema;
+    for segment in path.split('.') {
+        node = resolve_schema_ref(schema, node);
+        let Some(property) = node
+            .get("properties")
+            .and_then(|properties| properties.get(segment))
+        else {
+            return false;
+        };
+        node = property;
+    }
+    true
+}
+
+fn resolve_schema_ref<'a>(
+    schema: &'a serde_json::Value,
+    node: &'a serde_json::Value,
+) -> &'a serde_json::Value {
+    let Some(reference) = node.get("$ref").and_then(|value| value.as_str()) else {
+        return node;
+    };
+    reference
+        .strip_prefix('#')
+        .and_then(|pointer| schema.pointer(pointer))
+        .unwrap_or(node)
+}

--- a/src/config/validate/performance.rs
+++ b/src/config/validate/performance.rs
@@ -1,26 +1,36 @@
 use super::Config;
+use crate::config::{
+    PERFORMANCE_BUFFER_COUNT_MAX, PERFORMANCE_BUFFER_COUNT_MIN, PERFORMANCE_UI_ANIMATION_FPS_MAX,
+};
 
 impl Config {
     pub(super) fn validate_performance(&mut self) {
-        // Buffer count: 2 - 4
-        if !(2..=4).contains(&self.performance.buffer_count) {
+        if !(PERFORMANCE_BUFFER_COUNT_MIN..=PERFORMANCE_BUFFER_COUNT_MAX)
+            .contains(&self.performance.buffer_count)
+        {
             log::warn!(
-                "Invalid buffer_count {}, clamping to 2-4 range",
-                self.performance.buffer_count
+                "Invalid buffer_count {}, clamping to {}-{} range",
+                self.performance.buffer_count,
+                PERFORMANCE_BUFFER_COUNT_MIN,
+                PERFORMANCE_BUFFER_COUNT_MAX,
             );
-            self.performance.buffer_count = self.performance.buffer_count.clamp(2, 4);
+            self.performance.buffer_count = self
+                .performance
+                .buffer_count
+                .clamp(PERFORMANCE_BUFFER_COUNT_MIN, PERFORMANCE_BUFFER_COUNT_MAX);
         }
 
         // UI animation FPS: allow 0 (unlimited), otherwise clamp to 1 - 240.
-        const MAX_UI_ANIMATION_FPS: u32 = 240;
-        if self.performance.ui_animation_fps > MAX_UI_ANIMATION_FPS {
+        if self.performance.ui_animation_fps > PERFORMANCE_UI_ANIMATION_FPS_MAX {
             log::warn!(
                 "Invalid ui_animation_fps {}, clamping to 0-{} range",
                 self.performance.ui_animation_fps,
-                MAX_UI_ANIMATION_FPS
+                PERFORMANCE_UI_ANIMATION_FPS_MAX
             );
-            self.performance.ui_animation_fps =
-                self.performance.ui_animation_fps.min(MAX_UI_ANIMATION_FPS);
+            self.performance.ui_animation_fps = self
+                .performance
+                .ui_animation_fps
+                .min(PERFORMANCE_UI_ANIMATION_FPS_MAX);
         }
     }
 }

--- a/src/durable_io.rs
+++ b/src/durable_io.rs
@@ -18,9 +18,8 @@ static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug)]
 struct Destination {
-    original_path: PathBuf,
     final_path: PathBuf,
-    followed_target: Option<PathBuf>,
+    followed_links: Vec<(PathBuf, PathBuf)>,
     existing_mode: Option<u32>,
     existing_identity: Option<FileIdentity>,
     existed_at_inspect: bool,
@@ -113,52 +112,65 @@ fn inspect_destination(
 }
 
 fn inspect_follow_destination(path: &Path) -> Result<Destination, DurableIoError> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => {
-            let target = read_resolved_link(path)?;
-            let target_metadata = fs::symlink_metadata(&target).map_err(|source| {
-                io_error(DurableIoOperation::InspectDestination, &target, source)
-            })?;
-            if target_metadata.file_type().is_symlink() {
-                return Err(DurableIoError::SymlinkRejected { path: target });
-            }
-            if !target_metadata.is_file() {
-                return Err(DurableIoError::UnsupportedFileType { path: target });
-            }
-            Ok(Destination {
-                original_path: path.to_path_buf(),
-                final_path: target.clone(),
-                followed_target: Some(target),
-                existing_mode: metadata_mode(&target_metadata),
-                existing_identity: file_identity(&target_metadata),
-                existed_at_inspect: true,
-            })
-        }
+    let (current, followed_links) = resolve_symlink_chain(path)?;
+    match fs::symlink_metadata(&current) {
         Ok(metadata) if metadata.is_file() => Ok(Destination {
-            original_path: path.to_path_buf(),
-            final_path: path.to_path_buf(),
-            followed_target: None,
+            final_path: current,
+            followed_links,
             existing_mode: metadata_mode(&metadata),
             existing_identity: file_identity(&metadata),
             existed_at_inspect: true,
         }),
-        Ok(_) => Err(DurableIoError::UnsupportedFileType {
-            path: path.to_path_buf(),
-        }),
+        Ok(_) => Err(DurableIoError::UnsupportedFileType { path: current }),
         Err(source) if source.kind() == ErrorKind::NotFound => Ok(Destination {
-            original_path: path.to_path_buf(),
-            final_path: path.to_path_buf(),
-            followed_target: None,
+            final_path: current,
+            followed_links,
             existing_mode: None,
             existing_identity: None,
             existed_at_inspect: false,
         }),
         Err(source) => Err(io_error(
             DurableIoOperation::InspectDestination,
-            path,
+            &current,
             source,
         )),
     }
+}
+
+pub(crate) fn resolve_symlink_chain(
+    path: &Path,
+) -> Result<(PathBuf, Vec<(PathBuf, PathBuf)>), DurableIoError> {
+    let mut current = path.to_path_buf();
+    let mut followed_links = Vec::new();
+    for _ in 0..40 {
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                if followed_links
+                    .iter()
+                    .any(|(link, _): &(PathBuf, PathBuf)| link == &current)
+                {
+                    return Err(DurableIoError::Conflict {
+                        operation: DurableIoOperation::ReadLink,
+                        path: current,
+                        reason: "symlink cycle detected".to_string(),
+                    });
+                }
+                let target = read_resolved_link(&current)?;
+                followed_links.push((current, target.clone()));
+                current = target;
+            }
+            Ok(_) => return Ok((current, followed_links)),
+            Err(source) if source.kind() == ErrorKind::NotFound => {
+                return Ok((current, followed_links));
+            }
+            Err(source) => return Err(io_error(DurableIoOperation::ReadLink, &current, source)),
+        }
+    }
+    Err(DurableIoError::Conflict {
+        operation: DurableIoOperation::ReadLink,
+        path: current,
+        reason: "symlink chain exceeds 40 links".to_string(),
+    })
 }
 
 fn inspect_reject_destination(path: &Path) -> Result<Destination, DurableIoError> {
@@ -167,9 +179,8 @@ fn inspect_reject_destination(path: &Path) -> Result<Destination, DurableIoError
             path: path.to_path_buf(),
         }),
         Ok(metadata) if metadata.is_file() => Ok(Destination {
-            original_path: path.to_path_buf(),
             final_path: path.to_path_buf(),
-            followed_target: None,
+            followed_links: Vec::new(),
             existing_mode: metadata_mode(&metadata),
             existing_identity: file_identity(&metadata),
             existed_at_inspect: true,
@@ -178,9 +189,8 @@ fn inspect_reject_destination(path: &Path) -> Result<Destination, DurableIoError
             path: path.to_path_buf(),
         }),
         Err(source) if source.kind() == ErrorKind::NotFound => Ok(Destination {
-            original_path: path.to_path_buf(),
             final_path: path.to_path_buf(),
-            followed_target: None,
+            followed_links: Vec::new(),
             existing_mode: None,
             existing_identity: None,
             existed_at_inspect: false,
@@ -197,17 +207,15 @@ fn revalidate_destination(
     destination: &Destination,
     options: AtomicWriteOptions,
 ) -> Result<(), DurableIoError> {
-    if let Some(expected) = &destination.followed_target {
-        let current = read_resolved_link(&destination.original_path).map_err(|_| {
-            DurableIoError::DestinationChanged {
-                operation: DurableIoOperation::ReadLink,
-                path: destination.original_path.clone(),
-            }
+    for (link, expected) in &destination.followed_links {
+        let current = read_resolved_link(link).map_err(|_| DurableIoError::DestinationChanged {
+            operation: DurableIoOperation::ReadLink,
+            path: link.clone(),
         })?;
         if current != *expected {
             return Err(DurableIoError::DestinationChanged {
                 operation: DurableIoOperation::ReadLink,
-                path: destination.original_path.clone(),
+                path: link.clone(),
             });
         }
     }
@@ -229,14 +237,11 @@ fn revalidate_destination(
                 source,
             )),
         },
-        OverwriteMode::Replace => revalidate_replace_destination(destination, options.symlink),
+        OverwriteMode::Replace => revalidate_replace_destination(destination),
     }
 }
 
-fn revalidate_replace_destination(
-    destination: &Destination,
-    symlink: SymlinkPolicy,
-) -> Result<(), DurableIoError> {
+fn revalidate_replace_destination(destination: &Destination) -> Result<(), DurableIoError> {
     match fs::symlink_metadata(&destination.final_path) {
         Ok(metadata) if metadata.file_type().is_symlink() => Err(DurableIoError::SymlinkRejected {
             path: destination.final_path.clone(),
@@ -245,14 +250,13 @@ fn revalidate_replace_destination(
             path: destination.final_path.clone(),
         }),
         Ok(metadata) => {
-            if symlink == SymlinkPolicy::Reject && !destination.existed_at_inspect {
+            if !destination.existed_at_inspect {
                 return Err(DurableIoError::DestinationChanged {
                     operation: DurableIoOperation::InspectDestination,
                     path: destination.final_path.clone(),
                 });
             }
-            if symlink == SymlinkPolicy::Reject
-                && let Some(expected) = destination.existing_identity
+            if let Some(expected) = destination.existing_identity
                 && file_identity(&metadata) != Some(expected)
             {
                 return Err(DurableIoError::DestinationChanged {
@@ -284,10 +288,7 @@ fn finalize_overwrite_mode(
     destination: &Destination,
     options: AtomicWriteOptions,
 ) -> OverwriteMode {
-    if options.overwrite == OverwriteMode::Replace
-        && options.symlink == SymlinkPolicy::Reject
-        && !destination.existed_at_inspect
-    {
+    if options.overwrite == OverwriteMode::Replace && !destination.existed_at_inspect {
         OverwriteMode::CreateNew
     } else {
         options.overwrite

--- a/src/durable_io/tests.rs
+++ b/src/durable_io/tests.rs
@@ -150,6 +150,42 @@ fn followed_symlink_change_is_rejected_before_finalization() {
 
 #[cfg(unix)]
 #[test]
+fn followed_symlink_target_replacement_is_rejected_before_finalization() {
+    let temp = crate::test_temp::tempdir().unwrap();
+    let target = temp.path().join("target.toml");
+    let link = temp.path().join("config.toml");
+    fs::write(&target, "old").unwrap();
+    symlink(&target, &link).unwrap();
+    let options = AtomicWriteOptions::user_config_file();
+    let destination = inspect_destination(&link, options).unwrap();
+    let _old_file = fs::File::open(&target).unwrap();
+    fs::remove_file(&target).unwrap();
+    fs::write(&target, "replacement").unwrap();
+
+    let err = revalidate_destination(&destination, options).unwrap_err();
+
+    assert!(matches!(err, DurableIoError::DestinationChanged { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn follow_policy_detects_replaced_regular_file() {
+    let temp = crate::test_temp::tempdir().unwrap();
+    let path = temp.path().join("config.toml");
+    fs::write(&path, "old").unwrap();
+    let options = AtomicWriteOptions::user_config_file();
+    let destination = inspect_destination(&path, options).unwrap();
+    let _old_file = fs::File::open(&path).unwrap();
+    fs::remove_file(&path).unwrap();
+    fs::write(&path, "replacement").unwrap();
+
+    let err = revalidate_destination(&destination, options).unwrap_err();
+
+    assert!(matches!(err, DurableIoError::DestinationChanged { .. }));
+}
+
+#[cfg(unix)]
+#[test]
 fn reject_policy_rejects_destination_symlink() {
     let temp = crate::test_temp::tempdir().unwrap();
     let target = temp.path().join("target");
@@ -220,21 +256,73 @@ fn reject_policy_detects_created_regular_file_after_missing_inspect() {
 
 #[cfg(unix)]
 #[test]
-fn dangling_followed_symlink_is_rejected() {
+fn dangling_followed_symlink_creates_target_and_preserves_link() {
     let temp = crate::test_temp::tempdir().unwrap();
     let link = temp.path().join("config.toml");
+    let target = temp.path().join("missing-target.toml");
     symlink("missing-target.toml", &link).unwrap();
 
-    let err = write_text_atomic(&link, "new", AtomicWriteOptions::user_config_file()).unwrap_err();
+    write_text_atomic(&link, "new", AtomicWriteOptions::user_config_file()).unwrap();
 
-    assert!(matches!(
-        err,
-        DurableIoError::Io {
-            operation: DurableIoOperation::InspectDestination,
-            ..
-        }
-    ));
-    assert!(fs::symlink_metadata(link).unwrap().file_type().is_symlink());
+    assert_eq!(fs::read_to_string(target).unwrap(), "new");
+    assert!(
+        fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn follows_multi_level_symlink_chain() {
+    let temp = crate::test_temp::tempdir().unwrap();
+    let target = temp.path().join("target.toml");
+    let middle = temp.path().join("middle.toml");
+    let link = temp.path().join("config.toml");
+    fs::write(&target, "old").unwrap();
+    symlink("target.toml", &middle).unwrap();
+    symlink("middle.toml", &link).unwrap();
+
+    write_text_atomic(&link, "new", AtomicWriteOptions::user_config_file()).unwrap();
+
+    assert_eq!(fs::read_to_string(target).unwrap(), "new");
+    assert!(
+        fs::symlink_metadata(&middle)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn changed_intermediate_symlink_is_rejected_before_finalization() {
+    let temp = crate::test_temp::tempdir().unwrap();
+    let first = temp.path().join("first.toml");
+    let second = temp.path().join("second.toml");
+    let middle = temp.path().join("middle.toml");
+    let link = temp.path().join("config.toml");
+    fs::write(&first, "first").unwrap();
+    fs::write(&second, "second").unwrap();
+    symlink("first.toml", &middle).unwrap();
+    symlink("middle.toml", &link).unwrap();
+    let options = AtomicWriteOptions::user_config_file();
+    let destination = inspect_destination(&link, options).unwrap();
+    fs::remove_file(&middle).unwrap();
+    symlink("second.toml", &middle).unwrap();
+
+    let err = revalidate_destination(&destination, options).unwrap_err();
+
+    assert!(matches!(err, DurableIoError::DestinationChanged { .. }));
+    assert_eq!(fs::read_to_string(first).unwrap(), "first");
+    assert_eq!(fs::read_to_string(second).unwrap(), "second");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Introduce `ConfigDocument` as the configurator-facing owner of the typed config, original TOML document, diagnostics, source path, and exact source revision.
- Merge configurator edits into the original document so comments, ordering, formatting, unknown settings, and omitted defaults survive saves.
- Reject saves when the source was created, deleted, externally modified, or retargeted through a symlink after loading.
- Preserve existing backup and durable atomic-write behavior.
- Add a guarded repair flow for readable but invalid configurations.
- Share Performance field metadata and validation constraints between the core config and configurator.
- Document the new preservation, sparse-save, conflict, and repair behavior.

## Preservation behavior

Configurator saves now:

- Preserve comments and section ordering.
- Retain unknown settings for forward compatibility, including future keys in strict export tables.
- Avoid materializing unchanged defaults in sparse configurations.
- Remove known settings discarded during validation instead of retaining stale values.
- Preserve unknown-field provenance when array-table entries are normalized, deduplicated, reordered, inserted, or removed.
- Keep top-level and nested array tables in their original section positions during no-op saves.
- Keep newly added nested mappings attached to the correct parent entry.

Runtime callers can continue using the existing typed `Config::load()` and `Config::save*()` APIs.