### PR TITLE
refactor(toolbar): share top toolbar specification across frontends

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -897,6 +897,8 @@ If you are working offline, prefetch dependencies first:
   - `bindings.rs` - Toolbar keybinding mapping.
   - `events.rs` - Toolbar events.
   - `snapshot.rs` - Toolbar snapshot helper.
+  - `model/top_spec.rs` - Renderer-neutral top-toolbar IDs, ordering, events, state, and
+    width-degradation result shared by the built-in and GTK adapters.
   - `apply/` - Apply toolbar state to input.
     - `actions.rs` - Toolbar actions.
     - `delays.rs` - Delay adjustments.

--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -136,7 +136,23 @@ Notifications are sent via `notification::send_notification_async`, keeping all 
 
 ---
 
-## 6. Configuration
+## 6. Toolbar Frontends
+
+- `src/ui/toolbar/model/top_spec.rs` owns the renderer-neutral top-toolbar contract: stable
+  control IDs, ordered strip/divider/chrome/overflow nodes, events, active/enabled state, labels,
+  tooltips, shortcut badges, and semantic icons. It consumes the shared width-degradation result
+  but contains no geometry or toolkit types.
+- `src/backend/wayland/toolbar/view/top/` exhaustively adapts that contract to the built-in
+  `WidgetTree`, which remains the sole owner of Cairo geometry, hit testing, popover placement,
+  and surface input regions.
+- `src/toolbar_gtk/view/top_bar/` exhaustively adapts the same contract to GTK widgets while
+  retaining GTK sizing, CSS, updater closures, drag gestures, and popover lifecycle.
+- Shape-picker compound rows and all side-palette layout remain frontend-specific. Their existing
+  tool/section ordering still comes from the shared toolbar model.
+
+---
+
+## 7. Configuration
 
 - **`src/config/`** handles loading `config.toml`, validating fields, and building the keybinding map.
 - **`ConfigDocument`** is the configurator-facing edit owner. It keeps validated `Config`, the
@@ -152,7 +168,7 @@ Notifications are sent via `notification::send_notification_async`, keeping all 
 
 ---
 
-## 7. Session Persistence and Named Session Manager
+## 8. Session Persistence and Named Session Manager
 
 **Modules:**
 - `src/session/`: target options, primary-file validation, snapshot load/save, sidecars, clear/recovery markers, saved tool-state reset, locks, catalog metadata, and inactive file operations.
@@ -172,7 +188,7 @@ Notifications are sent via `notification::send_notification_async`, keeping all 
 
 ---
 
-## 8. Utility Modules
+## 9. Utility Modules
 
 - **`src/draw/`**: Shape definitions, Cairo helpers, arrow geometry, fonts, and the `CanvasSet` abstraction (with undo/history per board mode).
 - **`src/ui.rs`**: Composes the status bar and help overlay using Cairo.
@@ -182,7 +198,7 @@ Notifications are sent via `notification::send_notification_async`, keeping all 
 
 ---
 
-## 9. Directory Map (excluding configurator)
+## 10. Directory Map (excluding configurator)
 
 | Path | Role |
 |------|------|
@@ -202,7 +218,7 @@ Notifications are sent via `notification::send_notification_async`, keeping all 
 
 ---
 
-## 10. Putting It Together
+## 11. Putting It Together
 
 1. **Launch** via CLI → choose daemon vs active.
 2. **Daemon** provides lifecycle management, tray integration, and toggles the backend on demand.

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -21,8 +21,12 @@ mod toolbar_intent;
 pub(crate) use state::clamp_floating_axis_offset;
 #[cfg(feature = "toolbar-gtk")]
 pub(crate) use toolbar::top_size as top_toolbar_size;
+#[cfg(all(test, feature = "toolbar-gtk"))]
+pub(crate) use toolbar::view::WidgetKind as TopToolbarWidgetKind;
+#[cfg(all(test, feature = "toolbar-gtk"))]
+pub(crate) use toolbar::view::top::build_top_view as build_top_toolbar_view;
 #[cfg(feature = "toolbar-gtk")]
-pub(crate) use toolbar::view::top::{TopStripPlan, plan_top_strip};
+pub(crate) use toolbar::view::top::plan_top_strip;
 mod zoom;
 
 pub use backend::WaylandBackend;

--- a/src/backend/wayland/toolbar/view/top.rs
+++ b/src/backend/wayland/toolbar/view/top.rs
@@ -9,7 +9,6 @@
 //! not interactive.
 
 use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
-use crate::config::toolbar_item_ids as ids;
 use crate::input::Tool;
 use crate::ui::toolbar::{ToolbarSnapshot, model};
 
@@ -29,36 +28,14 @@ pub(crate) const TOP_SWATCH_GAP: f64 = 4.0;
 /// Current-color chip size (opens the full picker; never collapses).
 pub(crate) const TOP_CHIP_SIZE: f64 = 28.0;
 /// Maximum quick-color swatches when width allows.
-pub(crate) const TOP_MAX_QUICK_COLORS: usize = 8;
+#[cfg(test)]
+pub(crate) const TOP_MAX_QUICK_COLORS: usize = TopStripPlan::MAX_QUICK_COLORS;
 const TOP_COMPACT_BUTTON: f64 = 26.0;
 const TOP_COMPACT_GAP: f64 = 1.0;
 const TOP_COMPACT_CHROME: f64 = 18.0;
 const TOP_COMPACT_MARGIN_RIGHT: f64 = 8.0;
 
-/// What fits on the strip at the current viewport width: how many quick
-/// swatches render and which items degrade into the overflow menu.
-/// Priority items (pens, Eraser, the chip, Undo/Redo, Clear, chrome) are
-/// never dropped.
-#[derive(Debug, Clone, PartialEq)]
-pub struct TopStripPlan {
-    pub swatch_count: usize,
-    pub dropped_tools: Vec<Tool>,
-    pub dropped_utilities: Vec<model::TopUtilityButton>,
-    pub show_overflow: bool,
-    pub compact: bool,
-}
-
-impl TopStripPlan {
-    fn unconstrained() -> Self {
-        Self {
-            swatch_count: TOP_MAX_QUICK_COLORS,
-            dropped_tools: Vec::new(),
-            dropped_utilities: Vec::new(),
-            show_overflow: false,
-            compact: false,
-        }
-    }
-}
+pub(crate) use model::TopStripPlan;
 
 /// Degrade the strip until it fits the viewport: quick swatches shrink
 /// 8→6→4→0 first, then droppable items move into the overflow menu.
@@ -269,11 +246,7 @@ fn natural_width_planned_at(snapshot: &ToolbarSnapshot, plan: &TopStripPlan, hei
         .map(|node| node.rect.0 + node.rect.2)
         .fold(0.0_f64, f64::max);
 
-    let mut chrome_count = usize::from(model::toolbar_item_visible(snapshot, ids::TOP_CHROME_PIN))
-        + usize::from(model::toolbar_item_visible(snapshot, ids::TOP_CHROME_CLOSE));
-    if plan.show_overflow {
-        chrome_count += 1;
-    }
+    let chrome_count = model::TopToolbarSpec::chrome_control_count(snapshot, plan);
     let chrome = if chrome_count == 0 {
         0.0
     } else {

--- a/src/backend/wayland/toolbar/view/top/build.rs
+++ b/src/backend/wayland/toolbar/view/top/build.rs
@@ -9,7 +9,6 @@ use crate::backend::wayland::toolbar::layout::ToolbarLayoutSpec;
 use crate::config::{Action, action_label, action_short_label, toolbar_item_ids as ids};
 use crate::input::Tool;
 use crate::toolbar_icons;
-use crate::ui::toolbar::bindings::{tool_label, tool_tooltip_label};
 use crate::ui::toolbar::{ToolbarEvent, ToolbarSnapshot, model};
 
 use super::super::node::{
@@ -29,8 +28,9 @@ pub(super) fn build_top_view_planned(
     width: f64,
     height: f64,
 ) -> WidgetTree {
+    let spec = model::TopToolbarSpec::build(snapshot, plan);
     if snapshot.top_minimized {
-        return build_top_minimized_tab(width, height);
+        return build_top_minimized_tab(snapshot, &spec, width, height);
     }
     let gap = planned_gap(plan);
     let mut tree = WidgetTree::new((width, height));
@@ -46,25 +46,7 @@ pub(super) fn build_top_view_planned(
     } else {
         ToolbarLayoutSpec::TOP_START_X
     };
-    let handle_size = ToolbarLayoutSpec::TOP_HANDLE_SIZE;
-    let handle_visible = model::toolbar_item_visible(snapshot, ids::TOP_CHROME_DRAG);
-    if handle_visible {
-        tree.push(WidgetNode::new(
-            ids::TOP_CHROME_DRAG.as_str(),
-            (x, ToolbarLayoutSpec::TOP_HANDLE_Y, handle_size, handle_size),
-            WidgetKind::DragHandle,
-            Some(Interaction {
-                event: ToolbarEvent::MoveTopToolbar { x: 0.0, y: 0.0 },
-                kind: HitKind::DragMoveTop,
-                tooltip: Some("Drag toolbar".to_string()),
-            }),
-        ));
-        x += handle_size + gap;
-    }
-
     let is_simple = snapshot.layout_mode == crate::config::ToolbarLayoutMode::Simple;
-    let current_shape_tool =
-        model::current_shape_tool(snapshot.active_tool, snapshot.tool_override);
     let fill_tool_active = model::fill_tool_active(snapshot.active_tool, snapshot.tool_override);
 
     let use_icons = planned_use_icons(snapshot, plan);
@@ -82,309 +64,142 @@ pub(super) fn build_top_view_planned(
         *x += divider_span + gap;
     };
 
-    // --- Tool groups: pens | shapes ----------------------------------------
-    let mut previous_group: Option<model::TopToolGroup> = None;
-    let mut tool_drawn = false;
-    for tool in model::visible_top_tool_buttons(is_simple, snapshot) {
-        if plan.dropped_tools.contains(&tool) {
-            continue;
-        }
-        let group = model::top_tool_group(tool);
-        if let Some(previous) = previous_group
-            && previous != group
-        {
-            push_divider(&mut tree, &mut x, "tools");
-        }
-        previous_group = Some(group);
-        let active = snapshot.active_tool == tool || snapshot.tool_override == Some(tool);
-        tree.push(tool_button_node(
-            snapshot,
-            tool,
-            model::toolbar_item_id_for_tool(tool).as_str(),
-            (x, y, btn_w, btn_h),
-            active,
-            use_icons,
-        ));
-        x += btn_w + gap;
-        tool_drawn = true;
-    }
-
-    // --- Shapes picker (family icon, caret grid below) ----------------------
     let mut picker_anchor: Option<(f64, f64, f64, f64)> = None;
-    if model::top_shape_picker_visible(snapshot) {
-        if previous_group == Some(model::TopToolGroup::Pens) {
-            push_divider(&mut tree, &mut x, "tools");
-        }
-        let picker_active = snapshot.shape_picker_open || current_shape_tool.is_some();
-        let interact = Interaction::click(
-            ToolbarEvent::ToggleShapePicker(!snapshot.shape_picker_open),
-            Some("Shapes".to_string()),
-        );
-        let kind = if use_icons {
-            WidgetKind::IconButton {
-                glyph: IconFn(toolbar_icons::draw_icon_shape_picker),
-                icon_size: ToolbarLayoutSpec::TOP_ICON_SIZE,
-                style: ButtonStyle::active(picker_active),
-            }
-        } else {
-            WidgetKind::TextButton {
-                label: LabelSpec::new("Shapes", TOP_LABEL_FONT_SIZE, true),
-                style: ButtonStyle::active(picker_active),
-            }
-        };
-        tree.push(WidgetNode::new(
-            ids::TOP_UTILITY_SHAPE_PICKER.as_str(),
-            (x, y, btn_w, btn_h),
-            kind,
-            Some(interact),
-        ));
-        picker_anchor = Some((x, y, btn_w, btn_h));
-        x += btn_w + gap;
-        tool_drawn = true;
-    }
+    let contextual_ring = spec.contextual().first().copied();
+    let swatches_have_badges = spec.strip().iter().any(|node| {
+        matches!(
+            node,
+            model::TopToolbarNode::Control(model::TopToolbarControl::QuickColor(index))
+                if snapshot.binding_hints.quick_color_badge(*index).is_some()
+        )
+    });
+    let swatch_y = if swatches_have_badges {
+        y + (btn_h - (10.0 + 1.0 + TOP_SWATCH_SIZE)) / 2.0 + 11.0
+    } else {
+        y + (btn_h - TOP_SWATCH_SIZE) / 2.0
+    };
 
-    // --- Annotation utilities    // --- Annotation utilities (Clear is pulled out and isolated below) ------
-    let utilities: Vec<model::TopUtilityButton> =
-        model::visible_top_utility_buttons(snapshot, is_simple, snapshot.use_icons)
-            .into_iter()
-            .filter(|button| *button != model::TopUtilityButton::ClearCanvas)
-            .filter(|button| !plan.dropped_utilities.contains(button))
-            .collect();
-    let clear_visible = model::visible_top_utility_buttons(snapshot, is_simple, snapshot.use_icons)
-        .contains(&model::TopUtilityButton::ClearCanvas);
-    if !utilities.is_empty() && tool_drawn {
-        push_divider(&mut tree, &mut x, "annotations");
-    }
-    for button in utilities {
-        match button {
-            model::TopUtilityButton::Text => {
-                tree.push(utility_node(
-                    snapshot,
-                    ids::TOP_UTILITY_TEXT.as_str(),
-                    (x, y, btn_w, btn_h),
-                    IconFn(toolbar_icons::draw_icon_text),
-                    action_short_label(Action::EnterTextMode),
-                    ButtonStyle::active(snapshot.text_active),
-                    ToolbarEvent::EnterTextMode,
-                    format_binding_label(
-                        action_label(Action::EnterTextMode),
-                        snapshot
-                            .binding_hints
-                            .binding_for_action(Action::EnterTextMode),
-                    ),
-                    use_icons,
-                ));
-                x += btn_w + gap;
+    for node in spec.strip() {
+        match *node {
+            model::TopToolbarNode::Divider(divider) => {
+                let key = divider.id().trim_start_matches("top.divider.");
+                push_divider(&mut tree, &mut x, key);
             }
-            model::TopUtilityButton::StickyNote => {
-                tree.push(utility_node(
-                    snapshot,
-                    ids::TOP_UTILITY_STICKY_NOTE.as_str(),
-                    (x, y, btn_w, btn_h),
-                    IconFn(toolbar_icons::draw_icon_note),
-                    action_short_label(Action::EnterStickyNoteMode),
-                    ButtonStyle::active(snapshot.note_active),
-                    ToolbarEvent::EnterStickyNoteMode,
-                    format_binding_label(
-                        action_label(Action::EnterStickyNoteMode),
-                        snapshot
-                            .binding_hints
-                            .binding_for_action(Action::EnterStickyNoteMode),
-                    ),
-                    use_icons,
-                ));
-                x += btn_w + gap;
-            }
-            model::TopUtilityButton::Screenshot => {
-                tree.push(utility_node(
-                    snapshot,
-                    ids::TOP_UTILITY_SCREENSHOT.as_str(),
-                    (x, y, btn_w, btn_h),
-                    IconFn(toolbar_icons::draw_icon_screenshot),
-                    "Shot",
-                    ButtonStyle::plain(),
-                    ToolbarEvent::CaptureScreenshot,
-                    format_binding_label(
-                        action_label(Action::CaptureSelection),
-                        snapshot
-                            .binding_hints
-                            .binding_for_action(Action::CaptureSelection),
-                    ),
-                    use_icons,
-                ));
-                x += btn_w + gap;
-            }
-            model::TopUtilityButton::Highlight => {
-                tree.push(utility_node(
-                    snapshot,
-                    ids::TOP_UTILITY_HIGHLIGHT.as_str(),
-                    (x, y, btn_w, btn_h),
-                    IconFn(toolbar_icons::draw_icon_highlight),
-                    "Highlight",
-                    ButtonStyle::active(snapshot.any_highlight_active),
-                    ToolbarEvent::ToggleAllHighlight(!snapshot.any_highlight_active),
-                    format_binding_label(
-                        action_label(Action::ToggleHighlightTool),
-                        snapshot
-                            .binding_hints
-                            .binding_for_action(Action::ToggleHighlightTool),
-                    ),
-                    use_icons,
-                ));
-                if snapshot.highlight_tool_active && model::top_highlight_ring_visible(snapshot) {
-                    let ring_y = y + btn_h + ToolbarLayoutSpec::TOP_ICON_FILL_OFFSET;
+            model::TopToolbarNode::Control(control) => match control {
+                model::TopToolbarControl::DragHandle => {
+                    let size = ToolbarLayoutSpec::TOP_HANDLE_SIZE;
                     tree.push(WidgetNode::new(
-                        ids::TOP_UTILITY_HIGHLIGHT_RING.as_str(),
-                        (x, ring_y, btn_w, ToolbarLayoutSpec::TOP_ICON_FILL_HEIGHT),
-                        WidgetKind::MiniCheckbox {
-                            checked: snapshot.highlight_tool_ring_enabled,
-                            label: LabelSpec::new("Ring", MINI_LABEL_FONT_SIZE, false),
+                        control.id().render_id().into_owned(),
+                        (x, ToolbarLayoutSpec::TOP_HANDLE_Y, size, size),
+                        WidgetKind::DragHandle,
+                        Some(Interaction {
+                            event: control.event(snapshot),
+                            kind: HitKind::DragMoveTop,
+                            tooltip: Some(control.tooltip(snapshot)),
+                        }),
+                    ));
+                    x += size + gap;
+                }
+                model::TopToolbarControl::Tool(_)
+                | model::TopToolbarControl::Utility(_)
+                | model::TopToolbarControl::ShapePicker
+                | model::TopToolbarControl::Undo
+                | model::TopToolbarControl::Redo
+                | model::TopToolbarControl::ClearCanvas => {
+                    if control == model::TopToolbarControl::ClearCanvas {
+                        x += gap;
+                    }
+                    let rect = (x, y, btn_w, btn_h);
+                    tree.push(control_button_node(
+                        snapshot,
+                        control,
+                        control.id().render_id().into_owned(),
+                        rect,
+                        use_icons,
+                    ));
+                    if control == model::TopToolbarControl::ShapePicker {
+                        picker_anchor = Some(rect);
+                    }
+                    if matches!(
+                        control,
+                        model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight)
+                    ) && let Some(ring) = contextual_ring
+                    {
+                        let ring_y = y + btn_h + ToolbarLayoutSpec::TOP_ICON_FILL_OFFSET;
+                        tree.push(WidgetNode::new(
+                            ring.id().render_id().into_owned(),
+                            (x, ring_y, btn_w, ToolbarLayoutSpec::TOP_ICON_FILL_HEIGHT),
+                            WidgetKind::MiniCheckbox {
+                                checked: ring.active(snapshot),
+                                label: LabelSpec::new(
+                                    ring.label(snapshot),
+                                    MINI_LABEL_FONT_SIZE,
+                                    false,
+                                ),
+                            },
+                            Some(Interaction::click(
+                                ring.event(snapshot),
+                                Some(ring.tooltip(snapshot)),
+                            )),
+                        ));
+                    }
+                    x += btn_w + gap;
+                }
+                model::TopToolbarControl::QuickColor(index) => {
+                    let entry = &snapshot.quick_colors.rendered_entries()[index];
+                    let badge = control.shortcut_badge(snapshot);
+                    tree.push(
+                        WidgetNode::new(
+                            control.id().render_id().into_owned(),
+                            (x, swatch_y, TOP_SWATCH_SIZE, TOP_SWATCH_SIZE),
+                            WidgetKind::Swatch {
+                                color: (entry.color.r, entry.color.g, entry.color.b, entry.color.a),
+                                selected: control.active(snapshot),
+                            },
+                            Some(Interaction::click(
+                                control.event(snapshot),
+                                Some(control.tooltip(snapshot)),
+                            )),
+                        )
+                        .with_shortcut_badge(badge.as_deref(), ShortcutBadgePlacement::Above),
+                    );
+                    x += TOP_SWATCH_SIZE + TOP_SWATCH_GAP;
+                }
+                model::TopToolbarControl::CurrentColor => {
+                    let chip_y = y + (btn_h - TOP_CHIP_SIZE) / 2.0;
+                    x += gap - TOP_SWATCH_GAP;
+                    tree.push(WidgetNode::new(
+                        control.id().render_id().into_owned(),
+                        (x, chip_y, TOP_CHIP_SIZE, TOP_CHIP_SIZE),
+                        WidgetKind::Swatch {
+                            color: (
+                                snapshot.color.r,
+                                snapshot.color.g,
+                                snapshot.color.b,
+                                snapshot.color.a,
+                            ),
+                            selected: control.active(snapshot),
                         },
                         Some(Interaction::click(
-                            ToolbarEvent::ToggleHighlightToolRing(
-                                !snapshot.highlight_tool_ring_enabled,
-                            ),
-                            Some("Highlight ring".to_string()),
+                            control.event(snapshot),
+                            Some(control.tooltip(snapshot)),
                         )),
                     ));
+                    x += TOP_CHIP_SIZE + gap;
                 }
-                x += btn_w + gap;
-            }
-            model::TopUtilityButton::ClearCanvas | model::TopUtilityButton::IconMode => {}
-        }
-    }
-
-    // --- Quick colors + current-color chip ----------------------------------
-    if model::toolbar_item_visible(snapshot, ids::TOP_GROUP_QUICK_COLORS) {
-        push_divider(&mut tree, &mut x, "colors");
-        let swatches_have_badges = snapshot
-            .quick_colors
-            .rendered_entries()
-            .iter()
-            .take(plan.swatch_count)
-            .enumerate()
-            .any(|(index, _)| snapshot.binding_hints.quick_color_badge(index).is_some());
-        let swatch_y = if swatches_have_badges {
-            // Reserve one 10px badge row plus a 1px gap above every swatch,
-            // keeping bound and unbound colors aligned in both bar modes.
-            y + (btn_h - (10.0 + 1.0 + TOP_SWATCH_SIZE)) / 2.0 + 11.0
-        } else {
-            y + (btn_h - TOP_SWATCH_SIZE) / 2.0
-        };
-        for (index, entry) in snapshot
-            .quick_colors
-            .rendered_entries()
-            .iter()
-            .take(plan.swatch_count)
-            .enumerate()
-        {
-            let action = crate::config::QuickColorPalette::action_for_index(index);
-            let binding =
-                action.and_then(|action| snapshot.binding_hints.binding_for_action(action));
-            tree.push(
-                WidgetNode::new(
-                    format!("top.quick-color.{index}"),
-                    (x, swatch_y, TOP_SWATCH_SIZE, TOP_SWATCH_SIZE),
-                    WidgetKind::Swatch {
-                        color: (entry.color.r, entry.color.g, entry.color.b, entry.color.a),
-                        selected: entry.color == snapshot.color,
-                    },
-                    Some(Interaction::click(
-                        ToolbarEvent::SetQuickColor {
-                            color: entry.color,
-                            action,
-                        },
-                        Some(format_binding_label(&entry.label, binding)),
-                    )),
-                )
-                .with_shortcut_badge(
-                    snapshot.binding_hints.quick_color_badge(index),
-                    ShortcutBadgePlacement::Above,
-                ),
-            );
-            x += TOP_SWATCH_SIZE + TOP_SWATCH_GAP;
-        }
-        // The chip shows the current color and opens the full picker; it
-        // never collapses under width pressure.
-        let chip_y = y + (btn_h - TOP_CHIP_SIZE) / 2.0;
-        x += gap - TOP_SWATCH_GAP;
-        tree.push(WidgetNode::new(
-            ids::TOP_GROUP_QUICK_COLORS.as_str(),
-            (x, chip_y, TOP_CHIP_SIZE, TOP_CHIP_SIZE),
-            WidgetKind::Swatch {
-                color: (
-                    snapshot.color.r,
-                    snapshot.color.g,
-                    snapshot.color.b,
-                    snapshot.color.a,
-                ),
-                selected: true,
+                model::TopToolbarControl::Restore
+                | model::TopToolbarControl::Pin
+                | model::TopToolbarControl::Overflow
+                | model::TopToolbarControl::Minimize
+                | model::TopToolbarControl::HighlightRing => {
+                    unreachable!("control belongs outside the main strip")
+                }
             },
-            Some(Interaction::click(
-                ToolbarEvent::OpenColorPickerPopup,
-                Some("Color picker".to_string()),
-            )),
-        ));
-        x += TOP_CHIP_SIZE + gap;
-    }
-
-    // --- History -------------------------------------------------------------
-    let undo_visible = model::toolbar_item_visible(snapshot, ids::TOP_UTILITY_UNDO);
-    let redo_visible = model::toolbar_item_visible(snapshot, ids::TOP_UTILITY_REDO);
-    if undo_visible || redo_visible {
-        push_divider(&mut tree, &mut x, "history");
-    }
-    if undo_visible {
-        tree.push(history_node(
-            snapshot,
-            ids::TOP_UTILITY_UNDO.as_str(),
-            (x, y, btn_w, btn_h),
-            IconFn(toolbar_icons::draw_icon_undo),
-            Action::Undo,
-            ToolbarEvent::Undo,
-            snapshot.undo_available,
-            use_icons,
-        ));
-        x += btn_w + gap;
-    }
-    if redo_visible {
-        tree.push(history_node(
-            snapshot,
-            ids::TOP_UTILITY_REDO.as_str(),
-            (x, y, btn_w, btn_h),
-            IconFn(toolbar_icons::draw_icon_redo),
-            Action::Redo,
-            ToolbarEvent::Redo,
-            snapshot.redo_available,
-            use_icons,
-        ));
-        x += btn_w + gap;
-    }
-
-    // --- Destructive Clear, isolated by a double gap --------------------------
-    if clear_visible {
-        x += gap;
-        tree.push(utility_node(
-            snapshot,
-            ids::TOP_UTILITY_CLEAR_CANVAS.as_str(),
-            (x, y, btn_w, btn_h),
-            IconFn(toolbar_icons::draw_icon_clear),
-            action_short_label(Action::ClearCanvas),
-            ButtonStyle::destructive(),
-            ToolbarEvent::ClearCanvas,
-            format_binding_label(
-                action_label(Action::ClearCanvas),
-                snapshot
-                    .binding_hints
-                    .binding_for_action(Action::ClearCanvas),
-            ),
-            use_icons,
-        ));
+        }
     }
 
     // --- Shapes popover: the grid plus per-tool options ------------------------
     if snapshot.shape_picker_open
-        && model::top_shape_picker_visible(snapshot)
         && let Some(anchor) = picker_anchor
     {
         let rows = model::visible_shape_picker_rows(snapshot, is_simple);
@@ -425,8 +240,6 @@ pub(super) fn build_top_view_planned(
                     if !model::tool_visible(snapshot, tool) {
                         continue;
                     }
-                    let active =
-                        snapshot.active_tool == tool || snapshot.tool_override == Some(tool);
                     tree.push(tool_button_node(
                         snapshot,
                         tool,
@@ -435,7 +248,6 @@ pub(super) fn build_top_view_planned(
                             model::toolbar_item_id_for_tool(tool).as_str()
                         ),
                         (shape_x, row_y, btn_w, btn_h),
-                        active,
                         use_icons,
                     ));
                     shape_x += btn_w + gap;
@@ -471,61 +283,47 @@ pub(super) fn build_top_view_planned(
     } else {
         ToolbarLayoutSpec::TOP_PIN_BUTTON_MARGIN_RIGHT
     };
-    let mut right_x = width - chrome_margin_right - chrome_size;
-    if model::toolbar_item_visible(snapshot, ids::TOP_CHROME_CLOSE) {
-        tree.push(WidgetNode::new(
-            ids::TOP_CHROME_CLOSE.as_str(),
-            (right_x, chrome_y, chrome_size, chrome_size),
-            WidgetKind::MinimizeButton,
-            Some(Interaction::click(
-                ToolbarEvent::SetTopMinimized(true),
-                Some("Minimize (leaves a restore tab)".to_string()),
-            )),
-        ));
-        right_x -= chrome_size + chrome_gap;
-    }
+    let chrome_count = spec.chrome().len();
+    let chrome_width =
+        chrome_size * chrome_count as f64 + chrome_gap * chrome_count.saturating_sub(1) as f64;
+    let mut chrome_x = width - chrome_margin_right - chrome_width;
     let mut overflow_anchor = None;
-    if plan.show_overflow {
-        let rect = (right_x, chrome_y, chrome_size, chrome_size);
-        overflow_anchor = Some(rect);
+    for control in spec.chrome().iter().copied() {
+        let rect = (chrome_x, chrome_y, chrome_size, chrome_size);
+        let kind = match control {
+            model::TopToolbarControl::Pin => WidgetKind::PinButton {
+                pinned: control.active(snapshot),
+            },
+            model::TopToolbarControl::Overflow => {
+                overflow_anchor = Some(rect);
+                WidgetKind::IconButton {
+                    glyph: IconFn(toolbar_icons::top_toolbar_icon_painter(
+                        control.icon(snapshot).expect("overflow icon"),
+                    )),
+                    icon_size: chrome_size * 0.7,
+                    style: ButtonStyle::active(control.active(snapshot)),
+                }
+            }
+            model::TopToolbarControl::Minimize => WidgetKind::MinimizeButton,
+            _ => unreachable!("non-chrome control in chrome specification"),
+        };
         tree.push(WidgetNode::new(
-            ids::TOP_CHROME_OVERFLOW.as_str(),
+            control.id().render_id().into_owned(),
             rect,
-            WidgetKind::IconButton {
-                glyph: IconFn(toolbar_icons::draw_icon_more),
-                icon_size: chrome_size * 0.7,
-                style: ButtonStyle::active(snapshot.top_overflow_open),
-            },
+            kind,
             Some(Interaction::click(
-                ToolbarEvent::ToggleTopOverflow(!snapshot.top_overflow_open),
-                Some("More tools".to_string()),
+                control.event(snapshot),
+                Some(control.tooltip(snapshot)),
             )),
         ));
-        right_x -= chrome_size + chrome_gap;
-    }
-    if model::toolbar_item_visible(snapshot, ids::TOP_CHROME_PIN) {
-        tree.push(WidgetNode::new(
-            ids::TOP_CHROME_PIN.as_str(),
-            (right_x, chrome_y, chrome_size, chrome_size),
-            WidgetKind::PinButton {
-                pinned: snapshot.top_pinned,
-            },
-            Some(Interaction::click(
-                ToolbarEvent::PinTopToolbar(!snapshot.top_pinned),
-                Some(if snapshot.top_pinned {
-                    "Pinned: opens at startup (click to disable)".to_string()
-                } else {
-                    "Pin: click to open at startup".to_string()
-                }),
-            )),
-        ));
+        chrome_x += chrome_size + chrome_gap;
     }
 
     // --- Overflow popover: the width-dropped items ---------------------------
     if snapshot.top_overflow_open
         && let Some(anchor) = overflow_anchor
     {
-        let dropped_count = plan.dropped_tools.len() + plan.dropped_utilities.len();
+        let dropped_count = spec.overflow().len();
         if dropped_count > 0 {
             let cols = dropped_count.min(5);
             let rows = dropped_count.div_ceil(cols);
@@ -550,7 +348,6 @@ pub(super) fn build_top_view_planned(
                     caret_up: placement.side == super::super::popover::PopoverSide::Below,
                 },
             ));
-            let mut index = 0usize;
             let item_rect = |index: usize| {
                 let col = index % cols;
                 let row = index / cols;
@@ -561,71 +358,15 @@ pub(super) fn build_top_view_planned(
                     btn_h,
                 )
             };
-            for tool in &plan.dropped_tools {
-                let active = snapshot.active_tool == *tool || snapshot.tool_override == Some(*tool);
-                tree.push(tool_button_node(
+            for (index, control) in spec.overflow().iter().copied().enumerate() {
+                let id = format!("top.overflow.{}", control.id().render_id());
+                tree.push(overflow_control_button_node(
                     snapshot,
-                    *tool,
-                    format!(
-                        "top.overflow.{}",
-                        model::toolbar_item_id_for_tool(*tool).as_str()
-                    ),
+                    control,
+                    id,
                     item_rect(index),
-                    active,
                     use_icons,
                 ));
-                index += 1;
-            }
-            for utility in &plan.dropped_utilities {
-                let rect = item_rect(index);
-                match utility {
-                    model::TopUtilityButton::Text => tree.push(utility_node(
-                        snapshot,
-                        "top.overflow.top.utility.text",
-                        rect,
-                        IconFn(toolbar_icons::draw_icon_text),
-                        action_short_label(Action::EnterTextMode),
-                        ButtonStyle::active(snapshot.text_active),
-                        ToolbarEvent::EnterTextMode,
-                        action_label(Action::EnterTextMode).to_string(),
-                        use_icons,
-                    )),
-                    model::TopUtilityButton::StickyNote => tree.push(utility_node(
-                        snapshot,
-                        "top.overflow.top.utility.sticky-note",
-                        rect,
-                        IconFn(toolbar_icons::draw_icon_note),
-                        action_short_label(Action::EnterStickyNoteMode),
-                        ButtonStyle::active(snapshot.note_active),
-                        ToolbarEvent::EnterStickyNoteMode,
-                        action_label(Action::EnterStickyNoteMode).to_string(),
-                        use_icons,
-                    )),
-                    model::TopUtilityButton::Screenshot => tree.push(utility_node(
-                        snapshot,
-                        "top.overflow.top.utility.screenshot",
-                        rect,
-                        IconFn(toolbar_icons::draw_icon_screenshot),
-                        "Shot",
-                        ButtonStyle::plain(),
-                        ToolbarEvent::CaptureScreenshot,
-                        action_label(Action::CaptureSelection).to_string(),
-                        use_icons,
-                    )),
-                    model::TopUtilityButton::Highlight => tree.push(utility_node(
-                        snapshot,
-                        "top.overflow.top.utility.highlight",
-                        rect,
-                        IconFn(toolbar_icons::draw_icon_highlight),
-                        "Highlight",
-                        ButtonStyle::active(snapshot.any_highlight_active),
-                        ToolbarEvent::ToggleAllHighlight(!snapshot.any_highlight_active),
-                        action_label(Action::ToggleHighlightTool).to_string(),
-                        use_icons,
-                    )),
-                    model::TopUtilityButton::ClearCanvas | model::TopUtilityButton::IconMode => {}
-                }
-                index += 1;
             }
         }
     }
@@ -635,7 +376,16 @@ pub(super) fn build_top_view_planned(
 
 /// Minimized top strip: the whole tab is one restore button. It is not an
 /// item id on purpose — the way back must not be hideable.
-fn build_top_minimized_tab(width: f64, height: f64) -> WidgetTree {
+fn build_top_minimized_tab(
+    snapshot: &ToolbarSnapshot,
+    spec: &model::TopToolbarSpec,
+    width: f64,
+    height: f64,
+) -> WidgetTree {
+    let control = match spec.strip() {
+        [model::TopToolbarNode::Control(control)] => *control,
+        _ => unreachable!("minimized specification contains one restore control"),
+    };
     let mut tree = WidgetTree::new((width, height));
     tree.push(WidgetNode::decor(
         "top.panel",
@@ -643,16 +393,18 @@ fn build_top_minimized_tab(width: f64, height: f64) -> WidgetTree {
         WidgetKind::Panel,
     ));
     tree.push(WidgetNode::new(
-        "top.chrome.restore",
+        control.id().render_id().into_owned(),
         (0.0, 0.0, width, height),
         WidgetKind::IconButton {
-            glyph: IconFn(toolbar_icons::draw_icon_restore),
+            glyph: IconFn(toolbar_icons::top_toolbar_icon_painter(
+                control.icon(snapshot).expect("restore icon"),
+            )),
             icon_size: (height * 0.75).min(18.0),
             style: ButtonStyle::plain(),
         },
         Some(Interaction::click(
-            ToolbarEvent::SetTopMinimized(false),
-            Some("Show toolbar".to_string()),
+            control.event(snapshot),
+            Some(control.tooltip(snapshot)),
         )),
     ));
     tree
@@ -750,11 +502,11 @@ fn push_option_row(
 }
 
 pub(super) fn shape_popover_height(snapshot: &ToolbarSnapshot) -> f64 {
-    if !snapshot.shape_picker_open || !model::top_shape_picker_visible(snapshot) {
+    if !snapshot.shape_picker_open || !model::TopToolbarSpec::shape_picker_visible(snapshot) {
         return 0.0;
     }
-    let is_simple = snapshot.layout_mode == crate::config::ToolbarLayoutMode::Simple;
     let plan = plan_top_strip(snapshot);
+    let is_simple = snapshot.layout_mode == crate::config::ToolbarLayoutMode::Simple;
     let (_, btn_h) = planned_button_size(snapshot, &plan);
     let gap = planned_gap(&plan);
     let pad = ToolbarLayoutSpec::TOP_POPOVER_PAD;
@@ -782,21 +534,7 @@ pub(super) fn ring_row_height(snapshot: &ToolbarSnapshot) -> f64 {
 }
 
 pub(super) fn ring_row_height_planned(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> f64 {
-    let is_simple = snapshot.layout_mode == crate::config::ToolbarLayoutMode::Simple;
-    if !planned_use_icons(snapshot, plan)
-        || is_simple
-        || !snapshot.highlight_tool_active
-        || !model::top_highlight_ring_visible(snapshot)
-    {
-        return 0.0;
-    }
-    let highlight_shown =
-        model::visible_top_utility_buttons(snapshot, is_simple, snapshot.use_icons)
-            .contains(&model::TopUtilityButton::Highlight)
-            && !plan
-                .dropped_utilities
-                .contains(&model::TopUtilityButton::Highlight);
-    if !highlight_shown {
+    if !model::TopToolbarSpec::contextual_highlight_ring_visible(snapshot, plan) {
         return 0.0;
     }
     ToolbarLayoutSpec::TOP_ICON_FILL_OFFSET + ToolbarLayoutSpec::TOP_ICON_FILL_HEIGHT + 2.0
@@ -824,8 +562,8 @@ pub(super) fn overflow_height(snapshot: &ToolbarSnapshot) -> f64 {
         return 0.0;
     }
     let plan = plan_top_strip(snapshot);
-    let dropped_count = plan.dropped_tools.len() + plan.dropped_utilities.len();
-    if dropped_count == 0 || !plan.show_overflow {
+    let dropped_count = model::TopToolbarSpec::overflow_control_count(snapshot, &plan);
+    if dropped_count == 0 {
         return 0.0;
     }
     let (_, btn_h) = planned_button_size(snapshot, &plan);
@@ -839,149 +577,79 @@ fn tool_button_node(
     tool: Tool,
     id: impl Into<super::super::node::WidgetId>,
     rect: (f64, f64, f64, f64),
-    active: bool,
     use_icons: bool,
 ) -> WidgetNode {
-    let tooltip = tool_tooltip(snapshot, tool, tool_tooltip_label(tool));
-    let kind = if use_icons {
-        WidgetKind::IconButton {
-            glyph: semantic_icon_fn(model::semantic_icon_for_tool(tool)),
-            icon_size: ToolbarLayoutSpec::TOP_ICON_SIZE.min((rect.2 - 4.0).max(8.0)),
-            style: ButtonStyle::active(active),
-        }
-    } else {
-        WidgetKind::TextButton {
-            label: LabelSpec::new(tool_label(tool), TOP_LABEL_FONT_SIZE, true),
-            style: ButtonStyle::active(active),
-        }
-    };
-    let badge = (rect.2 > super::TOP_COMPACT_BUTTON)
-        .then(|| snapshot.binding_hints.badge_for_tool(tool))
-        .flatten();
-    WidgetNode::new(
+    control_button_node(
+        snapshot,
+        model::TopToolbarControl::Tool(tool),
         id,
         rect,
-        kind,
-        Some(Interaction::click(
-            ToolbarEvent::SelectTool(tool),
-            Some(tooltip),
-        )),
+        use_icons,
     )
-    .with_shortcut_badge(badge, ShortcutBadgePlacement::Corner)
 }
 
-#[allow(clippy::too_many_arguments)]
-fn utility_node(
+fn control_button_node(
     snapshot: &ToolbarSnapshot,
+    control: model::TopToolbarControl,
     id: impl Into<super::super::node::WidgetId>,
     rect: (f64, f64, f64, f64),
-    glyph: IconFn,
-    label: &str,
-    style: ButtonStyle,
-    event: ToolbarEvent,
-    tooltip: String,
     use_icons: bool,
 ) -> WidgetNode {
-    let badge = (rect.2 > super::TOP_COMPACT_BUTTON)
-        .then(|| snapshot.binding_hints.badge_for_event(&event))
-        .flatten();
-    let kind = if use_icons {
-        WidgetKind::IconButton {
-            glyph,
-            icon_size: ToolbarLayoutSpec::TOP_ICON_SIZE.min((rect.2 - 4.0).max(8.0)),
-            style,
-        }
-    } else {
-        WidgetKind::TextButton {
-            label: LabelSpec::new(label, TOP_LABEL_FONT_SIZE, true),
-            style,
-        }
-    };
-    WidgetNode::new(
-        id,
-        rect,
-        kind,
-        Some(Interaction::click(event, Some(tooltip))),
-    )
-    .with_shortcut_badge(badge, ShortcutBadgePlacement::Corner)
+    let tooltip = control.tooltip(snapshot);
+    control_button_node_with_tooltip(snapshot, control, id, rect, use_icons, tooltip)
 }
 
-/// Undo/Redo button: dimmed and non-interactive while unavailable.
-#[allow(clippy::too_many_arguments)]
-fn history_node(
+fn overflow_control_button_node(
     snapshot: &ToolbarSnapshot,
-    id: &'static str,
+    control: model::TopToolbarControl,
+    id: impl Into<super::super::node::WidgetId>,
     rect: (f64, f64, f64, f64),
-    glyph: IconFn,
-    action: Action,
-    event: ToolbarEvent,
-    enabled: bool,
     use_icons: bool,
 ) -> WidgetNode {
-    let style = if enabled {
-        ButtonStyle::plain()
-    } else {
+    let tooltip = control.overflow_tooltip(snapshot);
+    control_button_node_with_tooltip(snapshot, control, id, rect, use_icons, tooltip)
+}
+
+fn control_button_node_with_tooltip(
+    snapshot: &ToolbarSnapshot,
+    control: model::TopToolbarControl,
+    id: impl Into<super::super::node::WidgetId>,
+    rect: (f64, f64, f64, f64),
+    use_icons: bool,
+    tooltip: String,
+) -> WidgetNode {
+    let enabled = control.enabled(snapshot);
+    let style = if !enabled {
         ButtonStyle::disabled()
+    } else {
+        match control.role() {
+            model::TopToolbarControlRole::Destructive => ButtonStyle::destructive(),
+            _ => ButtonStyle::active(control.active(snapshot)),
+        }
     };
     let kind = if use_icons {
+        let icon_size = if control == model::TopToolbarControl::ShapePicker {
+            ToolbarLayoutSpec::TOP_ICON_SIZE
+        } else {
+            ToolbarLayoutSpec::TOP_ICON_SIZE.min((rect.2 - 4.0).max(8.0))
+        };
         WidgetKind::IconButton {
-            glyph,
-            icon_size: ToolbarLayoutSpec::TOP_ICON_SIZE.min((rect.2 - 4.0).max(8.0)),
+            glyph: IconFn(toolbar_icons::top_toolbar_icon_painter(
+                control.icon(snapshot).expect("button icon"),
+            )),
+            icon_size,
             style,
         }
     } else {
         WidgetKind::TextButton {
-            label: LabelSpec::new(action_short_label(action), TOP_LABEL_FONT_SIZE, true),
+            label: LabelSpec::new(control.label(snapshot), TOP_LABEL_FONT_SIZE, true),
             style,
         }
     };
-    let interact = enabled.then(|| {
-        Interaction::click(
-            event,
-            Some(format_binding_label(
-                action_label(action),
-                snapshot.binding_hints.binding_for_action(action),
-            )),
-        )
-    });
+    let interact = enabled.then(|| Interaction::click(control.event(snapshot), Some(tooltip)));
     let badge = (rect.2 > super::TOP_COMPACT_BUTTON)
-        .then(|| snapshot.binding_hints.badge_for_action(action))
+        .then(|| control.shortcut_badge(snapshot))
         .flatten();
     WidgetNode::new(id, rect, kind, interact)
-        .with_shortcut_badge(badge, ShortcutBadgePlacement::Corner)
-}
-
-/// Tooltip text for a tool button: label plus binding and/or drag hint.
-fn tool_tooltip(snapshot: &ToolbarSnapshot, tool: Tool, label: &str) -> String {
-    let default_hint = model::default_drag_hint(tool);
-    let binding = match (snapshot.binding_hints.for_tool(tool), default_hint) {
-        (Some(binding), Some(fallback)) => Some(format!("{}, {}", binding, fallback)),
-        (Some(binding), None) => Some(binding.to_string()),
-        (None, Some(fallback)) => Some(fallback.to_string()),
-        (None, None) => None,
-    };
-    format_binding_label(label, binding.as_deref())
-}
-
-/// Glyph function for a semantic tool icon.
-fn semantic_icon_fn(icon: model::SemanticToolIcon) -> IconFn {
-    use model::SemanticToolIcon as S;
-    IconFn(match icon {
-        S::Select => toolbar_icons::draw_icon_select,
-        S::Pen => toolbar_icons::draw_icon_pen,
-        S::Line => toolbar_icons::draw_icon_line,
-        S::Rect => toolbar_icons::draw_icon_rect,
-        S::Circle => toolbar_icons::draw_icon_circle,
-        S::Triangle => toolbar_icons::draw_icon_triangle,
-        S::Parallelogram => toolbar_icons::draw_icon_parallelogram,
-        S::Rhombus => toolbar_icons::draw_icon_rhombus,
-        S::Polygon => toolbar_icons::draw_icon_polygon,
-        S::FreeformPolygon => toolbar_icons::draw_icon_freeform_polygon,
-        S::Arrow => toolbar_icons::draw_icon_arrow,
-        S::Blur => toolbar_icons::draw_icon_blur,
-        S::Marker => toolbar_icons::draw_icon_marker,
-        S::Highlight => toolbar_icons::draw_icon_highlight,
-        S::StepMarker => toolbar_icons::draw_icon_step_marker,
-        S::Eraser => toolbar_icons::draw_icon_eraser,
-    })
+        .with_shortcut_badge(badge.as_deref(), ShortcutBadgePlacement::Corner)
 }

--- a/src/backend/wayland/toolbar/view/top/tests.rs
+++ b/src/backend/wayland/toolbar/view/top/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::backend::wayland::toolbar::layout::{ToolbarLayoutSpec, top_size};
 use crate::backend::wayland::toolbar::view::{ShortcutBadgePlacement, WidgetKind, WidgetTree};
-use crate::config::toolbar_item_ids as ids;
+use crate::config::{Action, action_label, toolbar_item_ids as ids};
 use crate::input::state::test_support::make_test_input_state;
 use crate::ui::toolbar::{ToolbarBindingHints, ToolbarEvent, ToolbarSnapshot};
 
@@ -288,6 +288,48 @@ fn minimized_strip_is_a_single_restore_tab() {
         interactive[0].interact.as_ref().unwrap().event,
         ToolbarEvent::SetTopMinimized(false)
     ));
+}
+
+#[test]
+fn compact_shape_picker_preserves_its_full_semantic_icon_size() {
+    let snapshot = snapshot();
+    let mut plan = TopStripPlan::unconstrained();
+    plan.compact = true;
+    let tree = super::build::build_top_view_planned(&snapshot, &plan, 800.0, 100.0);
+    let picker = tree
+        .node_by_id(&ids::TOP_UTILITY_SHAPE_PICKER.as_str().into())
+        .expect("shape picker");
+
+    assert!(matches!(
+        picker.kind,
+        WidgetKind::IconButton { icon_size, .. }
+            if (icon_size - ToolbarLayoutSpec::TOP_ICON_SIZE).abs() < f64::EPSILON
+    ));
+}
+
+#[test]
+fn overflow_utility_tooltips_remain_bare_action_labels() {
+    let state = make_test_input_state();
+    let mut snapshot = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    snapshot.top_overflow_open = true;
+    let mut plan = TopStripPlan::unconstrained();
+    plan.swatch_count = 0;
+    plan.show_overflow = true;
+    plan.dropped_utilities = vec![model::TopUtilityButton::Text];
+
+    let tree = super::build::build_top_view_planned(&snapshot, &plan, 800.0, 160.0);
+    let text = tree
+        .node_by_id(&"top.overflow.top.utility.text".into())
+        .expect("overflow text control");
+    assert_eq!(
+        text.interact
+            .as_ref()
+            .and_then(|interaction| interaction.tooltip.as_deref()),
+        Some(action_label(Action::EnterTextMode))
+    );
 }
 
 #[test]

--- a/src/toolbar_gtk/icons.rs
+++ b/src/toolbar_gtk/icons.rs
@@ -16,29 +16,13 @@ use crate::input::Tool;
 use crate::toolbar_icons;
 use crate::ui::toolbar::model;
 
-pub(super) type IconPainter = fn(&cairo::Context, f64, f64, f64);
+pub(super) type IconPainter = toolbar_icons::ToolbarIconPainter;
 
 /// Painter for a tool's semantic icon; mirrors the built-in mapping.
 pub(super) fn tool_icon_painter(tool: Tool) -> IconPainter {
-    use model::SemanticToolIcon as S;
-    match model::semantic_icon_for_tool(tool) {
-        S::Select => toolbar_icons::draw_icon_select,
-        S::Pen => toolbar_icons::draw_icon_pen,
-        S::Line => toolbar_icons::draw_icon_line,
-        S::Rect => toolbar_icons::draw_icon_rect,
-        S::Circle => toolbar_icons::draw_icon_circle,
-        S::Triangle => toolbar_icons::draw_icon_triangle,
-        S::Parallelogram => toolbar_icons::draw_icon_parallelogram,
-        S::Rhombus => toolbar_icons::draw_icon_rhombus,
-        S::Polygon => toolbar_icons::draw_icon_polygon,
-        S::FreeformPolygon => toolbar_icons::draw_icon_freeform_polygon,
-        S::Arrow => toolbar_icons::draw_icon_arrow,
-        S::Blur => toolbar_icons::draw_icon_blur,
-        S::Marker => toolbar_icons::draw_icon_marker,
-        S::Highlight => toolbar_icons::draw_icon_highlight,
-        S::StepMarker => toolbar_icons::draw_icon_step_marker,
-        S::Eraser => toolbar_icons::draw_icon_eraser,
-    }
+    toolbar_icons::top_toolbar_icon_painter(model::TopToolbarIcon::Tool(
+        model::semantic_icon_for_tool(tool),
+    ))
 }
 
 /// Handle to an icon widget whose painter can be swapped when live toolbar

--- a/src/toolbar_gtk/view/top_bar.rs
+++ b/src/toolbar_gtk/view/top_bar.rs
@@ -1,10 +1,9 @@
 //! The GTK top strip.
 //!
-//! Reproduces the built-in strip's reading order — drag grip | pens |
+//! Adapts the shared `TopToolbarSpec` reading order — drag grip | pens |
 //! shapes | shapes-picker | annotations | quick colors + chip | history |
-//! Clear | pin/overflow/minimize — from the same `ui::toolbar::model`
-//! ordering/visibility logic and the same `plan_top_strip` width
-//! degradation, so the two frontends stay behaviorally identical.
+//! Clear | pin/overflow/minimize — into GTK widgets. Width degradation uses
+//! the same shared plan as the built-in frontend.
 //!
 //! The bar content is rebuilt only when its *structure* changes (item
 //! order/visibility, icon mode, plan, scale, palette); per-state changes
@@ -25,15 +24,14 @@ use std::rc::Rc;
 use gtk4::prelude::*;
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
-use crate::backend::wayland::{TopStripPlan, plan_top_strip, top_toolbar_size};
-use crate::config::{Action, ToolbarLayoutMode, action_label, action_short_label};
+use crate::backend::wayland::{plan_top_strip, top_toolbar_size};
+use crate::config::{Action, ToolbarLayoutMode, action_short_label};
 use crate::input::Tool;
-use crate::label_format::format_binding_label;
-use crate::toolbar_icons;
-use crate::ui::toolbar::bindings::{tool_label, tool_tooltip_label};
+use crate::toolbar_icons::top_toolbar_icon_painter;
 use crate::ui::toolbar::{ToolbarEvent, ToolbarSnapshot, model};
+use model::TopStripPlan;
 
-use super::super::icons::{IconWidget, tool_icon_painter};
+use super::super::icons::IconWidget;
 use super::super::widgets::{
     FeedbackSender, SwatchButton, add_shortcut_badge, icon_button, install_shortcut_focus_policy,
     send_event, set_active_class, sized_button, swatch_with_shortcut, text_button,
@@ -119,37 +117,29 @@ fn top_default_width(snapshot: &ToolbarSnapshot) -> i32 {
 }
 
 fn ring_row_active(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> bool {
-    let is_simple = snapshot.layout_mode == ToolbarLayoutMode::Simple;
-    (snapshot.use_icons || plan.compact)
-        && !is_simple
-        && snapshot.highlight_tool_active
-        && model::top_highlight_ring_visible(snapshot)
-        && model::visible_top_utility_buttons(snapshot, is_simple, snapshot.use_icons)
-            .contains(&model::TopUtilityButton::Highlight)
-        && !plan
-            .dropped_utilities
-            .contains(&model::TopUtilityButton::Highlight)
+    model::TopToolbarSpec::contextual_highlight_ring_visible(snapshot, plan)
 }
 
-/// Tooltip for a tool button: label plus binding and/or drag hint,
-/// mirroring the built-in `tool_tooltip`.
-fn tool_tooltip(snapshot: &ToolbarSnapshot, tool: Tool) -> String {
-    let label = tool_tooltip_label(tool);
-    let default_hint = model::default_drag_hint(tool);
-    let binding = match (snapshot.binding_hints.for_tool(tool), default_hint) {
-        (Some(binding), Some(fallback)) => Some(format!("{binding}, {fallback}")),
-        (Some(binding), None) => Some(binding.to_string()),
-        (None, Some(fallback)) => Some(fallback.to_string()),
-        (None, None) => None,
-    };
-    format_binding_label(label, binding.as_deref())
+/// Attach the renderer-neutral id to concrete widgets in test builds so the
+/// contract suite can read the actual GTK adapter tree without widening the
+/// production CSS surface.
+fn set_semantic_widget_id(_widget: &impl IsA<gtk4::Widget>, _id: &str) {
+    #[cfg(test)]
+    _widget.as_ref().set_widget_name(_id);
 }
 
-fn action_tooltip(snapshot: &ToolbarSnapshot, action: Action) -> String {
-    format_binding_label(
-        action_label(action),
-        snapshot.binding_hints.binding_for_action(action),
-    )
+fn set_control_widget_id(_widget: &impl IsA<gtk4::Widget>, _control: model::TopToolbarControl) {
+    #[cfg(test)]
+    set_semantic_widget_id(_widget, _control.id().render_id().as_ref());
+}
+
+fn set_prefixed_control_widget_id(
+    _widget: &impl IsA<gtk4::Widget>,
+    _prefix: &str,
+    _control: model::TopToolbarControl,
+) {
+    #[cfg(test)]
+    set_semantic_widget_id(_widget, &format!("{_prefix}{}", _control.id().render_id()));
 }
 
 pub(in crate::toolbar_gtk) struct TopBar {
@@ -199,6 +189,19 @@ impl TopBar {
         // (panels/bars) and do not reserve one.
         window.set_exclusive_zone(-1);
 
+        Self::with_window(feedback, window)
+    }
+
+    /// Build an unpresented GTK widget tree without layer-shell side effects.
+    /// This keeps adapter contract tests usable on any GTK display backend.
+    #[cfg(test)]
+    fn new_for_test(feedback: FeedbackSender) -> Self {
+        let window = gtk4::Window::new();
+        window.add_css_class("wayscriber-toolbar");
+        Self::with_window(feedback, window)
+    }
+
+    fn with_window(feedback: FeedbackSender, window: gtk4::Window) -> Self {
         let root = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
         root.add_css_class("panel");
         window.set_child(Some(&root));
@@ -313,7 +316,7 @@ impl TopBar {
         self.updaters.borrow_mut().clear();
 
         if snapshot.top_minimized {
-            self.build_minimized(snapshot);
+            self.build_minimized(snapshot, plan);
         } else {
             self.build_strip(snapshot, plan);
         }

--- a/src/toolbar_gtk/view/top_bar/controls.rs
+++ b/src/toolbar_gtk/view/top_bar/controls.rs
@@ -5,77 +5,80 @@
 use super::popovers::attach_escape_dismiss;
 use super::*;
 
-type UtilitySpec = (
-    Action,
-    crate::toolbar_gtk::icons::IconPainter,
-    &'static str,
-    String,
-    ToolbarEvent,
-    Option<fn(&ToolbarSnapshot) -> bool>,
-);
+pub(super) fn event_for_toggle_state(
+    control: model::TopToolbarControl,
+    next_active: bool,
+) -> ToolbarEvent {
+    match control {
+        model::TopToolbarControl::ShapePicker => ToolbarEvent::ToggleShapePicker(next_active),
+        model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight) => {
+            ToolbarEvent::ToggleAllHighlight(next_active)
+        }
+        model::TopToolbarControl::Pin => ToolbarEvent::PinTopToolbar(next_active),
+        model::TopToolbarControl::Overflow => ToolbarEvent::ToggleTopOverflow(next_active),
+        model::TopToolbarControl::HighlightRing => {
+            ToolbarEvent::ToggleHighlightToolRing(next_active)
+        }
+        _ => unreachable!("non-toggle control in GTK toggle adapter"),
+    }
+}
 
 impl TopBar {
     pub(super) fn tool_button(
         &mut self,
         snapshot: &ToolbarSnapshot,
-        tool: Tool,
+        control: model::TopToolbarControl,
         button_size: (f64, f64),
         icon_size: f64,
         use_icons: bool,
         show_badge: bool,
     ) -> gtk4::Button {
-        let tooltip = tool_tooltip(snapshot, tool);
-        let button = if use_icons {
-            icon_button(tool_icon_painter(tool), button_size, icon_size, &tooltip).button
-        } else {
-            text_button(tool_label(tool), button_size, &tooltip)
-        };
-        if show_badge {
-            add_shortcut_badge(&button, snapshot.binding_hints.badge_for_tool(tool));
-        }
-        let sender = self.feedback.clone();
-        button.connect_clicked(move |_| {
-            send_event(&sender, ToolbarEvent::SelectTool(tool));
-        });
-        let handle = button.clone();
-        self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-            let active = snapshot.active_tool == tool || snapshot.tool_override == Some(tool);
-            set_active_class(&handle, active);
-        }));
-        button
+        assert!(matches!(control, model::TopToolbarControl::Tool(_)));
+        self.action_button(
+            snapshot,
+            control,
+            button_size,
+            icon_size,
+            use_icons,
+            show_badge,
+        )
     }
 
     /// Shapes picker button: the family icon opens the grid and per-tool
     /// option rows; individual shapes keep their own icons inside the popover.
     pub(super) fn shapes_picker_button(
         &mut self,
-        _snapshot: &ToolbarSnapshot,
+        snapshot: &ToolbarSnapshot,
+        control: model::TopToolbarControl,
         button_size: (f64, f64),
         icon_size: f64,
         use_icons: bool,
     ) -> gtk4::Button {
+        assert_eq!(control, model::TopToolbarControl::ShapePicker);
+        let tooltip = control.tooltip(snapshot);
+        let label = control.label(snapshot);
         let button = if use_icons {
             icon_button(
-                toolbar_icons::draw_icon_shape_picker,
+                top_toolbar_icon_painter(control.icon(snapshot).expect("shape-picker icon")),
                 button_size,
                 icon_size,
-                "Shapes",
+                &tooltip,
             )
             .button
         } else {
-            text_button("Shapes", button_size, "Shapes")
+            text_button(&label, button_size, &tooltip)
         };
+        set_control_widget_id(&button, control);
+        let accessible_label = control.accessible_label(snapshot);
+        button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
         let sender = self.feedback.clone();
         let expected = self.shapes_expected_open.clone();
         button.connect_clicked(move |_| {
-            send_event(&sender, ToolbarEvent::ToggleShapePicker(!expected.get()));
+            send_event(&sender, event_for_toggle_state(control, !expected.get()));
         });
         let handle = button.clone();
         self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-            let active = snapshot.shape_picker_open
-                || model::current_shape_tool(snapshot.active_tool, snapshot.tool_override)
-                    .is_some();
-            set_active_class(&handle, active);
+            set_active_class(&handle, control.active(snapshot));
         }));
 
         let popover = gtk4::Popover::new();
@@ -89,13 +92,13 @@ impl TopBar {
         attach_escape_dismiss(
             &popover,
             &self.feedback,
-            ToolbarEvent::ToggleShapePicker(false),
+            event_for_toggle_state(control, false),
         );
         let sender = self.feedback.clone();
         let expected = self.shapes_expected_open.clone();
         popover.connect_closed(move |_| {
             if expected.get() {
-                send_event(&sender, ToolbarEvent::ToggleShapePicker(false));
+                send_event(&sender, event_for_toggle_state(control, false));
             }
         });
         self.shapes_popover = Some(popover);
@@ -105,131 +108,122 @@ impl TopBar {
     pub(super) fn utility_button(
         &mut self,
         snapshot: &ToolbarSnapshot,
-        utility: model::TopUtilityButton,
+        control: model::TopToolbarControl,
         button_size: (f64, f64),
         icon_size: f64,
         use_icons: bool,
         show_badge: bool,
     ) -> Option<gtk4::Button> {
-        let (action, painter, label, tooltip, event, active): UtilitySpec = match utility {
-            model::TopUtilityButton::Text => (
-                Action::EnterTextMode,
-                toolbar_icons::draw_icon_text,
-                action_short_label(Action::EnterTextMode),
-                action_tooltip(snapshot, Action::EnterTextMode),
-                ToolbarEvent::EnterTextMode,
-                Some(|snapshot| snapshot.text_active),
-            ),
-            model::TopUtilityButton::StickyNote => (
-                Action::EnterStickyNoteMode,
-                toolbar_icons::draw_icon_note,
-                action_short_label(Action::EnterStickyNoteMode),
-                action_tooltip(snapshot, Action::EnterStickyNoteMode),
-                ToolbarEvent::EnterStickyNoteMode,
-                Some(|snapshot| snapshot.note_active),
-            ),
-            model::TopUtilityButton::Screenshot => (
-                Action::CaptureSelection,
-                toolbar_icons::draw_icon_screenshot,
-                "Shot",
-                action_tooltip(snapshot, Action::CaptureSelection),
-                ToolbarEvent::CaptureScreenshot,
-                None,
-            ),
-            model::TopUtilityButton::Highlight => (
-                Action::ToggleHighlightTool,
-                toolbar_icons::draw_icon_highlight,
-                "Highlight",
-                action_tooltip(snapshot, Action::ToggleHighlightTool),
-                // The click handler recomputes the toggle from live state.
-                ToolbarEvent::ToggleAllHighlight(true),
-                Some(|snapshot| snapshot.any_highlight_active),
-            ),
-            model::TopUtilityButton::ClearCanvas | model::TopUtilityButton::IconMode => {
-                return None;
-            }
-        };
-        let button = if use_icons {
-            icon_button(painter, button_size, icon_size, &tooltip).button
-        } else {
-            text_button(label, button_size, &tooltip)
-        };
-        if show_badge {
-            add_shortcut_badge(&button, snapshot.binding_hints.badge_for_action(action));
+        match control {
+            model::TopToolbarControl::Utility(_) => Some(self.action_button(
+                snapshot,
+                control,
+                button_size,
+                icon_size,
+                use_icons,
+                show_badge,
+            )),
+            _ => unreachable!("utility adapter received non-utility control"),
         }
-        let sender = self.feedback.clone();
-        if utility == model::TopUtilityButton::Highlight {
-            // Highlight toggles off the *current* state rather than firing a
-            // fixed event.
-            let active_state = Rc::new(Cell::new(snapshot.any_highlight_active));
-            let click_state = active_state.clone();
-            button.connect_clicked(move |_| {
-                send_event(
-                    &sender,
-                    ToolbarEvent::ToggleAllHighlight(!click_state.get()),
-                );
-            });
-            let handle = button.clone();
-            self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-                active_state.set(snapshot.any_highlight_active);
-                set_active_class(&handle, snapshot.any_highlight_active);
-            }));
-        } else {
-            button.connect_clicked(move |_| {
-                send_event(&sender, event.clone());
-            });
-            if let Some(is_active) = active {
-                let handle = button.clone();
-                self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-                    set_active_class(&handle, is_active(snapshot));
-                }));
-            }
-        }
-        Some(button)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn history_button(
         &mut self,
         snapshot: &ToolbarSnapshot,
-        painter: crate::toolbar_gtk::icons::IconPainter,
-        action: Action,
-        event: ToolbarEvent,
-        available: fn(&ToolbarSnapshot) -> bool,
+        control: model::TopToolbarControl,
         button_size: (f64, f64),
         icon_size: f64,
         use_icons: bool,
         show_badge: bool,
     ) -> gtk4::Button {
-        let tooltip = action_tooltip(snapshot, action);
+        assert!(matches!(
+            control,
+            model::TopToolbarControl::Undo | model::TopToolbarControl::Redo
+        ));
+        self.action_button(
+            snapshot,
+            control,
+            button_size,
+            icon_size,
+            use_icons,
+            show_badge,
+        )
+    }
+
+    pub(super) fn action_button(
+        &mut self,
+        snapshot: &ToolbarSnapshot,
+        control: model::TopToolbarControl,
+        button_size: (f64, f64),
+        icon_size: f64,
+        use_icons: bool,
+        show_badge: bool,
+    ) -> gtk4::Button {
+        let tooltip = control.tooltip(snapshot);
+        let label = control.label(snapshot);
         let button = if use_icons {
-            icon_button(painter, button_size, icon_size, &tooltip).button
+            icon_button(
+                top_toolbar_icon_painter(control.icon(snapshot).expect("action icon")),
+                button_size,
+                icon_size,
+                &tooltip,
+            )
+            .button
         } else {
-            text_button(action_short_label(action), button_size, &tooltip)
+            text_button(&label, button_size, &tooltip)
         };
+        set_control_widget_id(&button, control);
+        let accessible_label = control.accessible_label(snapshot);
+        button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
         if show_badge {
-            add_shortcut_badge(&button, snapshot.binding_hints.badge_for_action(action));
+            let badge = control.shortcut_badge(snapshot);
+            add_shortcut_badge(&button, badge.as_deref());
         }
         let sender = self.feedback.clone();
-        button.connect_clicked(move |_| {
-            send_event(&sender, event.clone());
-        });
+        if matches!(
+            control,
+            model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight)
+        ) {
+            let active = Rc::new(Cell::new(control.active(snapshot)));
+            let click_active = active.clone();
+            button.connect_clicked(move |_| {
+                send_event(
+                    &sender,
+                    event_for_toggle_state(control, !click_active.get()),
+                );
+            });
+            let handle = button.clone();
+            self.updaters.borrow_mut().push(Box::new(move |snapshot| {
+                active.set(control.active(snapshot));
+                set_active_class(&handle, control.active(snapshot));
+                handle.set_sensitive(control.enabled(snapshot));
+            }));
+            return button;
+        }
+        let event = control.event(snapshot);
+        button.connect_clicked(move |_| send_event(&sender, event.clone()));
         let handle = button.clone();
         self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-            handle.set_sensitive(available(snapshot));
+            set_active_class(&handle, control.active(snapshot));
+            handle.set_sensitive(control.enabled(snapshot));
         }));
         button
     }
 
-    pub(super) fn pin_button(&mut self, snapshot: &ToolbarSnapshot, size: f64) -> gtk4::Button {
+    pub(super) fn pin_button(
+        &mut self,
+        snapshot: &ToolbarSnapshot,
+        control: model::TopToolbarControl,
+        size: f64,
+    ) -> gtk4::Button {
+        assert_eq!(control, model::TopToolbarControl::Pin);
         let button = sized_button(size, size);
+        set_control_widget_id(&button, control);
         button.add_css_class("chrome");
+        let accessible_label = control.accessible_label(snapshot);
+        button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
         let icon = IconWidget::new(
-            if snapshot.top_pinned {
-                toolbar_icons::draw_icon_pin
-            } else {
-                toolbar_icons::draw_icon_unpin
-            },
+            top_toolbar_icon_painter(control.icon(snapshot).expect("pin icon")),
             size * 0.62,
         );
         button.set_child(Some(&icon.area));
@@ -237,23 +231,25 @@ impl TopBar {
         let pinned = Rc::new(Cell::new(snapshot.top_pinned));
         let click_pinned = pinned.clone();
         button.connect_clicked(move |_| {
-            send_event(&sender, ToolbarEvent::PinTopToolbar(!click_pinned.get()));
+            send_event(
+                &sender,
+                event_for_toggle_state(control, !click_pinned.get()),
+            );
         });
         let handle = button.clone();
         self.updaters.borrow_mut().push(Box::new(move |snapshot| {
             pinned.set(snapshot.top_pinned);
-            icon.set_painter(if snapshot.top_pinned {
-                toolbar_icons::draw_icon_pin
-            } else {
-                toolbar_icons::draw_icon_unpin
-            });
+            icon.set_painter(top_toolbar_icon_painter(
+                control.icon(snapshot).expect("pin icon"),
+            ));
             if snapshot.top_pinned {
                 handle.add_css_class("pinned");
-                handle.set_tooltip_text(Some("Pinned: opens at startup (click to disable)"));
             } else {
                 handle.remove_css_class("pinned");
-                handle.set_tooltip_text(Some("Pin: click to open at startup"));
             }
+            let accessible_label = control.accessible_label(snapshot);
+            handle.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
+            handle.set_tooltip_text(Some(&control.tooltip(snapshot)));
         }));
         button
     }
@@ -261,26 +257,30 @@ impl TopBar {
     pub(super) fn overflow_button(
         &mut self,
         snapshot: &ToolbarSnapshot,
-        _plan: &TopStripPlan,
+        control: model::TopToolbarControl,
         size: f64,
-        _use_icons: bool,
     ) -> gtk4::Button {
+        assert_eq!(control, model::TopToolbarControl::Overflow);
         let button = sized_button(size, size);
+        set_control_widget_id(&button, control);
         button.add_css_class("chrome");
-        button.set_tooltip_text(Some("More tools"));
-        let icon = IconWidget::new(toolbar_icons::draw_icon_more, size * 0.7);
+        let accessible_label = control.accessible_label(snapshot);
+        button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
+        button.set_tooltip_text(Some(&control.tooltip(snapshot)));
+        let icon = IconWidget::new(
+            top_toolbar_icon_painter(control.icon(snapshot).expect("overflow icon")),
+            size * 0.7,
+        );
         button.set_child(Some(&icon.area));
         let sender = self.feedback.clone();
         let expected = self.overflow_expected_open.clone();
         button.connect_clicked(move |_| {
-            send_event(&sender, ToolbarEvent::ToggleTopOverflow(!expected.get()));
+            send_event(&sender, event_for_toggle_state(control, !expected.get()));
         });
         let handle = button.clone();
         self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-            set_active_class(&handle, snapshot.top_overflow_open);
+            set_active_class(&handle, control.active(snapshot));
         }));
-        let _ = snapshot;
-
         let popover = gtk4::Popover::new();
         popover.set_parent(&button);
         popover.set_position(gtk4::PositionType::Bottom);
@@ -289,29 +289,42 @@ impl TopBar {
         attach_escape_dismiss(
             &popover,
             &self.feedback,
-            ToolbarEvent::ToggleTopOverflow(false),
+            event_for_toggle_state(control, false),
         );
         let sender = self.feedback.clone();
         let expected = self.overflow_expected_open.clone();
         popover.connect_closed(move |_| {
             if expected.get() {
-                send_event(&sender, ToolbarEvent::ToggleTopOverflow(false));
+                send_event(&sender, event_for_toggle_state(control, false));
             }
         });
         self.overflow_popover = Some(popover);
         button
     }
 
-    pub(super) fn minimize_button(&mut self, size: f64) -> gtk4::Button {
+    pub(super) fn minimize_button(
+        &mut self,
+        snapshot: &ToolbarSnapshot,
+        control: model::TopToolbarControl,
+        size: f64,
+    ) -> gtk4::Button {
+        assert_eq!(control, model::TopToolbarControl::Minimize);
         let button = sized_button(size, size);
+        set_control_widget_id(&button, control);
         button.add_css_class("chrome");
         button.add_css_class("minimize");
-        button.set_tooltip_text(Some("Minimize (leaves a restore tab)"));
-        let icon = IconWidget::new(toolbar_icons::draw_icon_minimize, size * 0.6);
+        let accessible_label = control.accessible_label(snapshot);
+        button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
+        button.set_tooltip_text(Some(&control.tooltip(snapshot)));
+        let icon = IconWidget::new(
+            top_toolbar_icon_painter(control.icon(snapshot).expect("minimize icon")),
+            size * 0.6,
+        );
         button.set_child(Some(&icon.area));
         let sender = self.feedback.clone();
+        let event = control.event(snapshot);
         button.connect_clicked(move |_| {
-            send_event(&sender, ToolbarEvent::SetTopMinimized(true));
+            send_event(&sender, event.clone());
         });
         button
     }

--- a/src/toolbar_gtk/view/top_bar/popovers.rs
+++ b/src/toolbar_gtk/view/top_bar/popovers.rs
@@ -23,7 +23,7 @@ impl TopBar {
         let icon_size = ICON_SIZE * scale;
 
         if let Some(popover) = self.shapes_popover.clone() {
-            let open = snapshot.shape_picker_open && model::top_shape_picker_visible(snapshot);
+            let open = snapshot.shape_picker_open;
             if open {
                 // Only rebuild the grid when its inputs changed; a rebuild
                 // resets hover and cancels an in-flight press.
@@ -54,7 +54,7 @@ impl TopBar {
 
         if let Some(popover) = self.overflow_popover.clone() {
             let open = snapshot.top_overflow_open
-                && plan.dropped_tools.len() + plan.dropped_utilities.len() > 0;
+                && model::TopToolbarSpec::overflow_control_count(snapshot, plan) > 0;
             if open {
                 let content_key = (
                     snapshot.active_tool,
@@ -64,9 +64,10 @@ impl TopBar {
                     snapshot.any_highlight_active,
                 );
                 if self.overflow_content_key.get() != Some(content_key) {
+                    let spec = model::TopToolbarSpec::build(snapshot, plan);
                     popover.set_child(Some(&self.build_overflow_popover_content(
                         snapshot,
-                        plan,
+                        &spec,
                         button_size,
                         icon_size,
                         use_icons,
@@ -86,7 +87,7 @@ impl TopBar {
         }
     }
 
-    fn build_shapes_popover_content(
+    pub(super) fn build_shapes_popover_content(
         &self,
         snapshot: &ToolbarSnapshot,
         button_size: (f64, f64),
@@ -97,6 +98,7 @@ impl TopBar {
         let is_simple = snapshot.layout_mode == ToolbarLayoutMode::Simple;
         let gap = (GAP * scale).round() as i32;
         let content = gtk4::Box::new(gtk4::Orientation::Vertical, gap);
+        set_semantic_widget_id(&content, "top.shapes.panel");
 
         for row in model::visible_shape_picker_rows(snapshot, is_simple) {
             let row_box = gtk4::Box::new(gtk4::Orientation::Horizontal, gap);
@@ -104,20 +106,30 @@ impl TopBar {
                 if !model::tool_visible(snapshot, tool) {
                     continue;
                 }
-                let tooltip = tool_tooltip(snapshot, tool);
+                let control = model::TopToolbarControl::Tool(tool);
+                let tooltip = control.tooltip(snapshot);
+                let label = control.label(snapshot);
                 let button = if use_icons {
-                    icon_button(tool_icon_painter(tool), button_size, icon_size, &tooltip).button
+                    icon_button(
+                        top_toolbar_icon_painter(control.icon(snapshot).expect("tool icon")),
+                        button_size,
+                        icon_size,
+                        &tooltip,
+                    )
+                    .button
                 } else {
-                    text_button(tool_label(tool), button_size, &tooltip)
+                    text_button(&label, button_size, &tooltip)
                 };
-                add_shortcut_badge(&button, snapshot.binding_hints.badge_for_tool(tool));
-                set_active_class(
-                    &button,
-                    snapshot.active_tool == tool || snapshot.tool_override == Some(tool),
-                );
+                set_prefixed_control_widget_id(&button, "top.picker.", control);
+                let accessible_label = control.accessible_label(snapshot);
+                button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
+                let badge = control.shortcut_badge(snapshot);
+                add_shortcut_badge(&button, badge.as_deref());
+                set_active_class(&button, control.active(snapshot));
                 let sender = self.feedback.clone();
+                let event = control.event(snapshot);
                 button.connect_clicked(move |_| {
-                    send_event(&sender, ToolbarEvent::SelectTool(tool));
+                    send_event(&sender, event.clone());
                 });
                 row_box.append(&button);
             }
@@ -130,7 +142,11 @@ impl TopBar {
             model::fill_tool_active(snapshot.active_tool, snapshot.tool_override);
         if fill_tool_active && model::top_fill_visible(snapshot) {
             let fill = gtk4::CheckButton::with_label(action_short_label(Action::ToggleFill));
-            fill.set_tooltip_text(Some(&action_tooltip(snapshot, Action::ToggleFill)));
+            set_semantic_widget_id(
+                &fill,
+                crate::config::toolbar_item_ids::TOP_UTILITY_FILL.as_str(),
+            );
+            fill.set_tooltip_text(Some(&model::action_tooltip(snapshot, Action::ToggleFill)));
             // set_active runs before connect_toggled, so every later
             // toggle is user input and forwards unconditionally.
             fill.set_active(snapshot.fill_enabled);
@@ -146,6 +162,7 @@ impl TopBar {
             let row = gtk4::Box::new(gtk4::Orientation::Horizontal, gap);
             let side_button = (24.0 * scale, 24.0 * scale);
             let minus = text_button("−", side_button, "Fewer sides");
+            set_semantic_widget_id(&minus, "top.options.sides-minus");
             let sender = self.feedback.clone();
             minus.connect_clicked(move |_| {
                 send_event(&sender, ToolbarEvent::NudgePolygonSides(-1));
@@ -153,6 +170,7 @@ impl TopBar {
             let label = gtk4::Label::new(Some(&format!("{} sides", snapshot.polygon_sides)));
             label.set_hexpand(true);
             let plus = text_button("+", side_button, "More sides");
+            set_semantic_widget_id(&plus, "top.options.sides-plus");
             let sender = self.feedback.clone();
             plus.connect_clicked(move |_| {
                 send_event(&sender, ToolbarEvent::NudgePolygonSides(1));
@@ -167,10 +185,10 @@ impl TopBar {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn build_overflow_popover_content(
+    pub(super) fn build_overflow_popover_content(
         &self,
         snapshot: &ToolbarSnapshot,
-        plan: &TopStripPlan,
+        spec: &model::TopToolbarSpec,
         button_size: (f64, f64),
         icon_size: f64,
         use_icons: bool,
@@ -178,83 +196,41 @@ impl TopBar {
     ) -> gtk4::Grid {
         let gap = (GAP * scale).round() as i32;
         let grid = gtk4::Grid::new();
+        set_semantic_widget_id(&grid, "top.overflow.panel");
         grid.set_row_spacing(gap as u32);
         grid.set_column_spacing(gap as u32);
-        let dropped_count = plan.dropped_tools.len() + plan.dropped_utilities.len();
+        let dropped_count = spec.overflow().len();
         let cols = dropped_count.clamp(1, 5) as i32;
         let mut index = 0i32;
         let mut attach = |widget: &gtk4::Button| {
             grid.attach(widget, index % cols, index / cols, 1, 1);
             index += 1;
         };
-        for tool in &plan.dropped_tools {
-            let tool = *tool;
-            let tooltip = tool_tooltip(snapshot, tool);
+        for control in spec.overflow().iter().copied() {
+            let tooltip = control.overflow_tooltip(snapshot);
+            let label = control.label(snapshot);
             let button = if use_icons {
-                icon_button(tool_icon_painter(tool), button_size, icon_size, &tooltip).button
+                icon_button(
+                    top_toolbar_icon_painter(control.icon(snapshot).expect("overflow icon")),
+                    button_size,
+                    icon_size,
+                    &tooltip,
+                )
+                .button
             } else {
-                text_button(tool_label(tool), button_size, &tooltip)
+                text_button(&label, button_size, &tooltip)
             };
-            add_shortcut_badge(&button, snapshot.binding_hints.badge_for_tool(tool));
-            set_active_class(
-                &button,
-                snapshot.active_tool == tool || snapshot.tool_override == Some(tool),
-            );
+            set_prefixed_control_widget_id(&button, "top.overflow.", control);
+            let accessible_label = control.accessible_label(snapshot);
+            button.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
+            if button_size.0 > COMPACT_BUTTON * scale {
+                let badge = control.shortcut_badge(snapshot);
+                add_shortcut_badge(&button, badge.as_deref());
+            }
+            set_active_class(&button, control.active(snapshot));
+            button.set_sensitive(control.enabled(snapshot));
             let sender = self.feedback.clone();
-            button.connect_clicked(move |_| {
-                send_event(&sender, ToolbarEvent::SelectTool(tool));
-            });
-            attach(&button);
-        }
-        for utility in &plan.dropped_utilities {
-            let (action, painter, label, event, active): (
-                Action,
-                crate::toolbar_gtk::icons::IconPainter,
-                &str,
-                ToolbarEvent,
-                bool,
-            ) = match utility {
-                model::TopUtilityButton::Text => (
-                    Action::EnterTextMode,
-                    toolbar_icons::draw_icon_text,
-                    action_short_label(Action::EnterTextMode),
-                    ToolbarEvent::EnterTextMode,
-                    snapshot.text_active,
-                ),
-                model::TopUtilityButton::StickyNote => (
-                    Action::EnterStickyNoteMode,
-                    toolbar_icons::draw_icon_note,
-                    action_short_label(Action::EnterStickyNoteMode),
-                    ToolbarEvent::EnterStickyNoteMode,
-                    snapshot.note_active,
-                ),
-                model::TopUtilityButton::Screenshot => (
-                    Action::CaptureSelection,
-                    toolbar_icons::draw_icon_screenshot,
-                    "Shot",
-                    ToolbarEvent::CaptureScreenshot,
-                    false,
-                ),
-                model::TopUtilityButton::Highlight => (
-                    Action::ToggleHighlightTool,
-                    toolbar_icons::draw_icon_highlight,
-                    "Highlight",
-                    ToolbarEvent::ToggleAllHighlight(!snapshot.any_highlight_active),
-                    snapshot.any_highlight_active,
-                ),
-                model::TopUtilityButton::ClearCanvas | model::TopUtilityButton::IconMode => {
-                    continue;
-                }
-            };
-            let tooltip = action_tooltip(snapshot, action);
-            let button = if use_icons {
-                icon_button(painter, button_size, icon_size, &tooltip).button
-            } else {
-                text_button(label, button_size, &tooltip)
-            };
-            add_shortcut_badge(&button, snapshot.binding_hints.badge_for_action(action));
-            set_active_class(&button, active);
-            let sender = self.feedback.clone();
+            let event = control.event(snapshot);
             button.connect_clicked(move |_| {
                 send_event(&sender, event.clone());
             });

--- a/src/toolbar_gtk/view/top_bar/strip.rs
+++ b/src/toolbar_gtk/view/top_bar/strip.rs
@@ -5,8 +5,33 @@
 
 use super::*;
 
+pub(super) fn top_toolbar_spec(
+    snapshot: &ToolbarSnapshot,
+    plan: &TopStripPlan,
+) -> model::TopToolbarSpec {
+    model::TopToolbarSpec::build(snapshot, plan)
+}
+
+pub(super) fn quick_color_badge_row_visible(
+    snapshot: &ToolbarSnapshot,
+    spec: &model::TopToolbarSpec,
+) -> bool {
+    spec.strip().iter().any(|node| {
+        matches!(
+            node,
+            model::TopToolbarNode::Control(model::TopToolbarControl::QuickColor(index))
+                if snapshot.binding_hints.quick_color_badge(*index).is_some()
+        )
+    })
+}
+
 impl TopBar {
-    pub(super) fn build_minimized(&mut self, snapshot: &ToolbarSnapshot) {
+    pub(super) fn build_minimized(&mut self, snapshot: &ToolbarSnapshot, plan: &TopStripPlan) {
+        let spec = top_toolbar_spec(snapshot, plan);
+        let control = match spec.strip() {
+            [model::TopToolbarNode::Control(control)] => *control,
+            _ => unreachable!("minimized specification contains one restore control"),
+        };
         let scale = effective_scale(snapshot);
         // A GTK toplevel never shrinks on its own; reset the default size
         // or the tab keeps the full strip's width. The panel padding is
@@ -17,25 +42,26 @@ impl TopBar {
         );
         self.root.add_css_class("minimized");
         let restore = sized_button(MINIMIZED_SIZE.0 * scale, MINIMIZED_SIZE.1 * scale);
+        set_control_widget_id(&restore, control);
         restore.add_css_class("chrome");
-        restore.set_tooltip_text(Some("Show toolbar"));
+        let accessible_label = control.accessible_label(snapshot);
+        restore.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
+        restore.set_tooltip_text(Some(&control.tooltip(snapshot)));
         let icon = IconWidget::new(
-            toolbar_icons::draw_icon_restore,
+            top_toolbar_icon_painter(control.icon(snapshot).expect("restore icon")),
             (MINIMIZED_SIZE.1 * 0.75 * scale).min(18.0 * scale),
         );
         restore.set_child(Some(&icon.area));
         let sender = self.feedback.clone();
+        let event = control.event(snapshot);
         restore.connect_clicked(move |_| {
-            send_event(&sender, ToolbarEvent::SetTopMinimized(false));
+            send_event(&sender, event.clone());
         });
         self.root.append(&restore);
     }
 
-    // The running spec-unit `x` mirrors the builtin builder walk; the last
-    // increments are intentionally kept even where nothing reads them so
-    // the two walks stay line-for-line comparable.
-    #[allow(unused_assignments)]
     pub(super) fn build_strip(&mut self, snapshot: &ToolbarSnapshot, plan: &TopStripPlan) {
+        let spec = top_toolbar_spec(snapshot, plan);
         self.root.remove_css_class("minimized");
         // GTK toplevels retain their previous default width across widget-tree
         // rebuilds. Reset it from the shared natural-size calculation so a
@@ -44,7 +70,6 @@ impl TopBar {
         self.window
             .set_default_size(top_default_width(snapshot), -1);
         let scale = effective_scale(snapshot);
-        let is_simple = snapshot.layout_mode == ToolbarLayoutMode::Simple;
         let use_icons = snapshot.use_icons || plan.compact;
         let gap = if plan.compact { COMPACT_GAP } else { GAP };
         let (btn_w, btn_h) = if plan.compact {
@@ -66,8 +91,8 @@ impl TopBar {
         bar.set_margin_end(0);
         self.root.append(&bar);
 
-        // Running spec-unit x, mirroring the builtin builder walk; used to
-        // align the contextual ring row under the Highlight button.
+        // Running spec-unit x used to align the contextual ring row under
+        // the Highlight button selected by the shared specification.
         let mut x = if plan.compact {
             COMPACT_START_X
         } else {
@@ -79,9 +104,10 @@ impl TopBar {
             widget.set_margin_end(px(gap_units).max(0));
             bar.append(widget);
         };
-        let push_divider = |bar: &gtk4::Box, x: &mut f64| {
+        let push_divider = |bar: &gtk4::Box, x: &mut f64, kind: model::TopToolbarDivider| {
             let span = if plan.compact { 3.0 } else { DIVIDER_SPAN };
             let divider = gtk4::Separator::new(gtk4::Orientation::Vertical);
+            set_semantic_widget_id(&divider, kind.id());
             divider.set_margin_top(px(6.0));
             divider.set_margin_bottom(px(6.0));
             divider.set_margin_start(px((span - 1.0) / 2.0));
@@ -90,237 +116,183 @@ impl TopBar {
             *x += span + gap;
         };
 
-        // --- Drag grip -----------------------------------------------------
-        if model::toolbar_item_visible(snapshot, crate::config::toolbar_item_ids::TOP_CHROME_DRAG) {
-            let grip = IconWidget::new(toolbar_icons::draw_icon_drag, sz(HANDLE_SIZE));
-            grip.area.set_can_target(true);
-            grip.area.add_css_class("drag-handle");
-            grip.area.set_tooltip_text(Some("Drag toolbar"));
-            grip.area.set_valign(gtk4::Align::Center);
-            grip.area.set_cursor_from_name(Some("grab"));
-            self.attach_move_drag(&grip.area);
-            append_gap(&bar, grip.area.as_ref(), gap);
-            x += HANDLE_SIZE + gap;
-        }
-
-        // --- Tool groups: pens | shapes --------------------------------------
-        let mut previous_group: Option<model::TopToolGroup> = None;
-        let mut tool_drawn = false;
-        for tool in model::visible_top_tool_buttons(is_simple, snapshot) {
-            if plan.dropped_tools.contains(&tool) {
-                continue;
-            }
-            let group = model::top_tool_group(tool);
-            if let Some(previous) = previous_group
-                && previous != group
-            {
-                push_divider(&bar, &mut x);
-            }
-            previous_group = Some(group);
-            let button = self.tool_button(
-                snapshot,
-                tool,
-                (sz(btn_w), sz(btn_h)),
-                sz(ICON_SIZE),
-                use_icons,
-                !plan.compact,
-            );
-            append_gap(&bar, button.as_ref(), gap);
-            x += btn_w + gap;
-            tool_drawn = true;
-        }
-
-        // --- Shapes picker ----------------------------------------------------
-        if model::top_shape_picker_visible(snapshot) {
-            if previous_group == Some(model::TopToolGroup::Pens) {
-                push_divider(&bar, &mut x);
-            }
-            let button = self.shapes_picker_button(
-                snapshot,
-                (sz(btn_w), sz(btn_h)),
-                sz(ICON_SIZE),
-                use_icons,
-            );
-            append_gap(&bar, button.as_ref(), gap);
-            x += btn_w + gap;
-            tool_drawn = true;
-        }
-
-        // --- Annotation utilities (Clear pulled out below) --------------------
-        let utilities: Vec<model::TopUtilityButton> =
-            model::visible_top_utility_buttons(snapshot, is_simple, snapshot.use_icons)
-                .into_iter()
-                .filter(|button| *button != model::TopUtilityButton::ClearCanvas)
-                .filter(|button| !plan.dropped_utilities.contains(button))
-                .collect();
-        let clear_visible =
-            model::visible_top_utility_buttons(snapshot, is_simple, snapshot.use_icons)
-                .contains(&model::TopUtilityButton::ClearCanvas);
-        if !utilities.is_empty() && tool_drawn {
-            push_divider(&bar, &mut x);
-        }
-        for utility in utilities {
-            if utility == model::TopUtilityButton::Highlight {
-                highlight_x = Some(x);
-            }
-            if let Some(button) = self.utility_button(
-                snapshot,
-                utility,
-                (sz(btn_w), sz(btn_h)),
-                sz(ICON_SIZE),
-                use_icons,
-                !plan.compact,
-            ) {
-                append_gap(&bar, button.as_ref(), gap);
-                x += btn_w + gap;
-            }
-        }
-
-        // --- Quick colors + current-color chip --------------------------------
-        if model::toolbar_item_visible(
-            snapshot,
-            crate::config::toolbar_item_ids::TOP_GROUP_QUICK_COLORS,
-        ) {
-            push_divider(&bar, &mut x);
-            let show_swatch_badge_row = !plan.compact
-                && snapshot
-                    .quick_colors
-                    .rendered_entries()
-                    .iter()
-                    .take(plan.swatch_count)
-                    .enumerate()
-                    .any(|(index, _)| snapshot.binding_hints.quick_color_badge(index).is_some());
-            for (index, entry) in snapshot
-                .quick_colors
-                .rendered_entries()
-                .iter()
-                .take(plan.swatch_count)
-                .enumerate()
-            {
-                let entry_color = entry.color;
-                let action = crate::config::QuickColorPalette::action_for_index(index);
-                let binding =
-                    action.and_then(|action| snapshot.binding_hints.binding_for_action(action));
-                let tooltip = format_binding_label(&entry.label, binding);
-                let swatch = SwatchButton::new(
-                    entry_color,
-                    entry_color == snapshot.color,
-                    sz(SWATCH_SIZE),
-                    &tooltip,
-                );
-                let sender = self.feedback.clone();
-                swatch.button.connect_clicked(move |_| {
-                    send_event(
-                        &sender,
-                        ToolbarEvent::SetQuickColor {
-                            color: entry_color,
-                            action,
-                        },
-                    );
-                });
-                let is_last = index + 1
-                    == plan
-                        .swatch_count
-                        .min(snapshot.quick_colors.rendered_entries().len());
-                let badge = (!plan.compact)
-                    .then(|| snapshot.binding_hints.quick_color_badge(index))
-                    .flatten();
-                let swatch_root = if !show_swatch_badge_row {
-                    swatch.button.clone().upcast()
-                } else {
-                    swatch_with_shortcut(&swatch.button, badge, sz(SWATCH_SIZE), sz(10.0))
-                };
-                append_gap(&bar, &swatch_root, if is_last { gap } else { SWATCH_GAP });
-                x += SWATCH_SIZE + if is_last { gap } else { SWATCH_GAP };
-                self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-                    swatch.set_selected(entry_color == snapshot.color);
-                }));
-            }
-            let chip = SwatchButton::new(snapshot.color, true, sz(CHIP_SIZE), "Color picker");
-            let sender = self.feedback.clone();
-            chip.button.connect_clicked(move |_| {
-                send_event(&sender, ToolbarEvent::OpenColorPickerPopup);
-            });
-            append_gap(&bar, chip.button.as_ref(), gap);
-            x += CHIP_SIZE + gap;
-            self.updaters.borrow_mut().push(Box::new(move |snapshot| {
-                chip.set_color(snapshot.color);
-            }));
-        }
-
-        // --- History -----------------------------------------------------------
-        let undo_visible = model::toolbar_item_visible(
-            snapshot,
-            crate::config::toolbar_item_ids::TOP_UTILITY_UNDO,
-        );
-        let redo_visible = model::toolbar_item_visible(
-            snapshot,
-            crate::config::toolbar_item_ids::TOP_UTILITY_REDO,
-        );
-        if undo_visible || redo_visible {
-            push_divider(&bar, &mut x);
-        }
-        if undo_visible {
-            let button = self.history_button(
-                snapshot,
-                toolbar_icons::draw_icon_undo,
-                Action::Undo,
-                ToolbarEvent::Undo,
-                |snapshot| snapshot.undo_available,
-                (sz(btn_w), sz(btn_h)),
-                sz(ICON_SIZE),
-                use_icons,
-                !plan.compact,
-            );
-            append_gap(&bar, button.as_ref(), gap);
-            x += btn_w + gap;
-        }
-        if redo_visible {
-            let button = self.history_button(
-                snapshot,
-                toolbar_icons::draw_icon_redo,
-                Action::Redo,
-                ToolbarEvent::Redo,
-                |snapshot| snapshot.redo_available,
-                (sz(btn_w), sz(btn_h)),
-                sz(ICON_SIZE),
-                use_icons,
-                !plan.compact,
-            );
-            append_gap(&bar, button.as_ref(), gap);
-            x += btn_w + gap;
-        }
-
-        // --- Destructive Clear, isolated by a double gap -------------------------
-        if clear_visible {
-            let button = if use_icons {
-                let icon = icon_button(
-                    toolbar_icons::draw_icon_clear,
-                    (sz(btn_w), sz(btn_h)),
-                    sz(ICON_SIZE),
-                    &action_tooltip(snapshot, Action::ClearCanvas),
-                );
-                icon.button
-            } else {
-                text_button(
-                    action_short_label(Action::ClearCanvas),
-                    (sz(btn_w), sz(btn_h)),
-                    &action_tooltip(snapshot, Action::ClearCanvas),
+        let quick_color_count = spec
+            .strip()
+            .iter()
+            .filter(|node| {
+                matches!(
+                    node,
+                    model::TopToolbarNode::Control(model::TopToolbarControl::QuickColor(_))
                 )
-            };
-            if !plan.compact {
-                add_shortcut_badge(
-                    &button,
-                    snapshot.binding_hints.badge_for_action(Action::ClearCanvas),
-                );
+            })
+            .count();
+        let show_swatch_badge_row = quick_color_badge_row_visible(snapshot, &spec);
+        let mut quick_color_seen = 0usize;
+
+        for node in spec.strip() {
+            match *node {
+                model::TopToolbarNode::Divider(divider) => push_divider(&bar, &mut x, divider),
+                model::TopToolbarNode::Control(control) => match control {
+                    model::TopToolbarControl::DragHandle => {
+                        let grip = IconWidget::new(
+                            top_toolbar_icon_painter(control.icon(snapshot).expect("drag icon")),
+                            sz(HANDLE_SIZE),
+                        );
+                        set_control_widget_id(&grip.area, control);
+                        grip.area.set_can_target(true);
+                        grip.area.add_css_class("drag-handle");
+                        let accessible_label = control.accessible_label(snapshot);
+                        grip.area
+                            .update_property(&[gtk4::accessible::Property::Label(
+                                &accessible_label,
+                            )]);
+                        grip.area.set_tooltip_text(Some(&control.tooltip(snapshot)));
+                        grip.area.set_valign(gtk4::Align::Center);
+                        grip.area.set_cursor_from_name(Some("grab"));
+                        self.attach_move_drag(&grip.area);
+                        append_gap(&bar, grip.area.as_ref(), gap);
+                        x += HANDLE_SIZE + gap;
+                    }
+                    model::TopToolbarControl::Tool(_) => {
+                        let button = self.tool_button(
+                            snapshot,
+                            control,
+                            (sz(btn_w), sz(btn_h)),
+                            sz(ICON_SIZE),
+                            use_icons,
+                            !plan.compact,
+                        );
+                        append_gap(&bar, button.as_ref(), gap);
+                        x += btn_w + gap;
+                    }
+                    model::TopToolbarControl::ShapePicker => {
+                        let button = self.shapes_picker_button(
+                            snapshot,
+                            control,
+                            (sz(btn_w), sz(btn_h)),
+                            sz(ICON_SIZE),
+                            use_icons,
+                        );
+                        append_gap(&bar, button.as_ref(), gap);
+                        x += btn_w + gap;
+                    }
+                    model::TopToolbarControl::Utility(_) => {
+                        if matches!(
+                            control,
+                            model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight)
+                        ) {
+                            highlight_x = Some(x);
+                        }
+                        if let Some(button) = self.utility_button(
+                            snapshot,
+                            control,
+                            (sz(btn_w), sz(btn_h)),
+                            sz(ICON_SIZE),
+                            use_icons,
+                            !plan.compact,
+                        ) {
+                            append_gap(&bar, button.as_ref(), gap);
+                            x += btn_w + gap;
+                        }
+                    }
+                    model::TopToolbarControl::QuickColor(index) => {
+                        let entry_color = snapshot.quick_colors.rendered_entries()[index].color;
+                        let swatch = SwatchButton::new(
+                            entry_color,
+                            control.active(snapshot),
+                            sz(SWATCH_SIZE),
+                            &control.tooltip(snapshot),
+                        );
+                        let accessible_label = control.accessible_label(snapshot);
+                        swatch
+                            .button
+                            .update_property(&[gtk4::accessible::Property::Label(
+                                &accessible_label,
+                            )]);
+                        let sender = self.feedback.clone();
+                        let event = control.event(snapshot);
+                        swatch.button.connect_clicked(move |_| {
+                            send_event(&sender, event.clone());
+                        });
+                        quick_color_seen += 1;
+                        let is_last = quick_color_seen == quick_color_count;
+                        let badge = control.shortcut_badge(snapshot);
+                        let swatch_root = if !show_swatch_badge_row {
+                            swatch.button.clone().upcast()
+                        } else {
+                            swatch_with_shortcut(
+                                &swatch.button,
+                                badge.as_deref(),
+                                sz(SWATCH_SIZE),
+                                sz(10.0),
+                            )
+                        };
+                        set_control_widget_id(&swatch_root, control);
+                        append_gap(&bar, &swatch_root, if is_last { gap } else { SWATCH_GAP });
+                        x += SWATCH_SIZE + if is_last { gap } else { SWATCH_GAP };
+                        self.updaters.borrow_mut().push(Box::new(move |snapshot| {
+                            swatch.set_selected(entry_color == snapshot.color);
+                        }));
+                    }
+                    model::TopToolbarControl::CurrentColor => {
+                        let chip = SwatchButton::new(
+                            snapshot.color,
+                            control.active(snapshot),
+                            sz(CHIP_SIZE),
+                            &control.tooltip(snapshot),
+                        );
+                        set_control_widget_id(&chip.button, control);
+                        let accessible_label = control.accessible_label(snapshot);
+                        chip.button
+                            .update_property(&[gtk4::accessible::Property::Label(
+                                &accessible_label,
+                            )]);
+                        let sender = self.feedback.clone();
+                        let event = control.event(snapshot);
+                        chip.button.connect_clicked(move |_| {
+                            send_event(&sender, event.clone());
+                        });
+                        append_gap(&bar, chip.button.as_ref(), gap);
+                        x += CHIP_SIZE + gap;
+                        self.updaters.borrow_mut().push(Box::new(move |snapshot| {
+                            chip.set_color(snapshot.color);
+                        }));
+                    }
+                    model::TopToolbarControl::Undo | model::TopToolbarControl::Redo => {
+                        let button = self.history_button(
+                            snapshot,
+                            control,
+                            (sz(btn_w), sz(btn_h)),
+                            sz(ICON_SIZE),
+                            use_icons,
+                            !plan.compact,
+                        );
+                        append_gap(&bar, button.as_ref(), gap);
+                        x += btn_w + gap;
+                    }
+                    model::TopToolbarControl::ClearCanvas => {
+                        let button = self.action_button(
+                            snapshot,
+                            control,
+                            (sz(btn_w), sz(btn_h)),
+                            sz(ICON_SIZE),
+                            use_icons,
+                            !plan.compact,
+                        );
+                        button.add_css_class("destructive");
+                        button.set_margin_start(px(gap));
+                        append_gap(&bar, button.as_ref(), gap);
+                        x += btn_w + gap * 2.0;
+                    }
+                    model::TopToolbarControl::Restore
+                    | model::TopToolbarControl::Pin
+                    | model::TopToolbarControl::Overflow
+                    | model::TopToolbarControl::Minimize
+                    | model::TopToolbarControl::HighlightRing => {
+                        unreachable!("control belongs outside the main strip")
+                    }
+                },
             }
-            button.add_css_class("destructive");
-            button.set_margin_start(px(gap));
-            let sender = self.feedback.clone();
-            button.connect_clicked(move |_| {
-                send_event(&sender, ToolbarEvent::ClearCanvas);
-            });
-            append_gap(&bar, button.as_ref(), gap);
         }
 
         // --- Right-aligned chrome -----------------------------------------------
@@ -341,26 +313,33 @@ impl TopBar {
             PIN_MARGIN_RIGHT
         }));
         chrome.set_valign(gtk4::Align::Center);
-        if model::toolbar_item_visible(snapshot, crate::config::toolbar_item_ids::TOP_CHROME_PIN) {
-            chrome.append(&self.pin_button(snapshot, sz(chrome_size)));
-        }
-        if plan.show_overflow {
-            chrome.append(&self.overflow_button(snapshot, plan, sz(chrome_size), use_icons));
-        }
-        if model::toolbar_item_visible(snapshot, crate::config::toolbar_item_ids::TOP_CHROME_CLOSE)
-        {
-            chrome.append(&self.minimize_button(sz(chrome_size)));
+        for control in spec.chrome().iter().copied() {
+            match control {
+                model::TopToolbarControl::Pin => {
+                    chrome.append(&self.pin_button(snapshot, control, sz(chrome_size)));
+                }
+                model::TopToolbarControl::Overflow => {
+                    chrome.append(&self.overflow_button(snapshot, control, sz(chrome_size)));
+                }
+                model::TopToolbarControl::Minimize => {
+                    chrome.append(&self.minimize_button(snapshot, control, sz(chrome_size)));
+                }
+                _ => unreachable!("non-chrome control in chrome specification"),
+            }
         }
         bar.append(&chrome);
 
         // --- Contextual highlight ring row ----------------------------------------
-        if ring_row_active(snapshot, plan)
+        if let Some(control) = spec.contextual().first().copied()
             && let Some(ring_x) = highlight_x
         {
-            let ring = gtk4::CheckButton::with_label("Ring");
+            let ring = gtk4::CheckButton::with_label(&control.label(snapshot));
+            set_control_widget_id(&ring, control);
+            let accessible_label = control.accessible_label(snapshot);
+            ring.update_property(&[gtk4::accessible::Property::Label(&accessible_label)]);
             ring.add_css_class("mini");
-            ring.set_tooltip_text(Some("Highlight ring"));
-            ring.set_active(snapshot.highlight_tool_ring_enabled);
+            ring.set_tooltip_text(Some(&control.tooltip(snapshot)));
+            ring.set_active(control.active(snapshot));
             ring.set_halign(gtk4::Align::Start);
             ring.set_margin_start(px(ring_x));
             ring.set_margin_top(px(2.0));
@@ -371,7 +350,7 @@ impl TopBar {
                 if !toggle_sync.get() {
                     send_event(
                         &sender,
-                        ToolbarEvent::ToggleHighlightToolRing(check.is_active()),
+                        super::controls::event_for_toggle_state(control, check.is_active()),
                     );
                 }
             });

--- a/src/toolbar_gtk/view/top_bar/tests.rs
+++ b/src/toolbar_gtk/view/top_bar/tests.rs
@@ -1,11 +1,14 @@
 //! GTK top-strip unit tests.
 
 use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::time::Duration;
 
 use super::*;
 use crate::config::KeyBinding;
 use crate::input::state::test_support::make_test_input_state;
 use crate::ui::toolbar::ToolbarBindingHints;
+use gtk4::prelude::*;
 
 #[test]
 fn top_structure_rebuilds_when_current_shortcuts_change() {
@@ -65,4 +68,840 @@ fn degraded_layout_requests_the_selected_plan_width() {
     let plan = plan_top_strip(&snapshot);
     assert!(plan.compact || plan.show_overflow || plan.swatch_count < 8);
     assert!(top_default_width(&snapshot) <= 700);
+}
+
+#[test]
+fn compact_adapter_keeps_quick_color_shortcut_badges() {
+    let state = make_test_input_state();
+    let snapshot = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    let mut plan = TopStripPlan::unconstrained();
+    plan.compact = true;
+    plan.swatch_count = 2;
+    let spec = super::strip::top_toolbar_spec(&snapshot, &plan);
+
+    assert!(super::strip::quick_color_badge_row_visible(
+        &snapshot, &spec
+    ));
+    assert!(spec.strip().iter().any(|node| {
+        matches!(
+            node,
+            model::TopToolbarNode::Control(model::TopToolbarControl::QuickColor(index))
+                if model::TopToolbarControl::QuickColor(*index)
+                    .shortcut_badge(&snapshot)
+                    .is_some()
+        )
+    }));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticLane {
+    Strip,
+    Contextual,
+    Chrome,
+    Overflow,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct SemanticControlRecord {
+    lane: SemanticLane,
+    id: String,
+    event: ToolbarEvent,
+    label: String,
+    accessible_label: String,
+    tooltip: String,
+    shortcut_badge: Option<String>,
+    enabled: bool,
+    active: bool,
+    role: model::TopToolbarControlRole,
+    icon: Option<model::TopToolbarIcon>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum SemanticAdapterRecord {
+    Divider(&'static str),
+    Control(SemanticControlRecord),
+}
+
+fn control_record(
+    snapshot: &ToolbarSnapshot,
+    lane: SemanticLane,
+    control: model::TopToolbarControl,
+    show_badge: bool,
+) -> SemanticControlRecord {
+    SemanticControlRecord {
+        lane,
+        id: control.id().render_id().into_owned(),
+        event: control.event(snapshot),
+        label: control.label(snapshot).into_owned(),
+        accessible_label: control.accessible_label(snapshot).into_owned(),
+        tooltip: if lane == SemanticLane::Overflow {
+            control.overflow_tooltip(snapshot)
+        } else {
+            control.tooltip(snapshot)
+        },
+        shortcut_badge: show_badge
+            .then(|| control.shortcut_badge(snapshot))
+            .flatten(),
+        enabled: control.enabled(snapshot),
+        active: control.active(snapshot),
+        role: control.role(),
+        icon: control.icon(snapshot),
+    }
+}
+
+fn expected_semantic_records(
+    snapshot: &ToolbarSnapshot,
+    spec: &model::TopToolbarSpec,
+    plan: &TopStripPlan,
+) -> Vec<SemanticAdapterRecord> {
+    let mut records = Vec::new();
+    for node in spec.strip() {
+        match *node {
+            model::TopToolbarNode::Divider(divider) => {
+                records.push(SemanticAdapterRecord::Divider(divider.id()));
+            }
+            model::TopToolbarNode::Control(control) => {
+                let show_badge =
+                    matches!(control, model::TopToolbarControl::QuickColor(_)) || !plan.compact;
+                records.push(SemanticAdapterRecord::Control(control_record(
+                    snapshot,
+                    SemanticLane::Strip,
+                    control,
+                    show_badge,
+                )));
+                if matches!(
+                    control,
+                    model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight)
+                ) {
+                    records.extend(spec.contextual().iter().copied().map(|contextual| {
+                        SemanticAdapterRecord::Control(control_record(
+                            snapshot,
+                            SemanticLane::Contextual,
+                            contextual,
+                            false,
+                        ))
+                    }));
+                }
+            }
+        }
+    }
+    records.extend(spec.chrome().iter().copied().map(|control| {
+        SemanticAdapterRecord::Control(control_record(
+            snapshot,
+            SemanticLane::Chrome,
+            control,
+            false,
+        ))
+    }));
+    if snapshot.top_overflow_open {
+        records.extend(spec.overflow().iter().copied().map(|control| {
+            SemanticAdapterRecord::Control(control_record(
+                snapshot,
+                SemanticLane::Overflow,
+                control,
+                !plan.compact,
+            ))
+        }));
+    }
+    records
+}
+
+fn record_id(record: &SemanticAdapterRecord) -> &str {
+    match record {
+        SemanticAdapterRecord::Divider(id) => id,
+        SemanticAdapterRecord::Control(control) => &control.id,
+    }
+}
+
+fn record_lane(record: &SemanticAdapterRecord) -> SemanticLane {
+    match record {
+        SemanticAdapterRecord::Divider(_) => SemanticLane::Strip,
+        SemanticAdapterRecord::Control(control) => control.lane,
+    }
+}
+
+fn collect_semantic_widgets(root: &gtk4::Widget) -> Vec<gtk4::Widget> {
+    fn visit(widget: &gtk4::Widget, widgets: &mut Vec<gtk4::Widget>) {
+        if widget.widget_name().starts_with("top.") {
+            widgets.push(widget.clone());
+            return;
+        }
+        let mut child = widget.first_child();
+        while let Some(current) = child {
+            child = current.next_sibling();
+            visit(&current, widgets);
+        }
+    }
+
+    let mut widgets = Vec::new();
+    let mut child = root.first_child();
+    while let Some(current) = child {
+        child = current.next_sibling();
+        visit(&current, &mut widgets);
+    }
+    widgets
+}
+
+fn expected_main_widget_ids(spec: &model::TopToolbarSpec) -> Vec<String> {
+    let mut ids = spec
+        .strip()
+        .iter()
+        .map(|node| match node {
+            model::TopToolbarNode::Divider(divider) => divider.id().to_string(),
+            model::TopToolbarNode::Control(control) => control.id().render_id().into_owned(),
+        })
+        .collect::<Vec<_>>();
+    ids.extend(
+        spec.chrome()
+            .iter()
+            .chain(spec.contextual())
+            .map(|control| control.id().render_id().into_owned()),
+    );
+    ids
+}
+
+fn find_control_surface(root: &gtk4::Widget) -> Option<gtk4::Widget> {
+    if root.is::<gtk4::Button>() || root.is::<gtk4::CheckButton>() || root.is::<gtk4::DrawingArea>()
+    {
+        return Some(root.clone());
+    }
+    let mut child = root.first_child();
+    while let Some(current) = child {
+        child = current.next_sibling();
+        if let Some(surface) = find_control_surface(&current) {
+            return Some(surface);
+        }
+    }
+    None
+}
+
+fn first_control_surface(root: &gtk4::Widget) -> gtk4::Widget {
+    find_control_surface(root).unwrap_or_else(|| {
+        panic!(
+            "semantic widget has no control surface: {}",
+            root.widget_name()
+        )
+    })
+}
+
+fn shortcut_badge_text(root: &gtk4::Widget) -> Option<String> {
+    if let Ok(label) = root.clone().downcast::<gtk4::Label>()
+        && label.has_css_class("shortcut-badge")
+        && !label.text().is_empty()
+    {
+        return Some(label.text().to_string());
+    }
+    let mut child = root.first_child();
+    while let Some(current) = child {
+        child = current.next_sibling();
+        if let Some(text) = shortcut_badge_text(&current) {
+            return Some(text);
+        }
+    }
+    None
+}
+
+fn assert_accessible_label(widget: &gtk4::Widget, expected: &str, id: &str) {
+    let expected = CString::new(expected).expect("accessible label contains no NUL");
+    // GTK returns a newly allocated diagnostic string on mismatch and null
+    // when the live accessible property has the requested value.
+    let mismatch = unsafe {
+        gtk4::ffi::gtk_test_accessible_check_property(
+            widget.as_ptr().cast(),
+            gtk4::ffi::GTK_ACCESSIBLE_PROPERTY_LABEL,
+            expected.as_ptr(),
+        )
+    };
+    if mismatch.is_null() {
+        return;
+    }
+    let message = unsafe { CStr::from_ptr(mismatch) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { gtk4::glib::ffi::g_free(mismatch.cast()) };
+    panic!("{id} accessible label: {message}");
+}
+
+fn assert_gtk_control_widget(widget: &gtk4::Widget, expected: &SemanticControlRecord) {
+    let surface = first_control_surface(widget);
+    assert_accessible_label(&surface, &expected.accessible_label, &expected.id);
+    assert_eq!(
+        surface.tooltip_text().as_deref(),
+        Some(expected.tooltip.as_str()),
+        "{} tooltip",
+        expected.id
+    );
+    assert_eq!(
+        surface.is_sensitive(),
+        expected.enabled,
+        "{} enabled state",
+        expected.id
+    );
+    assert_eq!(
+        shortcut_badge_text(widget),
+        expected.shortcut_badge,
+        "{} shortcut badge",
+        expected.id
+    );
+
+    if expected.role == model::TopToolbarControlRole::Destructive {
+        assert!(surface.has_css_class("destructive"), "{}", expected.id);
+    }
+    if expected.id == crate::config::toolbar_item_ids::TOP_CHROME_PIN.as_str() {
+        assert_eq!(
+            surface.has_css_class("pinned"),
+            expected.active,
+            "{} pinned state",
+            expected.id
+        );
+    } else if let Ok(check) = surface.clone().downcast::<gtk4::CheckButton>() {
+        assert_eq!(check.is_active(), expected.active, "{} state", expected.id);
+    } else if expected.role != model::TopToolbarControlRole::Swatch {
+        assert_eq!(
+            surface.has_css_class("active"),
+            expected.active,
+            "{} active class",
+            expected.id
+        );
+    }
+
+    if let Ok(button) = surface.clone().downcast::<gtk4::Button>()
+        && let Some(label) = button.label()
+    {
+        assert_eq!(label, expected.label, "{} text label", expected.id);
+    }
+}
+
+fn detach_test_popovers(top: &mut TopBar) {
+    if let Some(popover) = top.shapes_popover.take() {
+        popover.unparent();
+    }
+    if let Some(popover) = top.overflow_popover.take() {
+        popover.unparent();
+    }
+}
+
+fn assert_builtin_node(
+    node: &crate::backend::wayland::TopToolbarWidgetKind,
+    interaction: Option<&crate::ui::toolbar::ToolbarEvent>,
+    tooltip: Option<&str>,
+    shortcut_badge: Option<&str>,
+    expected: &SemanticAdapterRecord,
+) {
+    use crate::backend::wayland::TopToolbarWidgetKind as W;
+
+    let SemanticAdapterRecord::Control(expected) = expected else {
+        assert!(matches!(node, W::Divider { vertical: true }));
+        return;
+    };
+
+    assert_eq!(interaction, expected.enabled.then_some(&expected.event));
+    assert_eq!(
+        tooltip,
+        expected.enabled.then_some(expected.tooltip.as_str())
+    );
+    assert_eq!(shortcut_badge, expected.shortcut_badge.as_deref());
+
+    match node {
+        W::IconButton {
+            glyph,
+            icon_size: _,
+            style,
+        } => {
+            let icon = expected.icon.expect("semantic icon for icon button");
+            assert!(std::ptr::fn_addr_eq(
+                glyph.0,
+                crate::toolbar_icons::top_toolbar_icon_painter(icon)
+            ));
+            assert_eq!(style.active, expected.active);
+            assert_eq!(style.disabled, !expected.enabled);
+            assert_eq!(
+                style.destructive,
+                expected.role == model::TopToolbarControlRole::Destructive
+            );
+        }
+        W::TextButton { label, style } => {
+            assert_eq!(label.text, expected.label);
+            assert_eq!(style.active, expected.active);
+            assert_eq!(style.disabled, !expected.enabled);
+            assert_eq!(
+                style.destructive,
+                expected.role == model::TopToolbarControlRole::Destructive
+            );
+        }
+        W::Swatch { selected, .. } => assert_eq!(*selected, expected.active),
+        W::PinButton { pinned } => assert_eq!(*pinned, expected.active),
+        W::MiniCheckbox { checked, label } => {
+            assert_eq!(*checked, expected.active);
+            assert_eq!(label.text, expected.label);
+        }
+        W::DragHandle | W::MinimizeButton => {}
+        other => panic!("unexpected semantic control kind: {other:?}"),
+    }
+}
+
+fn builtin_semantic_records(
+    snapshot: &ToolbarSnapshot,
+    expected: &[SemanticAdapterRecord],
+) -> Vec<SemanticAdapterRecord> {
+    let (width, height) = top_toolbar_size(snapshot);
+    let tree =
+        crate::backend::wayland::build_top_toolbar_view(snapshot, width as f64, height as f64);
+    let mut records = Vec::new();
+    for node in tree.nodes() {
+        let raw_id = node.id.as_str();
+        let (lane, id) = if let Some(id) = raw_id.strip_prefix("top.overflow.") {
+            (SemanticLane::Overflow, id)
+        } else if raw_id == "top.utility.highlight-ring" {
+            (SemanticLane::Contextual, raw_id)
+        } else {
+            let lane = expected
+                .iter()
+                .find(|record| record_id(record) == raw_id)
+                .map(record_lane)
+                .unwrap_or(SemanticLane::Strip);
+            (lane, raw_id)
+        };
+        let Some(record) = expected
+            .iter()
+            .find(|record| record_id(record) == id && record_lane(record) == lane)
+        else {
+            continue;
+        };
+        assert_builtin_node(
+            &node.kind,
+            node.interact.as_ref().map(|interaction| &interaction.event),
+            node.interact
+                .as_ref()
+                .and_then(|interaction| interaction.tooltip.as_deref()),
+            node.shortcut_badge
+                .as_ref()
+                .map(|badge| badge.label.as_str()),
+            record,
+        );
+        records.push(record.clone());
+    }
+    records
+}
+
+#[test]
+fn shared_spec_matches_builtin_order_and_full_semantics_without_starting_a_gui() {
+    let state = make_test_input_state();
+    let regular = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    let mut simple = regular.clone();
+    simple.layout_mode = ToolbarLayoutMode::Simple;
+    let mut minimized = regular.clone();
+    minimized.top_minimized = true;
+    let mut narrow = regular.clone();
+    narrow.top_viewport_max = Some(520.0);
+    narrow.top_overflow_open = true;
+    let mut text = regular.clone();
+    text.use_icons = false;
+    let mut shapes = regular.clone();
+    shapes.shape_picker_open = true;
+    shapes.active_tool = Tool::RegularPolygon;
+    let mut highlighted = regular.clone();
+    highlighted.highlight_tool_active = true;
+
+    for (name, snapshot) in [
+        ("regular", regular),
+        ("simple", simple),
+        ("minimized", minimized),
+        ("narrow", narrow),
+        ("text", text),
+        ("shapes", shapes),
+        ("highlighted", highlighted),
+    ] {
+        let plan = plan_top_strip(&snapshot);
+        let spec = super::strip::top_toolbar_spec(&snapshot, &plan);
+        let expected = expected_semantic_records(&snapshot, &spec, &plan);
+        for record in &expected {
+            if let SemanticAdapterRecord::Control(control) = record {
+                assert!(!control.accessible_label.is_empty(), "{name}: {control:?}");
+            }
+        }
+        assert_eq!(
+            expected,
+            builtin_semantic_records(&snapshot, &expected),
+            "{name} adapter semantics"
+        );
+    }
+}
+
+#[test]
+fn actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window() {
+    const CHILD_ENV: &str = "WAYSCRIBER_GTK_WIDGET_CONTRACT_CHILD";
+    const TEST_NAME: &str = "toolbar_gtk::view::top_bar::tests::actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window";
+
+    if std::env::var_os(CHILD_ENV).is_none() {
+        let status = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .arg(TEST_NAME)
+            .arg("--exact")
+            .arg("--test-threads=1")
+            .env(CHILD_ENV, "1")
+            .status()
+            .expect("run isolated GTK widget contract test");
+        assert!(status.success(), "isolated GTK widget contract test failed");
+        return;
+    }
+
+    if let Err(error) = gtk4::init() {
+        eprintln!("skipping GTK widget contract test: {error}");
+        return;
+    }
+
+    let state = make_test_input_state();
+    let regular = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    let mut simple = regular.clone();
+    simple.layout_mode = ToolbarLayoutMode::Simple;
+    let mut minimized = regular.clone();
+    minimized.top_minimized = true;
+    let mut text = regular.clone();
+    text.use_icons = false;
+    let mut highlighted = regular.clone();
+    highlighted.highlight_tool_active = true;
+    let mut narrow = regular.clone();
+    narrow.top_viewport_max = Some(520.0);
+
+    for (name, snapshot) in [
+        ("regular", regular.clone()),
+        ("simple", simple),
+        ("minimized", minimized),
+        ("text", text),
+        ("highlighted", highlighted.clone()),
+        ("narrow", narrow),
+    ] {
+        let plan = plan_top_strip(&snapshot);
+        let spec = super::strip::top_toolbar_spec(&snapshot, &plan);
+        let expected = expected_semantic_records(&snapshot, &spec, &plan);
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut top = TopBar::new_for_test(FeedbackSender::new(tx));
+        if snapshot.top_minimized {
+            top.build_minimized(&snapshot, &plan);
+        } else {
+            top.build_strip(&snapshot, &plan);
+        }
+        for updater in top.updaters.borrow().iter() {
+            updater(&snapshot);
+        }
+
+        let widgets = collect_semantic_widgets(top.root.upcast_ref());
+        assert_eq!(
+            widgets
+                .iter()
+                .map(|widget| widget.widget_name().to_string())
+                .collect::<Vec<_>>(),
+            expected_main_widget_ids(&spec),
+            "{name} GTK widget order"
+        );
+        for widget in widgets {
+            let id = widget.widget_name();
+            let Some(control) = expected.iter().find_map(|record| match record {
+                SemanticAdapterRecord::Control(control) if control.id == id => Some(control),
+                _ => None,
+            }) else {
+                assert!(
+                    expected.iter().any(
+                        |record| matches!(record, SemanticAdapterRecord::Divider(divider) if *divider == id)
+                    ),
+                    "{name}: unexpected GTK widget {id}"
+                );
+                continue;
+            };
+            assert_gtk_control_widget(&widget, control);
+        }
+        detach_test_popovers(&mut top);
+    }
+
+    // Compact plans normally drop quick colors before reaching the last
+    // degradation step. Keep a direct adapter case so the presentation
+    // contract cannot silently diverge if that planner policy changes.
+    let mut compact_plan = TopStripPlan::unconstrained();
+    compact_plan.compact = true;
+    compact_plan.swatch_count = 2;
+    let compact_spec = super::strip::top_toolbar_spec(&regular, &compact_plan);
+    let compact_expected = expected_semantic_records(&regular, &compact_spec, &compact_plan);
+    let (tx, _rx) = std::sync::mpsc::channel();
+    let mut compact_top = TopBar::new_for_test(FeedbackSender::new(tx));
+    compact_top.build_strip(&regular, &compact_plan);
+    let compact_widgets = collect_semantic_widgets(compact_top.root.upcast_ref());
+    for control in compact_expected.iter().filter_map(|record| match record {
+        SemanticAdapterRecord::Control(control) if control.id.starts_with("top.quick-color.") => {
+            Some(control)
+        }
+        _ => None,
+    }) {
+        let widget = compact_widgets
+            .iter()
+            .find(|widget| widget.widget_name() == control.id)
+            .expect("compact quick-color widget");
+        assert_gtk_control_widget(widget, control);
+    }
+    detach_test_popovers(&mut compact_top);
+
+    let mut shapes = regular.clone();
+    shapes.shape_picker_open = true;
+    shapes.active_tool = Tool::RegularPolygon;
+    let (tx, shape_rx) = std::sync::mpsc::channel();
+    let shape_top = TopBar::new_for_test(FeedbackSender::new(tx));
+    let shape_content = shape_top.build_shapes_popover_content(
+        &shapes,
+        (ICON_BUTTON, ICON_BUTTON),
+        ICON_SIZE,
+        true,
+        1.0,
+    );
+    let shape_tools = model::visible_shape_picker_rows(&shapes, false)
+        .into_iter()
+        .flatten()
+        .filter(|tool| model::tool_visible(&shapes, *tool))
+        .collect::<Vec<_>>();
+    let mut expected_shape_ids = shape_tools
+        .iter()
+        .map(|tool| {
+            format!(
+                "top.picker.{}",
+                model::toolbar_item_id_for_tool(*tool).as_str()
+            )
+        })
+        .collect::<Vec<_>>();
+    if model::fill_tool_active(shapes.active_tool, shapes.tool_override)
+        && model::top_fill_visible(&shapes)
+    {
+        expected_shape_ids.push(
+            crate::config::toolbar_item_ids::TOP_UTILITY_FILL
+                .as_str()
+                .to_string(),
+        );
+    }
+    expected_shape_ids.extend([
+        "top.options.sides-minus".to_string(),
+        "top.options.sides-plus".to_string(),
+    ]);
+    let shape_widgets = collect_semantic_widgets(shape_content.upcast_ref());
+    assert_eq!(
+        shape_widgets
+            .iter()
+            .map(|widget| widget.widget_name().to_string())
+            .collect::<Vec<_>>(),
+        expected_shape_ids,
+        "GTK shapes-popover order"
+    );
+    for (widget, tool) in shape_widgets.iter().zip(&shape_tools) {
+        let expected = control_record(
+            &shapes,
+            SemanticLane::Strip,
+            model::TopToolbarControl::Tool(*tool),
+            true,
+        );
+        assert_gtk_control_widget(widget, &expected);
+    }
+    let first_shape = first_control_surface(&shape_widgets[0])
+        .downcast::<gtk4::Button>()
+        .expect("shape-picker tool button");
+    first_shape.emit_clicked();
+    assert_eq!(
+        shape_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("GTK shape event"),
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::SelectTool(shape_tools[0]),
+            rebind_requested: false,
+        }
+    );
+
+    let mut overflow_plan = TopStripPlan::unconstrained();
+    overflow_plan.show_overflow = true;
+    overflow_plan.dropped_tools = vec![Tool::Line, Tool::Arrow];
+    overflow_plan.dropped_utilities = vec![
+        model::TopUtilityButton::Screenshot,
+        model::TopUtilityButton::Highlight,
+    ];
+    let overflow_spec = super::strip::top_toolbar_spec(&regular, &overflow_plan);
+    let overflow_content = shape_top.build_overflow_popover_content(
+        &regular,
+        &overflow_spec,
+        (ICON_BUTTON, ICON_BUTTON),
+        ICON_SIZE,
+        true,
+        1.0,
+    );
+    let overflow_widgets = collect_semantic_widgets(overflow_content.upcast_ref());
+    assert_eq!(
+        overflow_widgets
+            .iter()
+            .map(|widget| widget.widget_name().to_string())
+            .collect::<Vec<_>>(),
+        overflow_spec
+            .overflow()
+            .iter()
+            .map(|control| format!("top.overflow.{}", control.id().render_id()))
+            .collect::<Vec<_>>(),
+        "GTK overflow order"
+    );
+    for (widget, control) in overflow_widgets.iter().zip(overflow_spec.overflow()) {
+        let expected = control_record(&regular, SemanticLane::Overflow, *control, true);
+        assert_gtk_control_widget(widget, &expected);
+    }
+    let first_overflow = first_control_surface(&overflow_widgets[0])
+        .downcast::<gtk4::Button>()
+        .expect("overflow tool button");
+    first_overflow.emit_clicked();
+    assert_eq!(
+        shape_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("GTK overflow event"),
+        GtkToolbarFeedback::Event {
+            event: overflow_spec.overflow()[0].event(&regular),
+            rebind_requested: false,
+        }
+    );
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut event_top = TopBar::new_for_test(FeedbackSender::new(tx));
+    let shape = event_top.shapes_picker_button(
+        &regular,
+        model::TopToolbarControl::ShapePicker,
+        (ICON_BUTTON, ICON_BUTTON),
+        ICON_SIZE,
+        true,
+    );
+    let highlight = event_top.action_button(
+        &regular,
+        model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight),
+        (ICON_BUTTON, ICON_BUTTON),
+        ICON_SIZE,
+        true,
+        true,
+    );
+    let pin = event_top.pin_button(&regular, model::TopToolbarControl::Pin, PIN_BUTTON_SIZE);
+    let overflow = event_top.overflow_button(
+        &regular,
+        model::TopToolbarControl::Overflow,
+        PIN_BUTTON_SIZE,
+    );
+    for (button, expected) in [
+        (
+            &shape,
+            ToolbarEvent::ToggleShapePicker(!regular.shape_picker_open),
+        ),
+        (
+            &highlight,
+            ToolbarEvent::ToggleAllHighlight(!regular.any_highlight_active),
+        ),
+        (&pin, ToolbarEvent::PinTopToolbar(!regular.top_pinned)),
+        (
+            &overflow,
+            ToolbarEvent::ToggleTopOverflow(!regular.top_overflow_open),
+        ),
+    ] {
+        button.emit_clicked();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1)).expect("GTK event"),
+            GtkToolbarFeedback::Event {
+                event: expected,
+                rebind_requested: false,
+            }
+        );
+    }
+
+    let mut active = regular.clone();
+    active.shape_picker_open = true;
+    active.any_highlight_active = true;
+    active.top_pinned = true;
+    active.top_overflow_open = true;
+    event_top.shapes_expected_open.set(true);
+    event_top.overflow_expected_open.set(true);
+    for updater in event_top.updaters.borrow().iter() {
+        updater(&active);
+    }
+    for (button, expected) in [
+        (&shape, ToolbarEvent::ToggleShapePicker(false)),
+        (&highlight, ToolbarEvent::ToggleAllHighlight(false)),
+        (&pin, ToolbarEvent::PinTopToolbar(false)),
+        (&overflow, ToolbarEvent::ToggleTopOverflow(false)),
+    ] {
+        button.emit_clicked();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(1)).expect("GTK event"),
+            GtkToolbarFeedback::Event {
+                event: expected,
+                rebind_requested: false,
+            }
+        );
+    }
+    event_top.shapes_expected_open.set(false);
+    event_top.overflow_expected_open.set(false);
+
+    // The direct factories parent popovers to their buttons. Detach those
+    // before rebuilding the test bar, matching the production rebuild path.
+    detach_test_popovers(&mut event_top);
+
+    event_top.build_strip(&highlighted, &plan_top_strip(&highlighted));
+    let ring = collect_semantic_widgets(event_top.root.upcast_ref())
+        .into_iter()
+        .find(|widget| {
+            widget.widget_name()
+                == crate::config::toolbar_item_ids::TOP_UTILITY_HIGHLIGHT_RING.as_str()
+        })
+        .expect("GTK highlight-ring widget")
+        .downcast::<gtk4::CheckButton>()
+        .expect("highlight ring check button");
+    ring.set_active(!highlighted.highlight_tool_ring_enabled);
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(1))
+            .expect("GTK ring event"),
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::ToggleHighlightToolRing(!highlighted.highlight_tool_ring_enabled),
+            rebind_requested: false,
+        }
+    );
+    detach_test_popovers(&mut event_top);
+}
+
+#[test]
+fn gtk_stateful_toggle_adapter_emits_the_requested_live_state() {
+    use super::controls::event_for_toggle_state;
+
+    let cases = [
+        (
+            model::TopToolbarControl::ShapePicker,
+            ToolbarEvent::ToggleShapePicker(false),
+            ToolbarEvent::ToggleShapePicker(true),
+        ),
+        (
+            model::TopToolbarControl::Utility(model::TopToolbarUtility::Highlight),
+            ToolbarEvent::ToggleAllHighlight(false),
+            ToolbarEvent::ToggleAllHighlight(true),
+        ),
+        (
+            model::TopToolbarControl::Pin,
+            ToolbarEvent::PinTopToolbar(false),
+            ToolbarEvent::PinTopToolbar(true),
+        ),
+        (
+            model::TopToolbarControl::Overflow,
+            ToolbarEvent::ToggleTopOverflow(false),
+            ToolbarEvent::ToggleTopOverflow(true),
+        ),
+        (
+            model::TopToolbarControl::HighlightRing,
+            ToolbarEvent::ToggleHighlightToolRing(false),
+            ToolbarEvent::ToggleHighlightToolRing(true),
+        ),
+    ];
+
+    for (control, inactive, active) in cases {
+        assert_eq!(event_for_toggle_state(control, false), inactive);
+        assert_eq!(event_for_toggle_state(control, true), active);
+    }
 }

--- a/src/toolbar_icons/mod.rs
+++ b/src/toolbar_icons/mod.rs
@@ -17,3 +17,44 @@ pub use history::*;
 pub use security::*;
 pub use tools::*;
 pub use zoom::*;
+
+pub(crate) type ToolbarIconPainter = fn(&cairo::Context, f64, f64, f64);
+
+pub(crate) fn top_toolbar_icon_painter(
+    icon: crate::ui::toolbar::model::TopToolbarIcon,
+) -> ToolbarIconPainter {
+    use crate::ui::toolbar::model::{SemanticToolIcon as T, TopToolbarIcon as I};
+
+    match icon {
+        I::Restore => draw_icon_restore,
+        I::Drag => draw_icon_drag,
+        I::ShapePicker => draw_icon_shape_picker,
+        I::Text => draw_icon_text,
+        I::StickyNote => draw_icon_note,
+        I::Screenshot => draw_icon_screenshot,
+        I::Highlight => draw_icon_highlight,
+        I::ClearCanvas => draw_icon_clear,
+        I::Undo => draw_icon_undo,
+        I::Redo => draw_icon_redo,
+        I::Pin => draw_icon_pin,
+        I::Unpin => draw_icon_unpin,
+        I::Overflow => draw_icon_more,
+        I::Minimize => draw_icon_minimize,
+        I::Tool(T::Select) => draw_icon_select,
+        I::Tool(T::Pen) => draw_icon_pen,
+        I::Tool(T::Line) => draw_icon_line,
+        I::Tool(T::Rect) => draw_icon_rect,
+        I::Tool(T::Circle) => draw_icon_circle,
+        I::Tool(T::Triangle) => draw_icon_triangle,
+        I::Tool(T::Parallelogram) => draw_icon_parallelogram,
+        I::Tool(T::Rhombus) => draw_icon_rhombus,
+        I::Tool(T::Polygon) => draw_icon_polygon,
+        I::Tool(T::FreeformPolygon) => draw_icon_freeform_polygon,
+        I::Tool(T::Arrow) => draw_icon_arrow,
+        I::Tool(T::Blur) => draw_icon_blur,
+        I::Tool(T::Marker) => draw_icon_marker,
+        I::Tool(T::Highlight) => draw_icon_highlight,
+        I::Tool(T::StepMarker) => draw_icon_step_marker,
+        I::Tool(T::Eraser) => draw_icon_eraser,
+    }
+}

--- a/src/ui/toolbar/model/mod.rs
+++ b/src/ui/toolbar/model/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod header;
 pub(crate) mod session;
 pub(crate) mod settings;
 pub(crate) mod tools;
+mod top_spec;
 
 #[allow(unused_imports)]
 pub(crate) use actions::{
@@ -47,6 +48,11 @@ pub(crate) use tools::{
     top_sticky_note_visible, top_text_visible, top_tool_buttons, top_tool_group,
     visible_shape_picker_max_row_len, visible_shape_picker_row_count, visible_shape_picker_rows,
     visible_tool_count, visible_top_tool_buttons, visible_top_utility_buttons,
+};
+#[allow(unused_imports)]
+pub(crate) use top_spec::{
+    TopStripPlan, TopToolbarControl, TopToolbarControlId, TopToolbarControlRole, TopToolbarDivider,
+    TopToolbarIcon, TopToolbarNode, TopToolbarSpec, TopToolbarUtility, action_tooltip,
 };
 
 #[cfg(test)]

--- a/src/ui/toolbar/model/top_spec.rs
+++ b/src/ui/toolbar/model/top_spec.rs
@@ -1,0 +1,902 @@
+use std::borrow::Cow;
+
+use crate::config::{
+    Action, ToolbarItemId, ToolbarLayoutMode, action_label, action_short_label,
+    toolbar_item_ids as ids,
+};
+use crate::input::Tool;
+use crate::label_format::format_binding_label;
+use crate::ui::toolbar::bindings::{tool_label, tool_tooltip_label};
+use crate::ui::toolbar::{ToolbarEvent, ToolbarSnapshot};
+
+use super::{
+    SemanticToolIcon, TopToolGroup, TopUtilityButton, current_shape_tool, default_drag_hint,
+    semantic_icon_for_tool, toolbar_item_id_for_tool, toolbar_item_visible,
+    top_highlight_ring_visible, top_highlight_visible, top_shape_picker_visible, top_tool_group,
+    visible_top_tool_buttons, visible_top_utility_buttons,
+};
+
+/// Width-degradation result shared by both top-toolbar frontends.
+///
+/// The built-in layout layer owns the geometry-dependent planner that fills
+/// this value. The semantic specification only consumes the result.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TopStripPlan {
+    pub(crate) swatch_count: usize,
+    pub(crate) dropped_tools: Vec<Tool>,
+    pub(crate) dropped_utilities: Vec<TopUtilityButton>,
+    pub(crate) show_overflow: bool,
+    pub(crate) compact: bool,
+}
+
+impl TopStripPlan {
+    pub(crate) const MAX_QUICK_COLORS: usize = 8;
+
+    pub(crate) fn unconstrained() -> Self {
+        Self {
+            swatch_count: Self::MAX_QUICK_COLORS,
+            dropped_tools: Vec::new(),
+            dropped_utilities: Vec::new(),
+            show_overflow: false,
+            compact: false,
+        }
+    }
+}
+
+/// Renderer-neutral top-toolbar structure for one snapshot and layout plan.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TopToolbarSpec {
+    strip: Vec<TopToolbarNode>,
+    chrome: Vec<TopToolbarControl>,
+    overflow: Vec<TopToolbarControl>,
+    contextual: Vec<TopToolbarControl>,
+}
+
+impl TopToolbarSpec {
+    pub(crate) fn build(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> Self {
+        if snapshot.top_minimized {
+            return Self {
+                strip: vec![TopToolbarNode::Control(TopToolbarControl::Restore)],
+                chrome: Vec::new(),
+                overflow: Vec::new(),
+                contextual: Vec::new(),
+            };
+        }
+
+        let simple = snapshot.layout_mode == ToolbarLayoutMode::Simple;
+        let mut strip = Vec::new();
+
+        if toolbar_item_visible(snapshot, ids::TOP_CHROME_DRAG) {
+            strip.push(TopToolbarNode::Control(TopToolbarControl::DragHandle));
+        }
+
+        let mut previous_tool_group = None;
+        let mut tool_control_present = false;
+        for tool in visible_top_tool_buttons(simple, snapshot) {
+            if plan.dropped_tools.contains(&tool) {
+                continue;
+            }
+            let group = top_tool_group(tool);
+            if previous_tool_group.is_some_and(|previous| previous != group) {
+                strip.push(TopToolbarNode::Divider(TopToolbarDivider::Tools));
+            }
+            previous_tool_group = Some(group);
+            strip.push(TopToolbarNode::Control(TopToolbarControl::Tool(tool)));
+            tool_control_present = true;
+        }
+
+        if Self::shape_picker_visible(snapshot) {
+            if previous_tool_group == Some(TopToolGroup::Pens) {
+                strip.push(TopToolbarNode::Divider(TopToolbarDivider::Tools));
+            }
+            strip.push(TopToolbarNode::Control(TopToolbarControl::ShapePicker));
+            tool_control_present = true;
+        }
+
+        let visible_utilities = visible_top_utility_buttons(snapshot, simple, snapshot.use_icons);
+        let clear_visible = visible_utilities.contains(&TopUtilityButton::ClearCanvas);
+        let utilities: Vec<_> = visible_utilities
+            .iter()
+            .copied()
+            .filter(|utility| *utility != TopUtilityButton::ClearCanvas)
+            .filter(|utility| !plan.dropped_utilities.contains(utility))
+            .collect();
+        if tool_control_present && !utilities.is_empty() {
+            strip.push(TopToolbarNode::Divider(TopToolbarDivider::Annotations));
+        }
+        strip.extend(utilities.into_iter().filter_map(|utility| {
+            TopToolbarUtility::from_model(utility)
+                .map(TopToolbarControl::Utility)
+                .map(TopToolbarNode::Control)
+        }));
+
+        if toolbar_item_visible(snapshot, ids::TOP_GROUP_QUICK_COLORS) {
+            strip.push(TopToolbarNode::Divider(TopToolbarDivider::Colors));
+            strip.extend(
+                snapshot
+                    .quick_colors
+                    .rendered_entries()
+                    .iter()
+                    .take(plan.swatch_count)
+                    .enumerate()
+                    .map(|(index, _)| {
+                        TopToolbarNode::Control(TopToolbarControl::QuickColor(index))
+                    }),
+            );
+            strip.push(TopToolbarNode::Control(TopToolbarControl::CurrentColor));
+        }
+
+        let undo_visible = toolbar_item_visible(snapshot, ids::TOP_UTILITY_UNDO);
+        let redo_visible = toolbar_item_visible(snapshot, ids::TOP_UTILITY_REDO);
+        if undo_visible || redo_visible {
+            strip.push(TopToolbarNode::Divider(TopToolbarDivider::History));
+        }
+        if undo_visible {
+            strip.push(TopToolbarNode::Control(TopToolbarControl::Undo));
+        }
+        if redo_visible {
+            strip.push(TopToolbarNode::Control(TopToolbarControl::Redo));
+        }
+        if clear_visible {
+            strip.push(TopToolbarNode::Control(TopToolbarControl::ClearCanvas));
+        }
+
+        let chrome = Self::chrome_controls(snapshot, plan)
+            .into_iter()
+            .flatten()
+            .collect();
+        let overflow = Self::overflow_controls(plan).collect();
+        let contextual = if Self::contextual_highlight_ring_visible(snapshot, plan) {
+            vec![TopToolbarControl::HighlightRing]
+        } else {
+            Vec::new()
+        };
+
+        Self {
+            strip,
+            chrome,
+            overflow,
+            contextual,
+        }
+    }
+
+    pub(crate) fn strip(&self) -> &[TopToolbarNode] {
+        &self.strip
+    }
+
+    pub(crate) fn chrome(&self) -> &[TopToolbarControl] {
+        &self.chrome
+    }
+
+    pub(crate) fn overflow(&self) -> &[TopToolbarControl] {
+        &self.overflow
+    }
+
+    pub(crate) fn contextual(&self) -> &[TopToolbarControl] {
+        &self.contextual
+    }
+
+    pub(crate) fn shape_picker_visible(snapshot: &ToolbarSnapshot) -> bool {
+        !snapshot.top_minimized && top_shape_picker_visible(snapshot)
+    }
+
+    pub(crate) fn contextual_highlight_ring_visible(
+        snapshot: &ToolbarSnapshot,
+        plan: &TopStripPlan,
+    ) -> bool {
+        !snapshot.top_minimized
+            && snapshot.layout_mode != ToolbarLayoutMode::Simple
+            && snapshot.use_icons
+            && snapshot.highlight_tool_active
+            && top_highlight_visible(snapshot)
+            && top_highlight_ring_visible(snapshot)
+            && !plan
+                .dropped_utilities
+                .contains(&TopUtilityButton::Highlight)
+    }
+
+    pub(crate) fn chrome_control_count(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> usize {
+        if snapshot.top_minimized {
+            return 0;
+        }
+        Self::chrome_controls(snapshot, plan)
+            .into_iter()
+            .flatten()
+            .count()
+    }
+
+    pub(crate) fn overflow_control_count(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> usize {
+        if snapshot.top_minimized {
+            return 0;
+        }
+        Self::overflow_controls(plan).count()
+    }
+
+    fn chrome_controls(
+        snapshot: &ToolbarSnapshot,
+        plan: &TopStripPlan,
+    ) -> [Option<TopToolbarControl>; 3] {
+        [
+            toolbar_item_visible(snapshot, ids::TOP_CHROME_PIN).then_some(TopToolbarControl::Pin),
+            plan.show_overflow.then_some(TopToolbarControl::Overflow),
+            toolbar_item_visible(snapshot, ids::TOP_CHROME_CLOSE)
+                .then_some(TopToolbarControl::Minimize),
+        ]
+    }
+
+    fn overflow_controls(plan: &TopStripPlan) -> impl Iterator<Item = TopToolbarControl> + '_ {
+        plan.dropped_tools
+            .iter()
+            .copied()
+            .map(TopToolbarControl::Tool)
+            .chain(
+                plan.dropped_utilities
+                    .iter()
+                    .copied()
+                    .filter_map(TopToolbarUtility::from_model)
+                    .map(TopToolbarControl::Utility),
+            )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarNode {
+    Divider(TopToolbarDivider),
+    Control(TopToolbarControl),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarDivider {
+    Tools,
+    Annotations,
+    Colors,
+    History,
+}
+
+impl TopToolbarDivider {
+    pub(crate) const fn id(self) -> &'static str {
+        match self {
+            Self::Tools => "top.divider.tools",
+            Self::Annotations => "top.divider.annotations",
+            Self::Colors => "top.divider.colors",
+            Self::History => "top.divider.history",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarControl {
+    Restore,
+    DragHandle,
+    Tool(Tool),
+    ShapePicker,
+    Utility(TopToolbarUtility),
+    QuickColor(usize),
+    CurrentColor,
+    Undo,
+    Redo,
+    ClearCanvas,
+    Pin,
+    Overflow,
+    Minimize,
+    HighlightRing,
+}
+
+impl TopToolbarControl {
+    pub(crate) fn id(self) -> TopToolbarControlId {
+        let id = match self {
+            Self::Restore => return TopToolbarControlId::Restore,
+            Self::DragHandle => ids::TOP_CHROME_DRAG,
+            Self::Tool(tool) => toolbar_item_id_for_tool(tool),
+            Self::ShapePicker => ids::TOP_UTILITY_SHAPE_PICKER,
+            Self::Utility(utility) => match utility {
+                TopToolbarUtility::Text => ids::TOP_UTILITY_TEXT,
+                TopToolbarUtility::StickyNote => ids::TOP_UTILITY_STICKY_NOTE,
+                TopToolbarUtility::Screenshot => ids::TOP_UTILITY_SCREENSHOT,
+                TopToolbarUtility::Highlight => ids::TOP_UTILITY_HIGHLIGHT,
+            },
+            Self::QuickColor(index) => return TopToolbarControlId::QuickColor(index),
+            Self::CurrentColor => ids::TOP_GROUP_QUICK_COLORS,
+            Self::Undo => ids::TOP_UTILITY_UNDO,
+            Self::Redo => ids::TOP_UTILITY_REDO,
+            Self::ClearCanvas => ids::TOP_UTILITY_CLEAR_CANVAS,
+            Self::Pin => ids::TOP_CHROME_PIN,
+            Self::Overflow => ids::TOP_CHROME_OVERFLOW,
+            Self::Minimize => ids::TOP_CHROME_CLOSE,
+            Self::HighlightRing => ids::TOP_UTILITY_HIGHLIGHT_RING,
+        };
+        TopToolbarControlId::Item(id)
+    }
+
+    pub(crate) fn event(self, snapshot: &ToolbarSnapshot) -> ToolbarEvent {
+        match self {
+            Self::Restore => ToolbarEvent::SetTopMinimized(false),
+            Self::DragHandle => ToolbarEvent::MoveTopToolbar { x: 0.0, y: 0.0 },
+            Self::Tool(tool) => ToolbarEvent::SelectTool(tool),
+            Self::ShapePicker => ToolbarEvent::ToggleShapePicker(!snapshot.shape_picker_open),
+            Self::Utility(utility) => utility_event(utility, snapshot),
+            Self::QuickColor(index) => {
+                let entry = &snapshot.quick_colors.rendered_entries()[index];
+                ToolbarEvent::SetQuickColor {
+                    color: entry.color,
+                    action: crate::config::QuickColorPalette::action_for_index(index),
+                }
+            }
+            Self::CurrentColor => ToolbarEvent::OpenColorPickerPopup,
+            Self::Undo => ToolbarEvent::Undo,
+            Self::Redo => ToolbarEvent::Redo,
+            Self::ClearCanvas => ToolbarEvent::ClearCanvas,
+            Self::Pin => ToolbarEvent::PinTopToolbar(!snapshot.top_pinned),
+            Self::Overflow => ToolbarEvent::ToggleTopOverflow(!snapshot.top_overflow_open),
+            Self::Minimize => ToolbarEvent::SetTopMinimized(true),
+            Self::HighlightRing => {
+                ToolbarEvent::ToggleHighlightToolRing(!snapshot.highlight_tool_ring_enabled)
+            }
+        }
+    }
+
+    pub(crate) fn action(self, snapshot: &ToolbarSnapshot) -> Option<Action> {
+        self.event(snapshot).action()
+    }
+
+    pub(crate) fn enabled(self, snapshot: &ToolbarSnapshot) -> bool {
+        match self {
+            Self::Undo => snapshot.undo_available,
+            Self::Redo => snapshot.redo_available,
+            _ => true,
+        }
+    }
+
+    pub(crate) fn active(self, snapshot: &ToolbarSnapshot) -> bool {
+        match self {
+            Self::Tool(tool) => {
+                snapshot.active_tool == tool || snapshot.tool_override == Some(tool)
+            }
+            Self::ShapePicker => {
+                snapshot.shape_picker_open
+                    || current_shape_tool(snapshot.active_tool, snapshot.tool_override).is_some()
+            }
+            Self::Utility(TopToolbarUtility::Text) => snapshot.text_active,
+            Self::Utility(TopToolbarUtility::StickyNote) => snapshot.note_active,
+            Self::Utility(TopToolbarUtility::Highlight) => snapshot.any_highlight_active,
+            Self::Utility(TopToolbarUtility::Screenshot) => false,
+            Self::QuickColor(index) => {
+                snapshot.quick_colors.rendered_entries()[index].color == snapshot.color
+            }
+            Self::CurrentColor => true,
+            Self::Pin => snapshot.top_pinned,
+            Self::Overflow => snapshot.top_overflow_open,
+            Self::HighlightRing => snapshot.highlight_tool_ring_enabled,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn role(self) -> TopToolbarControlRole {
+        match self {
+            Self::Restore => TopToolbarControlRole::Restore,
+            Self::DragHandle => TopToolbarControlRole::DragHandle,
+            Self::QuickColor(_) | Self::CurrentColor => TopToolbarControlRole::Swatch,
+            Self::ClearCanvas => TopToolbarControlRole::Destructive,
+            Self::ShapePicker
+            | Self::Utility(TopToolbarUtility::Highlight)
+            | Self::Pin
+            | Self::Overflow
+            | Self::HighlightRing => TopToolbarControlRole::Toggle,
+            Self::Minimize => TopToolbarControlRole::Chrome,
+            _ => TopToolbarControlRole::Button,
+        }
+    }
+
+    pub(crate) fn icon(self, snapshot: &ToolbarSnapshot) -> Option<TopToolbarIcon> {
+        Some(match self {
+            Self::Restore => TopToolbarIcon::Restore,
+            Self::DragHandle => TopToolbarIcon::Drag,
+            Self::Tool(tool) => TopToolbarIcon::Tool(semantic_icon_for_tool(tool)),
+            Self::ShapePicker => TopToolbarIcon::ShapePicker,
+            Self::Utility(TopToolbarUtility::Text) => TopToolbarIcon::Text,
+            Self::Utility(TopToolbarUtility::StickyNote) => TopToolbarIcon::StickyNote,
+            Self::Utility(TopToolbarUtility::Screenshot) => TopToolbarIcon::Screenshot,
+            Self::ClearCanvas => TopToolbarIcon::ClearCanvas,
+            Self::Utility(TopToolbarUtility::Highlight) => TopToolbarIcon::Highlight,
+            Self::Undo => TopToolbarIcon::Undo,
+            Self::Redo => TopToolbarIcon::Redo,
+            Self::Pin if snapshot.top_pinned => TopToolbarIcon::Pin,
+            Self::Pin => TopToolbarIcon::Unpin,
+            Self::Overflow => TopToolbarIcon::Overflow,
+            Self::Minimize => TopToolbarIcon::Minimize,
+            Self::QuickColor(_) | Self::CurrentColor | Self::HighlightRing => return None,
+        })
+    }
+
+    pub(crate) fn label(self, snapshot: &ToolbarSnapshot) -> Cow<'static, str> {
+        match self {
+            Self::Restore => Cow::Borrowed("Show toolbar"),
+            Self::DragHandle => Cow::Borrowed("Drag toolbar"),
+            Self::Tool(tool) => Cow::Borrowed(tool_label(tool)),
+            Self::ShapePicker => Cow::Borrowed("Shapes"),
+            Self::Utility(utility) => Cow::Borrowed(utility_short_label(utility)),
+            Self::QuickColor(index) => Cow::Owned(
+                snapshot.quick_colors.rendered_entries()[index]
+                    .label
+                    .clone(),
+            ),
+            Self::CurrentColor => Cow::Borrowed("Color picker"),
+            Self::Undo => Cow::Borrowed(action_short_label(Action::Undo)),
+            Self::Redo => Cow::Borrowed(action_short_label(Action::Redo)),
+            Self::ClearCanvas => Cow::Borrowed(action_short_label(Action::ClearCanvas)),
+            Self::Pin if snapshot.top_pinned => Cow::Borrowed("Unpin top toolbar"),
+            Self::Pin => Cow::Borrowed("Pin top toolbar"),
+            Self::Overflow => Cow::Borrowed("More tools"),
+            Self::Minimize => Cow::Borrowed("Minimize top toolbar"),
+            Self::HighlightRing => Cow::Borrowed("Ring"),
+        }
+    }
+
+    pub(crate) fn accessible_label(self, snapshot: &ToolbarSnapshot) -> Cow<'static, str> {
+        match self {
+            Self::Tool(tool) => Cow::Borrowed(tool_tooltip_label(tool)),
+            Self::Utility(utility) => Cow::Borrowed(utility_accessible_label(utility)),
+            Self::Undo => Cow::Borrowed(action_label(Action::Undo)),
+            Self::Redo => Cow::Borrowed(action_label(Action::Redo)),
+            Self::ClearCanvas => Cow::Borrowed(action_label(Action::ClearCanvas)),
+            Self::QuickColor(index) => Cow::Owned(
+                snapshot.quick_colors.rendered_entries()[index]
+                    .label
+                    .clone(),
+            ),
+            _ => self.label(snapshot),
+        }
+    }
+
+    pub(crate) fn tooltip(self, snapshot: &ToolbarSnapshot) -> String {
+        match self {
+            Self::Tool(tool) => tool_tooltip(snapshot, tool),
+            Self::Utility(utility) => action_tooltip(snapshot, utility_action(utility)),
+            Self::QuickColor(index) => {
+                let entry = &snapshot.quick_colors.rendered_entries()[index];
+                let binding = crate::config::QuickColorPalette::action_for_index(index)
+                    .and_then(|action| snapshot.binding_hints.binding_for_action(action));
+                format_binding_label(&entry.label, binding)
+            }
+            Self::Undo => action_tooltip(snapshot, Action::Undo),
+            Self::Redo => action_tooltip(snapshot, Action::Redo),
+            Self::ClearCanvas => action_tooltip(snapshot, Action::ClearCanvas),
+            Self::Pin if snapshot.top_pinned => {
+                "Pinned: opens at startup (click to disable)".to_string()
+            }
+            Self::Pin => "Pin: click to open at startup".to_string(),
+            Self::Minimize => "Minimize (leaves a restore tab)".to_string(),
+            Self::HighlightRing => "Highlight ring".to_string(),
+            _ => self.accessible_label(snapshot).into_owned(),
+        }
+    }
+
+    pub(crate) fn overflow_tooltip(self, snapshot: &ToolbarSnapshot) -> String {
+        match self {
+            Self::Utility(_) => self.accessible_label(snapshot).into_owned(),
+            _ => self.tooltip(snapshot),
+        }
+    }
+
+    pub(crate) fn shortcut_badge(self, snapshot: &ToolbarSnapshot) -> Option<String> {
+        match self {
+            Self::Tool(tool) => snapshot
+                .binding_hints
+                .badge_for_tool(tool)
+                .map(str::to_owned),
+            Self::QuickColor(index) => snapshot
+                .binding_hints
+                .quick_color_badge(index)
+                .map(str::to_owned),
+            _ => self
+                .action(snapshot)
+                .and_then(|action| snapshot.binding_hints.badge_for_action(action))
+                .map(str::to_owned),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarControlId {
+    Item(ToolbarItemId),
+    QuickColor(usize),
+    Restore,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarUtility {
+    Text,
+    StickyNote,
+    Screenshot,
+    Highlight,
+}
+
+impl TopToolbarUtility {
+    fn from_model(utility: TopUtilityButton) -> Option<Self> {
+        match utility {
+            TopUtilityButton::Text => Some(Self::Text),
+            TopUtilityButton::StickyNote => Some(Self::StickyNote),
+            TopUtilityButton::Screenshot => Some(Self::Screenshot),
+            TopUtilityButton::Highlight => Some(Self::Highlight),
+            TopUtilityButton::ClearCanvas | TopUtilityButton::IconMode => None,
+        }
+    }
+}
+
+impl TopToolbarControlId {
+    pub(crate) fn render_id(self) -> Cow<'static, str> {
+        match self {
+            Self::Item(id) => Cow::Borrowed(id.as_str()),
+            Self::QuickColor(index) => Cow::Owned(format!("top.quick-color.{index}")),
+            Self::Restore => Cow::Borrowed("top.chrome.restore"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarControlRole {
+    Button,
+    Toggle,
+    Swatch,
+    Destructive,
+    Chrome,
+    DragHandle,
+    Restore,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopToolbarIcon {
+    Restore,
+    Drag,
+    Tool(SemanticToolIcon),
+    ShapePicker,
+    Text,
+    StickyNote,
+    Screenshot,
+    Highlight,
+    ClearCanvas,
+    Undo,
+    Redo,
+    Pin,
+    Unpin,
+    Overflow,
+    Minimize,
+}
+
+fn utility_event(utility: TopToolbarUtility, snapshot: &ToolbarSnapshot) -> ToolbarEvent {
+    match utility {
+        TopToolbarUtility::Text => ToolbarEvent::EnterTextMode,
+        TopToolbarUtility::StickyNote => ToolbarEvent::EnterStickyNoteMode,
+        TopToolbarUtility::Screenshot => ToolbarEvent::CaptureScreenshot,
+        TopToolbarUtility::Highlight => {
+            ToolbarEvent::ToggleAllHighlight(!snapshot.any_highlight_active)
+        }
+    }
+}
+
+fn utility_action(utility: TopToolbarUtility) -> Action {
+    match utility {
+        TopToolbarUtility::Text => Action::EnterTextMode,
+        TopToolbarUtility::StickyNote => Action::EnterStickyNoteMode,
+        TopToolbarUtility::Screenshot => Action::CaptureSelection,
+        TopToolbarUtility::Highlight => Action::ToggleHighlightTool,
+    }
+}
+
+fn utility_short_label(utility: TopToolbarUtility) -> &'static str {
+    match utility {
+        TopToolbarUtility::Screenshot => "Shot",
+        TopToolbarUtility::Highlight => "Highlight",
+        _ => action_short_label(utility_action(utility)),
+    }
+}
+
+fn utility_accessible_label(utility: TopToolbarUtility) -> &'static str {
+    action_label(utility_action(utility))
+}
+
+pub(crate) fn action_tooltip(snapshot: &ToolbarSnapshot, action: Action) -> String {
+    format_binding_label(
+        action_label(action),
+        snapshot.binding_hints.binding_for_action(action),
+    )
+}
+
+fn tool_tooltip(snapshot: &ToolbarSnapshot, tool: Tool) -> String {
+    let label = tool_tooltip_label(tool);
+    let default_hint = default_drag_hint(tool);
+    let binding = match (snapshot.binding_hints.for_tool(tool), default_hint) {
+        (Some(binding), Some(fallback)) => Some(format!("{binding}, {fallback}")),
+        (Some(binding), None) => Some(binding.to_string()),
+        (None, Some(fallback)) => Some(fallback.to_string()),
+        (None, None) => None,
+    };
+    format_binding_label(label, binding.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ToolbarItemOrderGroup, ToolbarItemsConfig};
+    use crate::input::state::test_support::make_test_input_state;
+    use crate::ui::toolbar::ToolbarBindingHints;
+
+    fn snapshot() -> ToolbarSnapshot {
+        let state = make_test_input_state();
+        ToolbarSnapshot::from_input_with_bindings(&state, ToolbarBindingHints::default())
+    }
+
+    fn strip_control_ids(spec: &TopToolbarSpec) -> Vec<String> {
+        spec.strip()
+            .iter()
+            .filter_map(|node| match node {
+                TopToolbarNode::Control(control) => Some(control.id().render_id().into_owned()),
+                TopToolbarNode::Divider(_) => None,
+            })
+            .collect()
+    }
+
+    fn chrome_ids(spec: &TopToolbarSpec) -> Vec<String> {
+        spec.chrome()
+            .iter()
+            .map(|control| control.id().render_id().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn regular_spec_owns_control_order_ids_and_events() {
+        let snapshot = snapshot();
+        let spec = TopToolbarSpec::build(&snapshot, &TopStripPlan::unconstrained());
+        let ids = strip_control_ids(&spec);
+
+        let expected_order = [
+            "top.chrome.drag",
+            "top.tool.select",
+            "top.tool.pen",
+            "top.tool.marker",
+            "top.tool.step-marker",
+            "top.tool.eraser",
+            "top.tool.line",
+            "top.tool.arrow",
+            "top.utility.shape-picker",
+            "top.utility.text",
+            "top.utility.sticky-note",
+            "top.utility.highlight",
+            "top.quick-color.0",
+            "top.group.quick-colors",
+            "top.utility.undo",
+            "top.utility.redo",
+            "top.utility.clear-canvas",
+        ];
+        let mut position = 0;
+        for expected in expected_order {
+            let next = ids[position..]
+                .iter()
+                .position(|id| id == expected)
+                .map(|offset| position + offset)
+                .unwrap_or_else(|| panic!("{expected} missing from {ids:?}"));
+            position = next + 1;
+        }
+
+        assert_eq!(chrome_ids(&spec), ["top.chrome.pin", "top.chrome.close"]);
+        let pen = spec
+            .strip()
+            .iter()
+            .find_map(|node| match node {
+                TopToolbarNode::Control(control @ TopToolbarControl::Tool(Tool::Pen)) => {
+                    Some(*control)
+                }
+                _ => None,
+            })
+            .expect("pen control");
+        assert_eq!(pen.event(&snapshot), ToolbarEvent::SelectTool(Tool::Pen));
+        assert_eq!(pen.id(), TopToolbarControlId::Item(ids::TOP_TOOL_PEN));
+
+        let divider_ids: Vec<_> = spec
+            .strip()
+            .iter()
+            .filter_map(|node| match node {
+                TopToolbarNode::Divider(divider) => Some(divider.id()),
+                TopToolbarNode::Control(_) => None,
+            })
+            .collect();
+        assert_eq!(
+            divider_ids,
+            [
+                "top.divider.tools",
+                "top.divider.annotations",
+                "top.divider.colors",
+                "top.divider.history",
+            ]
+        );
+    }
+
+    #[test]
+    fn simple_and_compact_specs_preserve_semantics_without_geometry() {
+        let mut simple = snapshot();
+        simple.layout_mode = ToolbarLayoutMode::Simple;
+        let simple_spec = TopToolbarSpec::build(&simple, &TopStripPlan::unconstrained());
+        let simple_ids = strip_control_ids(&simple_spec);
+        assert!(!simple_ids.contains(&ids::TOP_TOOL_LINE.as_str().to_string()));
+        assert!(!simple_ids.contains(&ids::TOP_TOOL_ARROW.as_str().to_string()));
+        assert!(!simple_ids.contains(&ids::TOP_UTILITY_HIGHLIGHT.as_str().to_string()));
+        assert!(!simple_ids.contains(&ids::TOP_UTILITY_CLEAR_CANVAS.as_str().to_string()));
+        assert!(simple_ids.contains(&ids::TOP_UTILITY_SHAPE_PICKER.as_str().to_string()));
+
+        let regular = snapshot();
+        let mut compact_plan = TopStripPlan::unconstrained();
+        compact_plan.compact = true;
+        let compact_spec = TopToolbarSpec::build(&regular, &compact_plan);
+        assert_eq!(
+            strip_control_ids(&compact_spec),
+            strip_control_ids(&TopToolbarSpec::build(
+                &regular,
+                &TopStripPlan::unconstrained()
+            ))
+        );
+    }
+
+    #[test]
+    fn minimized_spec_contains_only_the_non_hideable_restore_control() {
+        let mut snapshot = snapshot();
+        snapshot.top_minimized = true;
+        snapshot
+            .resolved_toolbar_items
+            .hidden
+            .insert(ids::TOP_CHROME_CLOSE);
+
+        let spec = TopToolbarSpec::build(&snapshot, &TopStripPlan::unconstrained());
+        assert_eq!(strip_control_ids(&spec), ["top.chrome.restore"]);
+        assert!(spec.chrome().is_empty());
+        assert!(spec.overflow().is_empty());
+        assert_eq!(
+            match spec.strip() {
+                [TopToolbarNode::Control(control)] => control.event(&snapshot),
+                other => panic!("unexpected minimized spec: {other:?}"),
+            },
+            ToolbarEvent::SetTopMinimized(false)
+        );
+    }
+
+    #[test]
+    fn narrow_spec_moves_dropped_controls_to_one_ordered_overflow() {
+        let snapshot = snapshot();
+        let mut plan = TopStripPlan::unconstrained();
+        plan.swatch_count = 0;
+        plan.dropped_tools = vec![Tool::Line, Tool::Arrow];
+        plan.dropped_utilities = vec![
+            TopUtilityButton::Text,
+            TopUtilityButton::StickyNote,
+            TopUtilityButton::Highlight,
+        ];
+        plan.show_overflow = true;
+        plan.compact = true;
+
+        let spec = TopToolbarSpec::build(&snapshot, &plan);
+        let strip_ids = strip_control_ids(&spec);
+        for dropped in [
+            ids::TOP_TOOL_LINE,
+            ids::TOP_TOOL_ARROW,
+            ids::TOP_UTILITY_TEXT,
+            ids::TOP_UTILITY_STICKY_NOTE,
+            ids::TOP_UTILITY_HIGHLIGHT,
+        ] {
+            assert!(!strip_ids.contains(&dropped.as_str().to_string()));
+        }
+        let overflow_ids: Vec<_> = spec
+            .overflow()
+            .iter()
+            .map(|control| control.id().render_id().into_owned())
+            .collect();
+        assert_eq!(
+            overflow_ids,
+            [
+                "top.tool.line",
+                "top.tool.arrow",
+                "top.utility.text",
+                "top.utility.sticky-note",
+                "top.utility.highlight",
+            ]
+        );
+        assert_eq!(
+            chrome_ids(&spec),
+            ["top.chrome.pin", "top.chrome.overflow", "top.chrome.close"]
+        );
+        assert_eq!(
+            spec.overflow()[0].event(&snapshot),
+            ToolbarEvent::SelectTool(Tool::Line)
+        );
+    }
+
+    #[test]
+    fn contextual_ring_is_owned_by_the_highlight_control_spec() {
+        let mut snapshot = snapshot();
+        snapshot.highlight_tool_active = true;
+        snapshot.highlight_tool_ring_enabled = false;
+        let plan = TopStripPlan::unconstrained();
+
+        let spec = TopToolbarSpec::build(&snapshot, &plan);
+        assert_eq!(spec.contextual(), [TopToolbarControl::HighlightRing]);
+        assert_eq!(
+            spec.contextual()[0].event(&snapshot),
+            ToolbarEvent::ToggleHighlightToolRing(true)
+        );
+
+        let mut dropped = plan.clone();
+        dropped.dropped_utilities = vec![TopUtilityButton::Highlight];
+        assert!(
+            TopToolbarSpec::build(&snapshot, &dropped)
+                .contextual()
+                .is_empty()
+        );
+
+        snapshot
+            .resolved_toolbar_items
+            .hidden
+            .insert(ids::TOP_UTILITY_HIGHLIGHT_RING);
+        assert!(
+            TopToolbarSpec::build(&snapshot, &plan)
+                .contextual()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn allocation_free_queries_match_the_materialized_spec() {
+        let regular = snapshot();
+        let mut highlighted = regular.clone();
+        highlighted.highlight_tool_active = true;
+        let mut minimized = highlighted.clone();
+        minimized.top_minimized = true;
+        let mut narrow_plan = TopStripPlan::unconstrained();
+        narrow_plan.show_overflow = true;
+        narrow_plan.dropped_tools = vec![Tool::Line, Tool::Arrow];
+        narrow_plan.dropped_utilities = vec![TopUtilityButton::Text];
+
+        for (snapshot, plan) in [
+            (&regular, TopStripPlan::unconstrained()),
+            (&highlighted, TopStripPlan::unconstrained()),
+            (&highlighted, narrow_plan),
+            (&minimized, TopStripPlan::unconstrained()),
+        ] {
+            let spec = TopToolbarSpec::build(snapshot, &plan);
+            assert_eq!(
+                TopToolbarSpec::shape_picker_visible(snapshot),
+                spec.strip()
+                    .contains(&TopToolbarNode::Control(TopToolbarControl::ShapePicker))
+            );
+            assert_eq!(
+                TopToolbarSpec::contextual_highlight_ring_visible(snapshot, &plan),
+                !spec.contextual().is_empty()
+            );
+            assert_eq!(
+                TopToolbarSpec::chrome_control_count(snapshot, &plan),
+                spec.chrome().len()
+            );
+            assert_eq!(
+                TopToolbarSpec::overflow_control_count(snapshot, &plan),
+                spec.overflow().len()
+            );
+        }
+    }
+
+    #[test]
+    fn customized_visibility_and_order_flow_through_the_spec() {
+        let mut snapshot = snapshot();
+        let mut items = ToolbarItemsConfig::default();
+        items.set_hidden(ids::TOP_UTILITY_STICKY_NOTE, true);
+        assert!(
+            items.move_item_to_index(ToolbarItemOrderGroup::TopTools, ids::TOP_TOOL_ERASER, 0,)
+        );
+        snapshot.resolved_toolbar_items = items.resolved();
+
+        let spec = TopToolbarSpec::build(&snapshot, &TopStripPlan::unconstrained());
+        let ids = strip_control_ids(&spec);
+        let first_tool = ids
+            .iter()
+            .find(|id| id.starts_with("top.tool."))
+            .map(String::as_str);
+        assert_eq!(first_tool, Some("top.tool.eraser"));
+        assert!(!ids.contains(&"top.utility.sticky-note".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Unify the GTK and built-in top toolbars behind a shared, renderer-neutral specification.

Previously, each frontend defined much of the toolbar independently, which made visual and behavioral drift likely. The shared specification now provides the canonical control order, state, labels, tooltips, shortcuts, icons, dividers, and compact/overflow behavior.

## Changes

- Add a shared top-toolbar specification with stable control and event IDs.
- Render the shared specification through both the GTK and built-in backends.
- Centralize toolbar icon mappings.
- Preserve backend-specific presentation while sharing toolbar semantics.
- Add cross-frontend semantic parity tests.
- Add GTK widget-contract coverage without presenting a window.
- Document the shared toolbar architecture.

## Acceptance criteria

- GTK and built-in expose the same top-toolbar controls in the same order.
- Controls have matching visibility, enabled/active state, labels, tooltips, shortcut badges, icons, actions, and popovers.
- Pinning, minimizing/restoring, compact layout, and overflow behavior remain supported.
- Backend-specific styling differences are allowed, such as spacing and color-swatch shape.
- No duplicate or missing controls are introduced.