### PR TITLE
perf(configurator): keep the UI responsive during blocking jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ name = "wayscriber-configurator"
 version = "0.9.22"
 dependencies = [
  "iced",
+ "tokio",
  "wayscriber",
 ]
 

--- a/configurator/Cargo.toml
+++ b/configurator/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 # The configurator edits config and service files; it does not call portal D-Bus APIs directly.
 wayscriber = { path = "..", default-features = false }
 iced = { version = "0.14", default-features = false, features = ["tokio", "tiny-skia", "wayland"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "time", "sync"] }
 
 [features]
 default = ["tablet-input"]

--- a/configurator/README.md
+++ b/configurator/README.md
@@ -20,6 +20,11 @@ configurator binary.
 
 The window loads the current config, lets you tweak values across the tabbed sections, and writes changes back through the guarded `ConfigDocument` save interface.
 
+Config, daemon-setup, and saved-session filesystem/process operations run through a bounded Tokio
+blocking-job adapter. Two jobs may run concurrently; existing request ordering and busy-state gates
+still serialize user mutations. Once started, a durable blocking operation is allowed to finish even
+if its UI task is no longer observed.
+
 ### Handy actions
 
 - **Reload** – re-read `config.toml` from disk and refresh the guarded source revision. A transient load error leaves the last good document and current draft in place.

--- a/configurator/src/app/AGENTS.md
+++ b/configurator/src/app/AGENTS.md
@@ -13,6 +13,8 @@
 ## Invariants
 - Do not do file/process work directly from view code.
 - Preserve non-blocking task behavior and explicit validation feedback.
+- Run synchronous filesystem, locking, and process work from Iced tasks through `blocking_jobs`.
+  One logical operation must use one adapter call; never nest adapter jobs.
 - Session catalog operations must preserve lock checks, artifact movement, primary-file behavior, catalog collision handling, and rollback.
 - Daemon setup behavior must stay aligned with daemon runtime, shared service/shortcut helpers, and packaging service files.
 

--- a/configurator/src/app/blocking_jobs.rs
+++ b/configurator/src/app/blocking_jobs.rs
@@ -1,0 +1,299 @@
+use std::fmt;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Semaphore;
+
+const PRODUCTION_BLOCKING_JOB_LIMIT: usize = 2;
+const SLOW_JOB_THRESHOLD: Duration = Duration::from_millis(250);
+
+static PRODUCTION_RUNNER: LazyLock<BlockingJobRunner> =
+    LazyLock::new(|| BlockingJobRunner::new(PRODUCTION_BLOCKING_JOB_LIMIT));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BlockingJobKind {
+    ConfigLoad,
+    ConfigSave,
+    DaemonStatus,
+    DaemonAction,
+    SessionCatalogLoad,
+    SessionCatalogMutation,
+}
+
+impl fmt::Display for BlockingJobKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::ConfigLoad => "config load",
+            Self::ConfigSave => "config save",
+            Self::DaemonStatus => "daemon status",
+            Self::DaemonAction => "daemon action",
+            Self::SessionCatalogLoad => "session catalog load",
+            Self::SessionCatalogMutation => "session catalog mutation",
+        };
+        formatter.write_str(label)
+    }
+}
+
+#[derive(Clone)]
+struct BlockingJobRunner {
+    permits: Arc<Semaphore>,
+}
+
+impl BlockingJobRunner {
+    fn new(max_concurrent_jobs: usize) -> Self {
+        assert!(
+            max_concurrent_jobs > 0,
+            "blocking job runner needs at least one permit"
+        );
+        Self {
+            permits: Arc::new(Semaphore::new(max_concurrent_jobs)),
+        }
+    }
+
+    async fn run<T, F>(&self, kind: BlockingJobKind, job: F) -> Result<T, String>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Result<T, String> + Send + 'static,
+    {
+        let queued_at = Instant::now();
+        let permit = self
+            .permits
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| format!("{kind} blocking job queue is unavailable"))?;
+        report_slow_phase(kind, "queue wait", queued_at.elapsed());
+
+        let joined = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let started_at = Instant::now();
+            let outcome = catch_unwind(AssertUnwindSafe(job));
+            report_slow_phase(kind, "execution", started_at.elapsed());
+            outcome
+        })
+        .await;
+
+        let outcome =
+            joined.map_err(|err| format!("{kind} blocking job did not complete: {err}"))?;
+
+        match outcome {
+            Ok(result) => result,
+            Err(_) => Err(format!("{kind} blocking job panicked")),
+        }
+    }
+}
+
+pub(super) async fn run_blocking<T, F>(kind: BlockingJobKind, job: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    PRODUCTION_RUNNER.run(kind, job).await
+}
+
+fn report_slow_phase(kind: BlockingJobKind, phase: &str, elapsed: Duration) {
+    if elapsed >= SLOW_JOB_THRESHOLD {
+        eprintln!(
+            "wayscriber configurator: slow {kind} blocking job {phase}: {:.0} ms",
+            elapsed.as_secs_f64() * 1_000.0
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::thread;
+
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn success_and_failure_pass_through_unchanged() {
+        let runner = BlockingJobRunner::new(1);
+
+        assert_eq!(
+            runner
+                .run(BlockingJobKind::ConfigLoad, || Ok::<_, String>(42))
+                .await,
+            Ok(42)
+        );
+        assert_eq!(
+            runner
+                .run::<(), _>(BlockingJobKind::ConfigSave, || Err(
+                    "write failed".to_string()
+                ))
+                .await,
+            Err("write failed".to_string())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn blocking_work_is_offloaded_while_executor_work_progresses() {
+        let runner = BlockingJobRunner::new(1);
+        let caller_thread = thread::current().id();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let job = tokio::spawn(async move {
+            runner
+                .run(BlockingJobKind::DaemonStatus, move || {
+                    started_tx.send(thread::current().id()).ok();
+                    release_rx.recv().map_err(|err| err.to_string())?;
+                    Ok(())
+                })
+                .await
+        });
+
+        let blocking_thread = timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("blocking closure should start")
+            .expect("blocking closure should report its thread");
+        assert_ne!(blocking_thread, caller_thread);
+
+        let unrelated = tokio::spawn(async { 17 });
+        assert_eq!(
+            timeout(Duration::from_secs(1), unrelated)
+                .await
+                .expect("unrelated executor work should progress")
+                .expect("unrelated executor task should complete"),
+            17
+        );
+
+        release_tx.send(()).unwrap();
+        assert_eq!(job.await.unwrap(), Ok(()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn one_permit_prevents_a_second_closure_from_starting() {
+        let runner = BlockingJobRunner::new(1);
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_runner = runner.clone();
+        let first = tokio::spawn(async move {
+            first_runner
+                .run(BlockingJobKind::SessionCatalogMutation, move || {
+                    first_started_tx.send(()).ok();
+                    first_release_rx.recv().map_err(|err| err.to_string())?;
+                    Ok(())
+                })
+                .await
+        });
+        timeout(Duration::from_secs(1), first_started_rx)
+            .await
+            .expect("first closure should start")
+            .expect("first closure should report startup");
+
+        let (second_started_tx, mut second_started_rx) = tokio::sync::oneshot::channel();
+        let second = tokio::spawn(async move {
+            runner
+                .run(BlockingJobKind::SessionCatalogLoad, move || {
+                    second_started_tx.send(()).ok();
+                    Ok(())
+                })
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(50), &mut second_started_rx)
+                .await
+                .is_err(),
+            "second closure entered while the sole permit was held"
+        );
+
+        first_release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(1), &mut second_started_rx)
+            .await
+            .expect("second closure should start after permit release")
+            .expect("second closure should report startup");
+        assert_eq!(first.await.unwrap(), Ok(()));
+        assert_eq!(second.await.unwrap(), Ok(()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn panic_becomes_an_error_and_releases_the_permit() {
+        let runner = BlockingJobRunner::new(1);
+        let error = runner
+            .run::<(), _>(BlockingJobKind::DaemonAction, || {
+                panic!("synthetic blocking job panic")
+            })
+            .await
+            .unwrap_err();
+        assert!(error.contains("daemon action"));
+        assert!(error.contains("panicked"));
+
+        assert_eq!(
+            timeout(
+                Duration::from_secs(1),
+                runner.run(BlockingJobKind::ConfigLoad, || Ok::<_, String>("recovered"))
+            )
+            .await
+            .expect("permit should be released after panic"),
+            Ok("recovered")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_the_waiter_does_not_release_a_running_jobs_permit() {
+        let runner = BlockingJobRunner::new(1);
+        let (first_started_tx, first_started_rx) = tokio::sync::oneshot::channel();
+        let (first_release_tx, first_release_rx) = mpsc::channel();
+        let first_runner = runner.clone();
+        let first = tokio::spawn(async move {
+            first_runner
+                .run(BlockingJobKind::SessionCatalogMutation, move || {
+                    first_started_tx.send(()).ok();
+                    first_release_rx.recv().map_err(|err| err.to_string())?;
+                    Ok(())
+                })
+                .await
+        });
+        timeout(Duration::from_secs(1), first_started_rx)
+            .await
+            .expect("first closure should start")
+            .expect("first closure should report startup");
+
+        first.abort();
+        assert!(
+            first
+                .await
+                .expect_err("the async waiter should be cancelled")
+                .is_cancelled()
+        );
+        assert_eq!(
+            runner.permits.available_permits(),
+            0,
+            "the detached blocking closure must retain its permit"
+        );
+
+        let (second_started_tx, mut second_started_rx) = tokio::sync::oneshot::channel();
+        let second = tokio::spawn(async move {
+            runner
+                .run(BlockingJobKind::SessionCatalogLoad, move || {
+                    second_started_tx.send(()).ok();
+                    Ok(())
+                })
+                .await
+        });
+        assert!(
+            timeout(Duration::from_millis(50), &mut second_started_rx)
+                .await
+                .is_err(),
+            "cancelling the waiter released the running closure's permit"
+        );
+
+        first_release_tx.send(()).unwrap();
+        timeout(Duration::from_secs(1), &mut second_started_rx)
+            .await
+            .expect("second closure should start after detached work finishes")
+            .expect("second closure should report startup");
+        assert_eq!(second.await.unwrap(), Ok(()));
+    }
+
+    #[test]
+    fn production_concurrency_is_bounded_to_two_jobs() {
+        assert_eq!(PRODUCTION_BLOCKING_JOB_LIMIT, 2);
+    }
+}

--- a/configurator/src/app/daemon_setup/mod.rs
+++ b/configurator/src/app/daemon_setup/mod.rs
@@ -20,17 +20,26 @@ use service::{
 };
 use shortcut::{apply_shortcut, read_configured_shortcut, read_portal_shortcut_dropin_state};
 
+use super::blocking_jobs::{BlockingJobKind, run_blocking};
+
 pub(super) async fn load_daemon_runtime_status() -> Result<DaemonRuntimeStatus, String> {
-    load_daemon_runtime_status_sync()
+    run_blocking(
+        BlockingJobKind::DaemonStatus,
+        load_daemon_runtime_status_sync,
+    )
+    .await
 }
 
 pub(super) async fn perform_daemon_action(
     action: DaemonAction,
     shortcut_input: String,
 ) -> Result<DaemonActionResult, String> {
-    let message = perform_daemon_action_sync(action, shortcut_input.trim())?;
-    let status = load_daemon_runtime_status_sync()?;
-    Ok(DaemonActionResult { status, message })
+    run_blocking(BlockingJobKind::DaemonAction, move || {
+        let message = perform_daemon_action_sync(action, shortcut_input.trim())?;
+        let status = load_daemon_runtime_status_sync()?;
+        Ok(DaemonActionResult { status, message })
+    })
+    .await
 }
 
 fn perform_daemon_action_sync(
@@ -83,7 +92,7 @@ fn perform_daemon_action_sync(
     }
 }
 
-fn load_daemon_runtime_status_sync() -> Result<DaemonRuntimeStatus, String> {
+pub(super) fn load_daemon_runtime_status_sync() -> Result<DaemonRuntimeStatus, String> {
     let desktop = DesktopEnvironment::detect_current();
     let systemctl_available = command_available("systemctl");
     let gsettings_available = command_available("gsettings");

--- a/configurator/src/app/io.rs
+++ b/configurator/src/app/io.rs
@@ -2,20 +2,28 @@ use std::{path::PathBuf, sync::Arc};
 
 use wayscriber::config::{Config, ConfigDocument};
 
+use super::blocking_jobs::{BlockingJobKind, run_blocking};
+
 pub(super) async fn load_config_from_disk() -> Result<(Arc<ConfigDocument>, Option<String>), String>
 {
-    ConfigDocument::load_for_editing()
-        .map(|(document, warning)| (Arc::new(document), warning))
-        .map_err(|err| format!("{err:#}"))
+    run_blocking(BlockingJobKind::ConfigLoad, || {
+        ConfigDocument::load_for_editing()
+            .map(|(document, warning)| (Arc::new(document), warning))
+            .map_err(|err| format!("{err:#}"))
+    })
+    .await
 }
 
 pub(super) async fn save_config_to_disk(
     document: Arc<ConfigDocument>,
     config: Config,
 ) -> Result<(Option<PathBuf>, Arc<ConfigDocument>), String> {
-    let outcome = document
-        .save_with_backup(config)
-        .map_err(|err| format!("{err:#}"))?;
-    let (document, backup) = outcome.into_parts();
-    Ok((backup, Arc::new(document)))
+    run_blocking(BlockingJobKind::ConfigSave, move || {
+        let outcome = document
+            .save_with_backup(config)
+            .map_err(|err| format!("{err:#}"))?;
+        let (document, backup) = outcome.into_parts();
+        Ok((backup, Arc::new(document)))
+    })
+    .await
 }

--- a/configurator/src/app/mod.rs
+++ b/configurator/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod blocking_jobs;
 mod daemon_setup;
 mod entry;
 mod io;

--- a/configurator/src/app/session_catalog.rs
+++ b/configurator/src/app/session_catalog.rs
@@ -7,7 +7,8 @@ use wayscriber::session::try_lock_exclusive;
 
 use crate::models::{DaemonRuntimeStatus, SessionCatalogActionResult, SessionCatalogItem};
 
-use super::daemon_setup::load_daemon_runtime_status;
+use super::blocking_jobs::{BlockingJobKind, run_blocking};
+use super::daemon_setup::load_daemon_runtime_status_sync;
 mod duplicate;
 mod move_file;
 
@@ -15,158 +16,133 @@ pub(super) use duplicate::duplicate_session_catalog_entry;
 pub(super) use move_file::move_session_catalog_entry;
 
 pub(super) async fn load_session_catalog() -> Result<Vec<SessionCatalogItem>, String> {
-    load_session_catalog_sync()
+    run_blocking(
+        BlockingJobKind::SessionCatalogLoad,
+        load_session_catalog_sync,
+    )
+    .await
 }
 
 pub(super) async fn forget_session_catalog_entry(
     id: String,
 ) -> Result<SessionCatalogActionResult, String> {
-    let removed =
-        wayscriber::session::catalog::forget_session_by_id(&id).map_err(|err| err.to_string())?;
-    let items = load_session_catalog_sync()?;
-    Ok(SessionCatalogActionResult::success(
-        if removed {
-            "Forgot session metadata.".to_string()
-        } else {
-            "Session was already absent from the catalog.".to_string()
-        },
-        items,
-    ))
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let removed = wayscriber::session::catalog::forget_session_by_id(&id)
+            .map_err(|err| err.to_string())?;
+        let items = load_session_catalog_sync()?;
+        Ok(SessionCatalogActionResult::success(
+            if removed {
+                "Forgot session metadata.".to_string()
+            } else {
+                "Session was already absent from the catalog.".to_string()
+            },
+            items,
+        ))
+    })
+    .await
 }
 
 pub(super) async fn rename_session_catalog_entry(
     id: String,
     display_name: String,
 ) -> Result<SessionCatalogActionResult, String> {
-    let renamed =
-        wayscriber::session::catalog::rename_session_display_name_by_id(&id, display_name.trim())
-            .map_err(|err| err.to_string())?;
-    let items = load_session_catalog_sync()?;
-    Ok(SessionCatalogActionResult::success(
-        if let Some(entry) = renamed {
-            format!("Renamed session to {}.", entry.display_name)
-        } else {
-            "Session was already absent from the catalog.".to_string()
-        },
-        items,
-    ))
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let renamed = wayscriber::session::catalog::rename_session_display_name_by_id(
+            &id,
+            display_name.trim(),
+        )
+        .map_err(|err| err.to_string())?;
+        let items = load_session_catalog_sync()?;
+        Ok(SessionCatalogActionResult::success(
+            if let Some(entry) = renamed {
+                format!("Renamed session to {}.", entry.display_name)
+            } else {
+                "Session was already absent from the catalog.".to_string()
+            },
+            items,
+        ))
+    })
+    .await
 }
 
 pub(super) async fn reveal_session_catalog_entry(
     id: String,
 ) -> Result<SessionCatalogActionResult, String> {
-    let item = find_session_catalog_item(&id)?;
-    reveal_path_parent(&item.path)?;
-    let items = load_session_catalog_sync()?;
-    Ok(SessionCatalogActionResult::success(
-        format!("Opened folder for {}.", item.display_name),
-        items,
-    ))
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let item = find_session_catalog_item(&id)?;
+        reveal_path_parent(&item.path)?;
+        let items = load_session_catalog_sync()?;
+        Ok(SessionCatalogActionResult::success(
+            format!("Opened folder for {}.", item.display_name),
+            items,
+        ))
+    })
+    .await
 }
 
 pub(super) async fn clear_session_catalog_entry(
     id: String,
 ) -> Result<SessionCatalogActionResult, String> {
-    let status = load_daemon_runtime_status().await?;
-    let item = find_session_catalog_item(&id)?;
-    let _daemon_lock = acquire_runtime_lock_for_inactive_operation(
-        RuntimeLockKind::Daemon,
-        CatalogOperation::Clear,
-    )?;
-    let _overlay_lock = acquire_runtime_lock_for_inactive_operation(
-        RuntimeLockKind::Overlay,
-        CatalogOperation::Clear,
-    )?;
-    if let Some(blocker) = service_status_blocker(Some(&status), CatalogOperation::Clear) {
-        return Err(blocker);
-    }
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let status = load_daemon_runtime_status_sync()?;
+        let item = find_session_catalog_item(&id)?;
+        let _daemon_lock = acquire_runtime_lock_for_inactive_operation(
+            RuntimeLockKind::Daemon,
+            CatalogOperation::Clear,
+        )?;
+        let _overlay_lock = acquire_runtime_lock_for_inactive_operation(
+            RuntimeLockKind::Overlay,
+            CatalogOperation::Clear,
+        )?;
+        if let Some(blocker) = service_status_blocker(Some(&status), CatalogOperation::Clear) {
+            return Err(blocker);
+        }
 
-    let outcome = wayscriber::session::clear_named_session_non_lock_artifacts(&item.path)
-        .map_err(|err| err.to_string())?;
-    let items = load_session_catalog_sync()?;
-    Ok(SessionCatalogActionResult::success(
-        if outcome.removed_any() {
-            format!("Cleared saved data for {}.", item.display_name)
-        } else {
-            format!("No saved data found for {}.", item.display_name)
-        },
-        items,
-    ))
+        let outcome = wayscriber::session::clear_named_session_non_lock_artifacts(&item.path)
+            .map_err(|err| err.to_string())?;
+        let items = load_session_catalog_sync()?;
+        Ok(SessionCatalogActionResult::success(
+            if outcome.removed_any() {
+                format!("Cleared saved data for {}.", item.display_name)
+            } else {
+                format!("No saved data found for {}.", item.display_name)
+            },
+            items,
+        ))
+    })
+    .await
 }
 
 pub(super) async fn clear_session_catalog_tool_state_entry(
     id: String,
 ) -> Result<SessionCatalogActionResult, String> {
-    let status = load_daemon_runtime_status().await?;
-    let item = find_session_catalog_item(&id)?;
-    let _daemon_lock = acquire_runtime_lock_for_inactive_operation(
-        RuntimeLockKind::Daemon,
-        CatalogOperation::ClearToolState,
-    )?;
-    let _overlay_lock = acquire_runtime_lock_for_inactive_operation(
-        RuntimeLockKind::Overlay,
-        CatalogOperation::ClearToolState,
-    )?;
-    if let Some(blocker) = service_status_blocker(Some(&status), CatalogOperation::ClearToolState) {
-        return Err(blocker);
-    }
-
-    let options = named_session_options_for_catalog_item(&item)?;
-    let outcome = wayscriber::session::clear_tool_state(&options).map_err(|err| err.to_string())?;
-    let items = load_session_catalog_sync()?;
-    Ok(SessionCatalogActionResult::success(
-        clear_tool_state_catalog_message(&item.display_name, outcome),
-        items,
-    ))
-}
-
-pub(super) fn session_clear_blocker(status: Option<&DaemonRuntimeStatus>) -> Option<String> {
-    inactive_operation_blocker(status, CatalogOperation::Clear)
-}
-
-pub(super) fn session_clear_tool_state_blocker(
-    status: Option<&DaemonRuntimeStatus>,
-) -> Option<String> {
-    inactive_operation_blocker(status, CatalogOperation::ClearToolState)
-}
-
-pub(super) fn session_duplicate_blocker(status: Option<&DaemonRuntimeStatus>) -> Option<String> {
-    inactive_operation_blocker(status, CatalogOperation::Duplicate)
-}
-
-pub(super) fn session_move_blocker(status: Option<&DaemonRuntimeStatus>) -> Option<String> {
-    inactive_operation_blocker(status, CatalogOperation::Move)
-}
-
-fn inactive_operation_blocker(
-    status: Option<&DaemonRuntimeStatus>,
-    operation: CatalogOperation,
-) -> Option<String> {
-    match runtime_lock_active(RuntimeLockKind::Overlay, operation) {
-        Ok(true) => {
-            return Some(
-                operation
-                    .running_message(RuntimeLockKind::Overlay)
-                    .to_string(),
-            );
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let status = load_daemon_runtime_status_sync()?;
+        let item = find_session_catalog_item(&id)?;
+        let _daemon_lock = acquire_runtime_lock_for_inactive_operation(
+            RuntimeLockKind::Daemon,
+            CatalogOperation::ClearToolState,
+        )?;
+        let _overlay_lock = acquire_runtime_lock_for_inactive_operation(
+            RuntimeLockKind::Overlay,
+            CatalogOperation::ClearToolState,
+        )?;
+        if let Some(blocker) =
+            service_status_blocker(Some(&status), CatalogOperation::ClearToolState)
+        {
+            return Err(blocker);
         }
-        Ok(false) => {}
-        Err(err) => return Some(err),
-    }
 
-    match runtime_lock_active(RuntimeLockKind::Daemon, operation) {
-        Ok(true) => {
-            return Some(
-                operation
-                    .running_message(RuntimeLockKind::Daemon)
-                    .to_string(),
-            );
-        }
-        Ok(false) => {}
-        Err(err) => return Some(err),
-    }
-
-    service_status_blocker(status, operation)
+        let options = named_session_options_for_catalog_item(&item)?;
+        let outcome =
+            wayscriber::session::clear_tool_state(&options).map_err(|err| err.to_string())?;
+        let items = load_session_catalog_sync()?;
+        Ok(SessionCatalogActionResult::success(
+            clear_tool_state_catalog_message(&item.display_name, outcome),
+            items,
+        ))
+    })
+    .await
 }
 
 pub(super) fn session_clear_cached_status_blocker(
@@ -355,6 +331,7 @@ impl CatalogOperation {
     }
 }
 
+#[cfg(test)]
 fn runtime_lock_active(kind: RuntimeLockKind, operation: CatalogOperation) -> Result<bool, String> {
     let path = kind.path();
     let file = match OpenOptions::new().read(true).write(true).open(&path) {
@@ -446,6 +423,7 @@ impl CatalogOperation {
     }
 }
 
+#[cfg(test)]
 fn drop_lock(file: File) {
     drop(file);
 }

--- a/configurator/src/app/session_catalog/duplicate.rs
+++ b/configurator/src/app/session_catalog/duplicate.rs
@@ -7,14 +7,18 @@ use super::{
     load_session_catalog_sync, service_status_blocker,
 };
 
-use super::super::daemon_setup::load_daemon_runtime_status;
+use super::super::blocking_jobs::{BlockingJobKind, run_blocking};
+use super::super::daemon_setup::load_daemon_runtime_status_sync;
 
 pub(crate) async fn duplicate_session_catalog_entry(
     id: String,
     target: PathBuf,
 ) -> Result<SessionCatalogActionResult, String> {
-    let status = load_daemon_runtime_status().await?;
-    duplicate_session_catalog_entry_sync(&id, &target, &status)
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let status = load_daemon_runtime_status_sync()?;
+        duplicate_session_catalog_entry_sync(&id, &target, &status)
+    })
+    .await
 }
 
 fn duplicate_session_catalog_entry_sync(

--- a/configurator/src/app/session_catalog/move_file.rs
+++ b/configurator/src/app/session_catalog/move_file.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 
 use crate::models::{DaemonRuntimeStatus, SessionCatalogActionResult, SessionCatalogItem};
 
-use super::super::daemon_setup::load_daemon_runtime_status;
+use super::super::blocking_jobs::{BlockingJobKind, run_blocking};
+use super::super::daemon_setup::load_daemon_runtime_status_sync;
 use super::{
     CatalogOperation, RuntimeLockKind, acquire_runtime_lock_for_inactive_operation,
     load_session_catalog_sync, service_status_blocker,
@@ -12,8 +13,11 @@ pub(crate) async fn move_session_catalog_entry(
     id: String,
     target: PathBuf,
 ) -> Result<SessionCatalogActionResult, String> {
-    let status = load_daemon_runtime_status().await?;
-    move_session_catalog_entry_sync(&id, &target, &status)
+    run_blocking(BlockingJobKind::SessionCatalogMutation, move || {
+        let status = load_daemon_runtime_status_sync()?;
+        move_session_catalog_entry_sync(&id, &target, &status)
+    })
+    .await
 }
 
 fn move_session_catalog_entry_sync(

--- a/configurator/src/app/session_catalog/tests.rs
+++ b/configurator/src/app/session_catalog/tests.rs
@@ -55,75 +55,81 @@ fn daemon_status(active: bool) -> DaemonRuntimeStatus {
 }
 
 #[test]
-fn session_clear_blocker_blocks_running_daemon() {
+fn session_clear_cached_status_blocker_blocks_running_daemon() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
     let status = daemon_status(true);
 
-    let blocker = session_clear_blocker(Some(&status)).expect("daemon should block clear");
+    let blocker =
+        session_clear_cached_status_blocker(Some(&status)).expect("daemon should block clear");
 
     assert!(blocker.contains("background service"));
 }
 
 #[test]
-fn session_clear_blocker_allows_inactive_daemon_when_overlay_lock_is_free() {
+fn session_clear_cached_status_blocker_allows_inactive_daemon() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
     let status = daemon_status(false);
 
-    let blocker = session_clear_blocker(Some(&status));
+    let blocker = session_clear_cached_status_blocker(Some(&status));
 
     assert!(blocker.is_none(), "{blocker:?}");
 }
 
 #[test]
-fn session_duplicate_blocker_uses_duplicate_status_message() {
+fn session_duplicate_cached_status_blocker_uses_duplicate_status_message() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
-    let blocker = session_duplicate_blocker(None).expect("unknown status should block duplicate");
+    let blocker = session_duplicate_cached_status_blocker(None)
+        .expect("unknown status should block duplicate");
 
     assert!(blocker.contains("Duplicate Session"));
 }
 
 #[test]
-fn session_move_blocker_uses_move_status_message() {
+fn session_move_cached_status_blocker_uses_move_status_message() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
-    let blocker = session_move_blocker(None).expect("unknown status should block move");
+    let blocker =
+        session_move_cached_status_blocker(None).expect("unknown status should block move");
 
     assert!(blocker.contains("Move Session"));
 }
 
 #[test]
-fn session_clear_blocker_blocks_unknown_daemon_status() {
+fn session_clear_cached_status_blocker_blocks_unknown_daemon_status() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
-    let blocker = session_clear_blocker(None).expect("unknown status should block clear");
+    let blocker =
+        session_clear_cached_status_blocker(None).expect("unknown status should block clear");
 
     assert!(blocker.contains("status finishes loading"));
 }
 
 #[test]
-fn session_clear_tool_state_blocker_uses_tool_state_status_message() {
+fn session_clear_tool_state_cached_status_blocker_uses_tool_state_status_message() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
-    let blocker =
-        session_clear_tool_state_blocker(None).expect("unknown status should block tool reset");
+    let blocker = session_clear_tool_state_cached_status_blocker(None)
+        .expect("unknown status should block tool reset");
 
     assert!(blocker.contains("Clear saved tool state"));
     assert!(blocker.contains("status finishes loading"));
 }
 
 #[test]
-fn session_clear_blocker_blocks_manual_daemon_lock() {
+fn session_clear_transaction_guard_blocks_manual_daemon_lock() {
     let temp = crate::test_temp::tempdir().unwrap();
     let _env = RuntimeEnvGuard::set_xdg_runtime_dir(temp.path());
     let _daemon_lock = acquire_runtime_lock_for_clear(RuntimeLockKind::Daemon).unwrap();
-    let status = daemon_status(false);
+    let error = acquire_runtime_lock_for_inactive_operation(
+        RuntimeLockKind::Daemon,
+        CatalogOperation::Clear,
+    )
+    .expect_err("held daemon lock should block the transaction");
 
-    let blocker = session_clear_blocker(Some(&status)).expect("daemon lock should block clear");
-
-    assert!(blocker.contains("manually started daemon"));
+    assert!(error.contains("manually started daemon"));
 }
 
 #[test]

--- a/configurator/src/app/update/session_catalog.rs
+++ b/configurator/src/app/update/session_catalog.rs
@@ -6,8 +6,8 @@ use crate::app::session_catalog::{
     clear_session_catalog_entry, clear_session_catalog_tool_state_entry,
     duplicate_session_catalog_entry, forget_session_catalog_entry, load_session_catalog,
     move_session_catalog_entry, rename_session_catalog_entry, reveal_session_catalog_entry,
-    session_clear_blocker, session_clear_tool_state_blocker, session_duplicate_blocker,
-    session_move_blocker,
+    session_clear_cached_status_blocker, session_clear_tool_state_cached_status_blocker,
+    session_duplicate_cached_status_blocker, session_move_cached_status_blocker,
 };
 use crate::messages::Message;
 use crate::models::{SessionCatalogActionResult, SessionCatalogItem};
@@ -111,7 +111,8 @@ impl ConfiguratorApp {
         if self.session_catalog.busy {
             return Task::none();
         }
-        if let Some(blocker) = session_duplicate_blocker(self.daemon_status.as_ref()) {
+        if let Some(blocker) = session_duplicate_cached_status_blocker(self.daemon_status.as_ref())
+        {
             self.status = StatusMessage::warning(blocker);
             return Task::none();
         }
@@ -147,7 +148,7 @@ impl ConfiguratorApp {
         if self.session_catalog.busy {
             return Task::none();
         }
-        if let Some(blocker) = session_move_blocker(self.daemon_status.as_ref()) {
+        if let Some(blocker) = session_move_cached_status_blocker(self.daemon_status.as_ref()) {
             self.status = StatusMessage::warning(blocker);
             return Task::none();
         }
@@ -190,7 +191,9 @@ impl ConfiguratorApp {
         if self.session_catalog.busy {
             return Task::none();
         }
-        if let Some(blocker) = session_clear_tool_state_blocker(self.daemon_status.as_ref()) {
+        if let Some(blocker) =
+            session_clear_tool_state_cached_status_blocker(self.daemon_status.as_ref())
+        {
             self.status = StatusMessage::warning(blocker);
             return Task::none();
         }
@@ -212,7 +215,7 @@ impl ConfiguratorApp {
         if self.session_catalog.busy {
             return Task::none();
         }
-        if let Some(blocker) = session_clear_blocker(self.daemon_status.as_ref()) {
+        if let Some(blocker) = session_clear_cached_status_blocker(self.daemon_status.as_ref()) {
             self.status = StatusMessage::warning(blocker);
             return Task::none();
         }


### PR DESCRIPTION
## Summary

- Offload synchronous config, daemon, and saved-session operations from the configurator’s async executor.
- Run blocking work through a shared Tokio adapter limited to two concurrent jobs.
- Preserve existing request ordering, busy-state gates, runtime locks, and session mutation behavior.
- Keep durable operations running to completion if their UI task is dropped.
- Report blocking-job queue or execution times exceeding 250 ms.

## Why

Config file access, filesystem locking, session catalog operations, and systemd commands could run directly on the configurator’s executor. If one of these operations became slow, it could delay unrelated UI work and make the configurator appear frozen.