### PR TITLE
fix(config): limit runtime saves to the changed setting

### DIFF
--- a/src/backend/wayland/backend/event_loop/capture.rs
+++ b/src/backend/wayland/backend/event_loop/capture.rs
@@ -107,7 +107,7 @@ pub(super) fn handle_pending_actions(
                 state.handle_keybinding_edit(request);
             }
             PendingBackendAction::PersistToolbarConfig => {
-                state.save_toolbar_pin_config();
+                state.save_toolbar_display_config();
             }
         }
     }
@@ -117,8 +117,8 @@ pub(super) fn handle_pending_actions(
     if let Some(action) = state.input_state.take_pending_zoom_action() {
         state.handle_zoom_action(action);
     }
-    if let Some(boards) = state.input_state.take_pending_board_config() {
-        state.apply_board_config_update(boards);
+    if let Some(update) = state.input_state.take_pending_board_config_update() {
+        state.apply_board_config_update(update);
     }
     state.sync_zoom_board_mode();
 

--- a/src/backend/wayland/state/boards.rs
+++ b/src/backend/wayland/state/boards.rs
@@ -1,11 +1,15 @@
-use crate::config::BoardsConfig;
+use crate::config::BoardItemConfig;
 use crate::input::DrawingState;
+use crate::input::boards::PendingBoardConfigUpdate;
 
 use super::WaylandState;
 
 impl WaylandState {
-    pub(in crate::backend::wayland) fn apply_board_config_update(&mut self, boards: BoardsConfig) {
-        self.config.boards = Some(boards);
+    pub(in crate::backend::wayland) fn apply_board_config_update(
+        &mut self,
+        update: PendingBoardConfigUpdate,
+    ) {
+        apply_board_config_update_to_config(&mut self.config, update);
         if let Err(err) = self.config.save() {
             log::warn!("Failed to save board config: {}", err);
         }
@@ -145,5 +149,414 @@ impl WaylandState {
             && !self.pointer_over_toolbar()
             && self.toolbar_focus_target().is_none()
             && matches!(self.input_state.state, DrawingState::Idle)
+    }
+}
+
+fn apply_board_config_update_to_config(
+    config: &mut crate::config::Config,
+    update: PendingBoardConfigUpdate,
+) {
+    if config
+        .boards
+        .as_ref()
+        .is_none_or(|boards| boards.items.is_empty())
+    {
+        config.boards = Some(config.resolved_boards());
+    }
+    let boards = config.boards.as_mut().expect("resolved boards are present");
+    let PendingBoardConfigUpdate {
+        snapshot,
+        structure_changed,
+        created_ids,
+        deleted_ids: _,
+        changed_names,
+        changed_appearances,
+        changed_pins,
+    } = update;
+
+    let apply_changed_fields = |saved: &mut BoardItemConfig, live: &BoardItemConfig| {
+        if changed_names.contains(&live.id) {
+            saved.name = live.name.clone();
+        }
+        if changed_appearances.contains(&live.id) {
+            saved.background = live.background.clone();
+            saved.default_pen_color = live.default_pen_color.clone();
+        }
+        if changed_pins.contains(&live.id) {
+            saved.pinned = live.pinned;
+        }
+    };
+
+    if structure_changed {
+        boards.default_board = snapshot.default_board.clone();
+        let mut existing = std::mem::take(&mut boards.items);
+        boards.items = snapshot
+            .items
+            .into_iter()
+            .map(|live| {
+                if created_ids.contains(&live.id) {
+                    return live;
+                }
+                if let Some(index) = existing.iter().position(|saved| saved.id == live.id) {
+                    let mut saved = existing.remove(index);
+                    apply_changed_fields(&mut saved, &live);
+                    saved
+                } else {
+                    live
+                }
+            })
+            .collect();
+        return;
+    }
+
+    for live in snapshot.items {
+        let changed = changed_names.contains(&live.id)
+            || changed_appearances.contains(&live.id)
+            || changed_pins.contains(&live.id);
+        if !changed {
+            continue;
+        }
+        if let Some(saved) = boards.items.iter_mut().find(|saved| saved.id == live.id) {
+            apply_changed_fields(saved, &live);
+        } else {
+            boards.items.push(live);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::BoardsConfig;
+    use crate::input::boards::{BoardConfigChange, PendingBoardConfigUpdate};
+
+    fn board_mut<'a>(
+        boards: &'a mut BoardsConfig,
+        id: &str,
+    ) -> &'a mut crate::config::BoardItemConfig {
+        boards
+            .items
+            .iter_mut()
+            .find(|item| item.id == id)
+            .unwrap_or_else(|| panic!("missing test board {id}"))
+    }
+
+    #[test]
+    fn board_reorder_preserves_unrelated_live_item_fields() {
+        let mut config = crate::config::Config::default();
+        let configured = config.boards.as_mut().expect("configured boards");
+        board_mut(configured, "whiteboard").pinned = true;
+        board_mut(configured, "whiteboard").name = "Configured whiteboard".to_string();
+
+        let mut live = configured.clone();
+        board_mut(&mut live, "whiteboard").pinned = false;
+        board_mut(&mut live, "whiteboard").name = "Unrelated live name".to_string();
+        let whiteboard = live
+            .items
+            .iter()
+            .position(|item| item.id == "whiteboard")
+            .expect("whiteboard index");
+        let blackboard = live
+            .items
+            .iter()
+            .position(|item| item.id == "blackboard")
+            .expect("blackboard index");
+        live.items.swap(whiteboard, blackboard);
+
+        apply_board_config_update_to_config(
+            &mut config,
+            PendingBoardConfigUpdate::new(live, BoardConfigChange::Structure),
+        );
+
+        let saved = config.boards.as_ref().expect("saved boards");
+        let saved_whiteboard = saved
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("saved whiteboard");
+        assert!(saved_whiteboard.pinned);
+        assert_eq!(saved_whiteboard.name, "Configured whiteboard");
+        assert!(
+            saved
+                .items
+                .iter()
+                .position(|item| item.id == "blackboard")
+                .expect("saved blackboard index")
+                < saved
+                    .items
+                    .iter()
+                    .position(|item| item.id == "whiteboard")
+                    .expect("saved whiteboard index")
+        );
+    }
+
+    #[test]
+    fn board_field_update_changes_only_the_named_field() {
+        let mut config = crate::config::Config::default();
+        let configured = config.boards.as_mut().expect("configured boards");
+        board_mut(configured, "whiteboard").pinned = true;
+        let original_background = board_mut(configured, "whiteboard").background.clone();
+
+        let mut live = configured.clone();
+        board_mut(&mut live, "whiteboard").name = "Renamed".to_string();
+        board_mut(&mut live, "whiteboard").pinned = false;
+
+        apply_board_config_update_to_config(
+            &mut config,
+            PendingBoardConfigUpdate::new(live, BoardConfigChange::Name("whiteboard".to_string())),
+        );
+
+        let saved = config.boards.as_ref().expect("saved boards");
+        let saved_whiteboard = saved
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("saved whiteboard");
+        assert_eq!(saved_whiteboard.name, "Renamed");
+        assert!(saved_whiteboard.pinned);
+        assert_eq!(
+            saved_whiteboard.background.rgb_for_test(),
+            original_background.rgb_for_test()
+        );
+    }
+
+    #[test]
+    fn board_appearance_update_changes_only_the_appearance_fields() {
+        let mut config = crate::config::Config::default();
+        let configured = config.boards.as_mut().expect("configured boards");
+        board_mut(configured, "whiteboard").name = "Configured whiteboard".to_string();
+        board_mut(configured, "whiteboard").pinned = true;
+
+        let replacement = configured
+            .items
+            .iter()
+            .find(|item| item.id == "blackboard")
+            .expect("blackboard appearance")
+            .clone();
+        let mut live = configured.clone();
+        let live_whiteboard = board_mut(&mut live, "whiteboard");
+        live_whiteboard.background = replacement.background.clone();
+        live_whiteboard.default_pen_color = replacement.default_pen_color.clone();
+        live_whiteboard.name = "Unrelated live name".to_string();
+        live_whiteboard.pinned = false;
+
+        apply_board_config_update_to_config(
+            &mut config,
+            PendingBoardConfigUpdate::new(
+                live,
+                BoardConfigChange::Appearance("whiteboard".to_string()),
+            ),
+        );
+
+        let saved = config.boards.as_ref().expect("saved boards");
+        let saved_whiteboard = saved
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("saved whiteboard");
+        assert_eq!(
+            saved_whiteboard.background.rgb_for_test(),
+            replacement.background.rgb_for_test()
+        );
+        assert_eq!(
+            saved_whiteboard
+                .default_pen_color
+                .as_ref()
+                .map(crate::config::BoardColorConfig::rgb),
+            replacement
+                .default_pen_color
+                .as_ref()
+                .map(crate::config::BoardColorConfig::rgb)
+        );
+        assert_eq!(saved_whiteboard.name, "Configured whiteboard");
+        assert!(saved_whiteboard.pinned);
+    }
+
+    #[test]
+    fn coalesced_board_pin_and_reorder_apply_both_without_copying_other_fields() {
+        let mut config = crate::config::Config::default();
+        let configured = config.boards.as_mut().expect("configured boards");
+        board_mut(configured, "whiteboard").name = "Configured whiteboard".to_string();
+
+        let mut live = configured.clone();
+        board_mut(&mut live, "whiteboard").pinned = true;
+        let mut update = PendingBoardConfigUpdate::new(
+            live.clone(),
+            BoardConfigChange::Pinned("whiteboard".to_string()),
+        );
+
+        board_mut(&mut live, "whiteboard").name = "Unrelated live name".to_string();
+        let whiteboard = live
+            .items
+            .iter()
+            .position(|item| item.id == "whiteboard")
+            .expect("whiteboard index");
+        let blackboard = live
+            .items
+            .iter()
+            .position(|item| item.id == "blackboard")
+            .expect("blackboard index");
+        live.items.swap(whiteboard, blackboard);
+        update.merge(live, BoardConfigChange::Structure);
+
+        apply_board_config_update_to_config(&mut config, update);
+
+        let saved = config.boards.as_ref().expect("saved boards");
+        let saved_whiteboard = saved
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("saved whiteboard");
+        assert!(saved_whiteboard.pinned);
+        assert_eq!(saved_whiteboard.name, "Configured whiteboard");
+        assert!(
+            saved
+                .items
+                .iter()
+                .position(|item| item.id == "blackboard")
+                .expect("saved blackboard index")
+                < saved
+                    .items
+                    .iter()
+                    .position(|item| item.id == "whiteboard")
+                    .expect("saved whiteboard index")
+        );
+    }
+
+    #[test]
+    fn board_structure_update_adds_and_deletes_only_the_requested_entries() {
+        let mut config = crate::config::Config::default();
+        let configured = config.boards.as_mut().expect("configured boards");
+        configured.default_board = "blackboard".to_string();
+        board_mut(configured, "whiteboard").pinned = true;
+
+        let mut live = configured.clone();
+        live.items.retain(|item| item.id != "blackboard");
+        live.default_board = "transparent".to_string();
+        let mut created = live
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("whiteboard template")
+            .clone();
+        created.id = "custom-board".to_string();
+        created.name = "Custom board".to_string();
+        created.pinned = false;
+        live.items.push(created);
+
+        apply_board_config_update_to_config(
+            &mut config,
+            PendingBoardConfigUpdate::new(live, BoardConfigChange::Structure),
+        );
+
+        let saved = config.boards.as_ref().expect("saved boards");
+        assert_eq!(saved.default_board, "transparent");
+        assert!(saved.items.iter().all(|item| item.id != "blackboard"));
+        assert!(
+            saved
+                .items
+                .iter()
+                .any(|item| item.id == "custom-board" && item.name == "Custom board")
+        );
+        assert!(
+            saved
+                .items
+                .iter()
+                .find(|item| item.id == "whiteboard")
+                .expect("retained whiteboard")
+                .pinned
+        );
+    }
+
+    #[test]
+    fn board_structure_update_uses_new_snapshot_for_a_reused_id() {
+        let mut config = crate::config::Config::default();
+        let configured = config.boards.as_mut().expect("configured boards");
+        let mut old_board = configured
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("whiteboard template")
+            .clone();
+        old_board.id = "board-4".to_string();
+        old_board.name = "Old board".to_string();
+        old_board.pinned = true;
+        configured.items.push(old_board);
+
+        let mut after_delete = configured.clone();
+        after_delete.items.retain(|item| item.id != "board-4");
+        let mut update = PendingBoardConfigUpdate::new(
+            after_delete.clone(),
+            BoardConfigChange::IdentityDeleted("board-4".to_string()),
+        );
+
+        let mut replacement = after_delete
+            .items
+            .iter()
+            .find(|item| item.id == "blackboard")
+            .expect("blackboard template")
+            .clone();
+        replacement.id = "board-4".to_string();
+        replacement.name = "New board".to_string();
+        replacement.pinned = false;
+        after_delete.items.push(replacement.clone());
+        update.merge(
+            after_delete,
+            BoardConfigChange::IdentitiesCreated(vec!["board-4".to_string()]),
+        );
+
+        apply_board_config_update_to_config(&mut config, update);
+
+        let saved = config.boards.as_ref().expect("saved boards");
+        let board = saved
+            .items
+            .iter()
+            .find(|item| item.id == "board-4")
+            .expect("replacement board");
+        assert_eq!(board.name, replacement.name);
+        assert_eq!(
+            board.background.rgb_for_test(),
+            replacement.background.rgb_for_test()
+        );
+        assert_eq!(board.pinned, replacement.pinned);
+    }
+
+    #[test]
+    fn board_update_seeds_from_legacy_config_before_applying_exact_field() {
+        let mut config = crate::config::Config {
+            boards: None,
+            ..crate::config::Config::default()
+        };
+        config.board.enabled = true;
+        config.board.whiteboard_color = [0.1, 0.2, 0.3];
+        let mut live = config.resolved_boards();
+        board_mut(&mut live, "whiteboard").name = "Renamed legacy board".to_string();
+
+        apply_board_config_update_to_config(
+            &mut config,
+            PendingBoardConfigUpdate::new(live, BoardConfigChange::Name("whiteboard".to_string())),
+        );
+
+        let saved = config.boards.as_ref().expect("materialized boards");
+        let whiteboard = saved
+            .items
+            .iter()
+            .find(|item| item.id == "whiteboard")
+            .expect("legacy whiteboard");
+        assert_eq!(whiteboard.name, "Renamed legacy board");
+        assert_eq!(whiteboard.background.rgb_for_test(), Some([0.1, 0.2, 0.3]));
+    }
+
+    trait BoardBackgroundTestExt {
+        fn rgb_for_test(&self) -> Option<[f64; 3]>;
+    }
+
+    impl BoardBackgroundTestExt for crate::config::BoardBackgroundConfig {
+        fn rgb_for_test(&self) -> Option<[f64; 3]> {
+            match self {
+                crate::config::BoardBackgroundConfig::Transparent(_) => None,
+                crate::config::BoardBackgroundConfig::Color(color) => Some(color.rgb()),
+            }
+        }
     }
 }

--- a/src/backend/wayland/state/toolbar/drag/relative.rs
+++ b/src/backend/wayland/state/toolbar/drag/relative.rs
@@ -54,7 +54,7 @@ impl WaylandState {
     }
 
     pub(in crate::backend::wayland) fn end_toolbar_move_drag(&mut self) {
-        if self.data.toolbar_move_drag.is_some() {
+        if let Some(drag) = self.data.toolbar_move_drag {
             self.reconcile_top_base_after_drag();
             drag_log(format!(
                 "end move drag: offsets=({}, {})/({}, {}), active_kind={:?}, pointer_locked={}",
@@ -80,7 +80,7 @@ impl WaylandState {
             if self.toolbar_drag_preview_active() {
                 self.begin_toolbar_drag_handoff();
             }
-            self.save_toolbar_pin_config();
+            self.save_toolbar_position_config(drag.kind);
             self.unlock_pointer();
         }
     }

--- a/src/backend/wayland/state/toolbar/events.rs
+++ b/src/backend/wayland/state/toolbar/events.rs
@@ -4,40 +4,23 @@ use crate::{
     onboarding::OnboardingState,
     ui::toolbar::model::{
         ToolbarBackendRoute, ToolbarEventPolicy, ToolbarPersistence, ToolbarPersistenceTarget,
-        ToolbarPreApplyEffect, ToolbarUiPersistenceTarget,
+        ToolbarPreApplyEffect,
     },
 };
 use wayland_client::{Connection, QueueHandle};
 
+mod persistence;
 mod session;
 pub(in crate::backend::wayland::state) use session::SessionFileDialogController;
 
+#[cfg(test)]
+use crate::ui::toolbar::model::{ToolbarConfigPersistenceTarget, ToolbarUiPersistenceTarget};
+#[cfg(test)]
+use persistence::{
+    ToolbarPositions, apply_toolbar_config_target, apply_toolbar_ui_config_target,
+    persisted_tool_preview_value, persisted_top_display_mode_value, persisted_top_minimized_value,
+};
 use session::populate_session_snapshot;
-
-fn persisted_tool_preview_value(current: bool, presenter_restore: Option<bool>) -> bool {
-    presenter_restore.unwrap_or(current)
-}
-
-/// While presenter mode owns the top strip (`[presenter_mode] toolbar_mode =
-/// "micro"`), the live display mode and minimized flag hold presenter-mapped
-/// values (`Micro`, force-cleared `false`), not user preferences. Any
-/// `Persist(Toolbar)` event fired during presenter mode — a pin toggle, an
-/// icon-mode switch, ... — must therefore write the saved pre-presenter
-/// values from `PresenterRestore`. Outside presenter mode (and under the
-/// `"hidden"` mapping, which leaves both fields untouched) the restore slots
-/// are `None` and the live values persist as usual.
-fn persisted_top_minimized_value(current: bool, presenter_restore: Option<bool>) -> bool {
-    presenter_restore.unwrap_or(current)
-}
-
-fn persisted_top_display_mode_value(
-    current: crate::config::TopDisplayMode,
-    presenter_restore: Option<crate::config::TopDisplayMode>,
-) -> crate::config::TopDisplayMode {
-    // Hidden persists as Full: like the F9 visibility toggle, a hidden
-    // strip is runtime-only and `top_pinned` governs startup.
-    presenter_restore.unwrap_or(current).persisted()
-}
 
 fn record_drawer_hint_shown(state: &mut OnboardingState) -> bool {
     if state.drawer_hint_count >= crate::onboarding::DRAWER_HINT_MAX {
@@ -189,27 +172,6 @@ fn event_dismisses_settings_popover(event: &ToolbarEvent) -> bool {
                 | ToolbarEvent::OpenConfigurator
                 | ToolbarEvent::OpenConfigFile
         )
-}
-
-fn apply_toolbar_ui_config_target(
-    config: &mut crate::config::Config,
-    input_state: &InputState,
-    target: ToolbarUiPersistenceTarget,
-) {
-    match target {
-        ToolbarUiPersistenceTarget::StatusBar => {
-            config.ui.show_status_bar = input_state.show_status_bar;
-        }
-        ToolbarUiPersistenceTarget::StatusBoardBadge => {
-            config.ui.show_status_board_badge = input_state.show_status_board_badge;
-        }
-        ToolbarUiPersistenceTarget::StatusPageBadge => {
-            config.ui.show_status_page_badge = input_state.show_status_page_badge;
-        }
-        ToolbarUiPersistenceTarget::FloatingBadgeAlways => {
-            config.ui.show_floating_badge_always = input_state.show_floating_badge_always;
-        }
-    }
 }
 
 impl WaylandState {
@@ -427,8 +389,8 @@ impl WaylandState {
 
             match policy.persistence {
                 ToolbarPersistence::RuntimeOnly => {}
-                ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar) => {
-                    self.save_toolbar_pin_config();
+                ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar(target)) => {
+                    self.save_toolbar_config(target);
                 }
                 ToolbarPersistence::Persist(ToolbarPersistenceTarget::Ui(target)) => {
                     self.save_toolbar_ui_config(target);
@@ -477,138 +439,6 @@ impl WaylandState {
             self.stylus_peak_thickness
                 .map_or(thickness, |p| p.max(thickness)),
         );
-    }
-
-    /// Saves the current toolbar configuration to disk (pinned state, icon mode, section visibility).
-    pub(in crate::backend::wayland) fn save_toolbar_pin_config(&mut self) {
-        self.config.ui.toolbar.layout_mode = self.input_state.toolbar_layout_mode;
-        self.config.ui.toolbar.items = self.input_state.toolbar_items.clone();
-        self.config.ui.toolbar.top_pinned = self.input_state.toolbar_top_pinned;
-        self.config.ui.toolbar.side_pinned = self.input_state.toolbar_side_pinned;
-        self.config.ui.toolbar.top_minimized = persisted_top_minimized_value(
-            self.input_state.toolbar_top_minimized,
-            self.input_state
-                .presenter_restore
-                .as_ref()
-                .and_then(|restore| restore.toolbar_top_minimized),
-        );
-        self.config.ui.toolbar.top_display_mode = persisted_top_display_mode_value(
-            self.input_state.toolbar_top_display_mode,
-            self.input_state
-                .presenter_restore
-                .as_ref()
-                .and_then(|restore| restore.toolbar_top_display_mode),
-        );
-        self.config.ui.toolbar.side_minimized = self.input_state.toolbar_side_minimized;
-        self.config.ui.toolbar.side_active_pane =
-            self.input_state.toolbar_side_pane.config_id().to_string();
-        // Keep unknown ids (written by newer versions) so a round trip
-        // through this build does not drop them.
-        let mut collapsed: Vec<String> = self
-            .config
-            .ui
-            .toolbar
-            .collapsed_sections
-            .iter()
-            .filter(|id| crate::ui::toolbar::ToolbarSideSection::from_config_id(id).is_none())
-            .cloned()
-            .collect();
-        collapsed.extend(
-            self.input_state
-                .toolbar_collapsed_side_sections
-                .iter()
-                .map(|section| section.config_id().to_string()),
-        );
-        self.config.ui.toolbar.collapsed_sections = collapsed;
-        self.config.ui.toolbar.use_icons = self.input_state.toolbar_use_icons;
-        self.config.ui.toolbar.show_more_colors = self.input_state.show_more_colors;
-        self.config.ui.toolbar.show_actions_section = self.input_state.show_actions_section;
-        self.config.ui.toolbar.show_actions_advanced = self.input_state.show_actions_advanced;
-        self.config.ui.toolbar.show_zoom_actions = self.input_state.show_zoom_actions;
-        self.config.ui.toolbar.show_pages_section = self.input_state.show_pages_section;
-        self.config.ui.toolbar.show_boards_section = self.input_state.show_boards_section;
-        self.config.ui.toolbar.show_presets = self.input_state.show_presets;
-        self.config.ui.toolbar.show_step_section = self.input_state.show_step_section;
-        self.config.ui.toolbar.show_text_controls = self.input_state.show_text_controls;
-        self.config.ui.toolbar.context_aware_ui = self.input_state.context_aware_ui;
-        self.config.ui.toolbar.show_settings_section = self.input_state.show_settings_section;
-        self.config.ui.toolbar.show_delay_sliders = self.input_state.show_delay_sliders;
-        self.config.ui.toolbar.show_marker_opacity_section =
-            self.input_state.show_marker_opacity_section;
-        self.config.ui.toolbar.show_preset_toasts = self.input_state.show_preset_toasts;
-        self.config.ui.toolbar.show_tool_preview = persisted_tool_preview_value(
-            self.input_state.show_tool_preview,
-            self.input_state
-                .presenter_restore
-                .as_ref()
-                .and_then(|restore| restore.show_tool_preview),
-        );
-        self.config.ui.toolbar.top_offset = self.data.toolbar_top_offset;
-        self.config.ui.toolbar.top_offset_y = self.data.toolbar_top_offset_y;
-        self.config.ui.toolbar.side_offset = self.data.toolbar_side_offset;
-        self.config.ui.toolbar.side_offset_x = self.data.toolbar_side_offset_x;
-
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to save toolbar config: {}", err);
-        } else {
-            log::debug!("Saved toolbar config");
-        }
-    }
-
-    fn save_toolbar_ui_config(&mut self, target: ToolbarUiPersistenceTarget) {
-        apply_toolbar_ui_config_target(&mut self.config, &self.input_state, target);
-
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to save toolbar UI config: {}", err);
-        } else {
-            log::debug!("Saved toolbar UI config");
-        }
-    }
-
-    fn save_toolbar_history_config(&mut self) {
-        self.config.history.custom_section_enabled = self.input_state.custom_section_enabled;
-
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to save toolbar history config: {}", err);
-        } else {
-            log::debug!("Saved toolbar history config");
-        }
-    }
-
-    pub(in crate::backend::wayland) fn save_click_highlight_preferences(&mut self) {
-        if !(self.input_state.presenter_mode
-            && self
-                .input_state
-                .presenter_mode_config
-                .enable_click_highlight)
-        {
-            self.config.ui.click_highlight.enabled = self.input_state.click_highlight_enabled();
-        }
-        self.config.ui.click_highlight.show_on_highlight_tool =
-            self.input_state.highlight_tool_ring_enabled();
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to persist click highlight preferences: {}", err);
-        }
-    }
-
-    pub(in crate::backend::wayland) fn handle_preset_action(
-        &mut self,
-        action: crate::input::state::PresetAction,
-    ) {
-        match action {
-            crate::input::state::PresetAction::Save { slot, preset } => {
-                self.config.presets.set_slot(slot, Some(*preset));
-                if let Err(err) = self.config.save() {
-                    log::warn!("Failed to save preset slot {}: {}", slot, err);
-                }
-            }
-            crate::input::state::PresetAction::Clear { slot } => {
-                self.config.presets.set_slot(slot, None);
-                if let Err(err) = self.config.save() {
-                    log::warn!("Failed to clear preset slot {}: {}", slot, err);
-                }
-            }
-        }
     }
 }
 

--- a/src/backend/wayland/state/toolbar/events/persistence.rs
+++ b/src/backend/wayland/state/toolbar/events/persistence.rs
@@ -1,0 +1,287 @@
+use super::*;
+use crate::ui::toolbar::model::{ToolbarConfigPersistenceTarget, ToolbarUiPersistenceTarget};
+
+pub(super) fn persisted_tool_preview_value(current: bool, presenter_restore: Option<bool>) -> bool {
+    presenter_restore.unwrap_or(current)
+}
+
+/// While presenter mode owns the top strip (`[presenter_mode] toolbar_mode =
+/// "micro"`), the live display mode and minimized flag hold presenter-mapped
+/// values (`Micro`, force-cleared `false`), not user preferences. A targeted
+/// top-display or minimized save fired during presenter mode must therefore
+/// write the saved pre-presenter values from `PresenterRestore`. Outside
+/// presenter mode (and under the `"hidden"` mapping, which leaves both fields
+/// untouched) the restore slots are `None` and the live values persist as usual.
+pub(super) fn persisted_top_minimized_value(
+    current: bool,
+    presenter_restore: Option<bool>,
+) -> bool {
+    presenter_restore.unwrap_or(current)
+}
+
+pub(super) fn persisted_top_display_mode_value(
+    current: crate::config::TopDisplayMode,
+    presenter_restore: Option<crate::config::TopDisplayMode>,
+) -> crate::config::TopDisplayMode {
+    // Hidden persists as Full: like the F9 visibility toggle, a hidden
+    // strip is runtime-only and `top_pinned` governs startup.
+    presenter_restore.unwrap_or(current).persisted()
+}
+
+pub(super) fn apply_toolbar_ui_config_target(
+    config: &mut crate::config::Config,
+    input_state: &InputState,
+    target: ToolbarUiPersistenceTarget,
+) {
+    match target {
+        ToolbarUiPersistenceTarget::StatusBar => {
+            config.ui.show_status_bar = input_state.show_status_bar;
+        }
+        ToolbarUiPersistenceTarget::StatusBoardBadge => {
+            config.ui.show_status_board_badge = input_state.show_status_board_badge;
+        }
+        ToolbarUiPersistenceTarget::StatusPageBadge => {
+            config.ui.show_status_page_badge = input_state.show_status_page_badge;
+        }
+        ToolbarUiPersistenceTarget::FloatingBadgeAlways => {
+            config.ui.show_floating_badge_always = input_state.show_floating_badge_always;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct ToolbarPositions {
+    pub(super) top_x: f64,
+    pub(super) top_y: f64,
+    pub(super) side_x: f64,
+    pub(super) side_y: f64,
+}
+
+fn apply_section_compatibility_mirror(
+    config: &mut crate::config::Config,
+    flag: crate::config::ToolbarSectionFlag,
+    visible: bool,
+) {
+    use crate::config::ToolbarSectionFlag;
+
+    match flag {
+        ToolbarSectionFlag::Actions => config.ui.toolbar.show_actions_section = visible,
+        ToolbarSectionFlag::ActionsAdvanced => {
+            config.ui.toolbar.show_actions_advanced = visible;
+        }
+        ToolbarSectionFlag::ZoomActions => config.ui.toolbar.show_zoom_actions = visible,
+        ToolbarSectionFlag::Pages => config.ui.toolbar.show_pages_section = visible,
+        ToolbarSectionFlag::Boards => config.ui.toolbar.show_boards_section = visible,
+        ToolbarSectionFlag::Presets => config.ui.toolbar.show_presets = visible,
+        ToolbarSectionFlag::StepSection => config.ui.toolbar.show_step_section = visible,
+        ToolbarSectionFlag::TextControls => config.ui.toolbar.show_text_controls = visible,
+    }
+}
+
+fn apply_all_section_compatibility_mirrors(
+    config: &mut crate::config::Config,
+    input_state: &InputState,
+) {
+    config.ui.toolbar.show_actions_section = input_state.show_actions_section;
+    config.ui.toolbar.show_actions_advanced = input_state.show_actions_advanced;
+    config.ui.toolbar.show_zoom_actions = input_state.show_zoom_actions;
+    config.ui.toolbar.show_pages_section = input_state.show_pages_section;
+    config.ui.toolbar.show_boards_section = input_state.show_boards_section;
+    config.ui.toolbar.show_presets = input_state.show_presets;
+    config.ui.toolbar.show_step_section = input_state.show_step_section;
+    config.ui.toolbar.show_text_controls = input_state.show_text_controls;
+    config.ui.toolbar.show_settings_section = input_state.show_settings_section;
+}
+
+pub(super) fn apply_toolbar_config_target(
+    config: &mut crate::config::Config,
+    input_state: &InputState,
+    positions: ToolbarPositions,
+    target: ToolbarConfigPersistenceTarget,
+) {
+    use ToolbarConfigPersistenceTarget::*;
+
+    match target {
+        LayoutMode => {
+            config.ui.toolbar.layout_mode = input_state.toolbar_layout_mode;
+            apply_all_section_compatibility_mirrors(config, input_state);
+        }
+        ItemVisibility { id, hidden } => {
+            config.ui.toolbar.items.set_hidden(id, hidden);
+            if let Some(flag) = crate::config::section_flag_for_item(id) {
+                apply_section_compatibility_mirror(config, flag, !hidden);
+            }
+        }
+        ResetItemVisibility => {
+            config.ui.toolbar.items.reset_known_hidden_to_defaults();
+            apply_all_section_compatibility_mirrors(config, input_state);
+        }
+        ItemOrder(group) => {
+            config
+                .ui
+                .toolbar
+                .items
+                .sync_known_order_group_from(&input_state.toolbar_items, group);
+        }
+        TopPinned => config.ui.toolbar.top_pinned = input_state.toolbar_top_pinned,
+        SidePinned => config.ui.toolbar.side_pinned = input_state.toolbar_side_pinned,
+        TopMinimized => {
+            config.ui.toolbar.top_minimized = persisted_top_minimized_value(
+                input_state.toolbar_top_minimized,
+                input_state
+                    .presenter_restore
+                    .as_ref()
+                    .and_then(|restore| restore.toolbar_top_minimized),
+            );
+        }
+        TopDisplayState => {
+            config.ui.toolbar.top_minimized = persisted_top_minimized_value(
+                input_state.toolbar_top_minimized,
+                input_state
+                    .presenter_restore
+                    .as_ref()
+                    .and_then(|restore| restore.toolbar_top_minimized),
+            );
+            config.ui.toolbar.top_display_mode = persisted_top_display_mode_value(
+                input_state.toolbar_top_display_mode,
+                input_state
+                    .presenter_restore
+                    .as_ref()
+                    .and_then(|restore| restore.toolbar_top_display_mode),
+            );
+        }
+        SideMinimized => {
+            config.ui.toolbar.side_minimized = input_state.toolbar_side_minimized;
+        }
+        SidePane => {
+            config.ui.toolbar.side_active_pane =
+                input_state.toolbar_side_pane.config_id().to_string();
+        }
+        CollapsedSection { section, collapsed } => {
+            let id = section.config_id();
+            config.ui.toolbar.collapsed_sections.retain(|raw| {
+                crate::ui::toolbar::ToolbarSideSection::from_config_id(raw) != Some(section)
+            });
+            if collapsed {
+                config.ui.toolbar.collapsed_sections.push(id.to_string());
+            }
+        }
+        Icons => config.ui.toolbar.use_icons = input_state.toolbar_use_icons,
+        MoreColors => config.ui.toolbar.show_more_colors = input_state.show_more_colors,
+        ContextAwareUi => config.ui.toolbar.context_aware_ui = input_state.context_aware_ui,
+        PresetToasts => config.ui.toolbar.show_preset_toasts = input_state.show_preset_toasts,
+        ToolPreview => {
+            config.ui.toolbar.show_tool_preview = persisted_tool_preview_value(
+                input_state.show_tool_preview,
+                input_state
+                    .presenter_restore
+                    .as_ref()
+                    .and_then(|restore| restore.show_tool_preview),
+            );
+        }
+        DelaySliders => config.ui.toolbar.show_delay_sliders = input_state.show_delay_sliders,
+        TopPosition => {
+            config.ui.toolbar.top_offset = positions.top_x;
+            config.ui.toolbar.top_offset_y = positions.top_y;
+        }
+        SidePosition => {
+            // A side drag can change whether the side palette overlaps the
+            // top strip. Drag completion reconciles the top strip's X offset
+            // against that new base before saving, so persist the derived X
+            // together with the side position. The top Y value is unrelated.
+            config.ui.toolbar.top_offset = positions.top_x;
+            config.ui.toolbar.side_offset_x = positions.side_x;
+            config.ui.toolbar.side_offset = positions.side_y;
+        }
+    }
+}
+
+impl WaylandState {
+    pub(super) fn save_toolbar_config(&mut self, target: ToolbarConfigPersistenceTarget) {
+        apply_toolbar_config_target(
+            &mut self.config,
+            &self.input_state,
+            ToolbarPositions {
+                top_x: self.data.toolbar_top_offset,
+                top_y: self.data.toolbar_top_offset_y,
+                side_x: self.data.toolbar_side_offset_x,
+                side_y: self.data.toolbar_side_offset,
+            },
+            target,
+        );
+
+        if let Err(err) = self.config.save() {
+            log::warn!("Failed to save toolbar config: {}", err);
+        } else {
+            log::debug!("Saved toolbar config");
+        }
+    }
+
+    pub(in crate::backend::wayland) fn save_toolbar_position_config(&mut self, kind: MoveDragKind) {
+        let target = match kind {
+            MoveDragKind::Top => ToolbarConfigPersistenceTarget::TopPosition,
+            MoveDragKind::Side => ToolbarConfigPersistenceTarget::SidePosition,
+        };
+        self.save_toolbar_config(target);
+    }
+
+    pub(in crate::backend::wayland) fn save_toolbar_display_config(&mut self) {
+        self.save_toolbar_config(ToolbarConfigPersistenceTarget::TopDisplayState);
+    }
+
+    pub(super) fn save_toolbar_ui_config(&mut self, target: ToolbarUiPersistenceTarget) {
+        apply_toolbar_ui_config_target(&mut self.config, &self.input_state, target);
+
+        if let Err(err) = self.config.save() {
+            log::warn!("Failed to save toolbar UI config: {}", err);
+        } else {
+            log::debug!("Saved toolbar UI config");
+        }
+    }
+
+    pub(super) fn save_toolbar_history_config(&mut self) {
+        self.config.history.custom_section_enabled = self.input_state.custom_section_enabled;
+
+        if let Err(err) = self.config.save() {
+            log::warn!("Failed to save toolbar history config: {}", err);
+        } else {
+            log::debug!("Saved toolbar history config");
+        }
+    }
+
+    pub(in crate::backend::wayland) fn save_click_highlight_preferences(&mut self) {
+        if !(self.input_state.presenter_mode
+            && self
+                .input_state
+                .presenter_mode_config
+                .enable_click_highlight)
+        {
+            self.config.ui.click_highlight.enabled = self.input_state.click_highlight_enabled();
+        }
+        self.config.ui.click_highlight.show_on_highlight_tool =
+            self.input_state.highlight_tool_ring_enabled();
+        if let Err(err) = self.config.save() {
+            log::warn!("Failed to persist click highlight preferences: {}", err);
+        }
+    }
+
+    pub(in crate::backend::wayland) fn handle_preset_action(
+        &mut self,
+        action: crate::input::state::PresetAction,
+    ) {
+        match action {
+            crate::input::state::PresetAction::Save { slot, preset } => {
+                self.config.presets.set_slot(slot, Some(*preset));
+                if let Err(err) = self.config.save() {
+                    log::warn!("Failed to save preset slot {}: {}", slot, err);
+                }
+            }
+            crate::input::state::PresetAction::Clear { slot } => {
+                self.config.presets.set_slot(slot, None);
+                if let Err(err) = self.config.save() {
+                    log::warn!("Failed to clear preset slot {}: {}", slot, err);
+                }
+            }
+        }
+    }
+}

--- a/src/backend/wayland/state/toolbar/events/tests.rs
+++ b/src/backend/wayland/state/toolbar/events/tests.rs
@@ -4,7 +4,7 @@ use super::session::{
     session_info_summary,
 };
 use super::*;
-use crate::config::ToolbarLayoutMode;
+use crate::config::{ToolbarLayoutMode, ToolbarSectionFlag};
 use crate::draw::{Color, FontDescriptor};
 use crate::env_vars::XDG_DATA_HOME_ENV;
 use crate::input::state::test_support::make_test_input_state;
@@ -107,38 +107,135 @@ fn runtime_toolbar_events_do_not_directly_save_config() {
 }
 
 #[test]
-fn toolbar_preference_events_save_toolbar_config() {
+fn toolbar_preference_events_have_exact_config_targets() {
+    use crate::config::{ToolbarItemOrderGroup, TopDisplayMode, toolbar_item_ids as ids};
+    use ToolbarConfigPersistenceTarget::*;
+
     let events = vec![
-        ToolbarEvent::PinTopToolbar(true),
-        ToolbarEvent::PinSideToolbar(true),
-        ToolbarEvent::ToggleIconMode(true),
-        ToolbarEvent::ToggleMoreColors(true),
-        ToolbarEvent::ToggleActionsSection(true),
-        ToolbarEvent::ToggleActionsAdvanced(true),
-        ToolbarEvent::ToggleZoomActions(true),
-        ToolbarEvent::TogglePagesSection(true),
-        ToolbarEvent::ToggleBoardsSection(true),
-        ToolbarEvent::TogglePresets(true),
-        ToolbarEvent::ToggleStepSection(true),
-        ToolbarEvent::ToggleTextControls(true),
-        ToolbarEvent::ToggleContextAwareUi(true),
-        ToolbarEvent::TogglePresetToasts(true),
-        ToolbarEvent::ToggleToolPreview(true),
-        ToolbarEvent::ToggleDelaySliders(true),
-        ToolbarEvent::SetToolbarLayoutMode(ToolbarLayoutMode::Advanced),
-        ToolbarEvent::SetSidePane(crate::ui::toolbar::SidePane::Canvas),
-        ToolbarEvent::ToggleSideSectionCollapsed(ToolbarSideSection::Session, true),
-        ToolbarEvent::SetTopMinimized(true),
-        ToolbarEvent::SetSideMinimized(true),
-        ToolbarEvent::CloseTopToolbar,
-        ToolbarEvent::CloseSideToolbar,
+        (ToolbarEvent::PinTopToolbar(true), TopPinned),
+        (ToolbarEvent::PinSideToolbar(true), SidePinned),
+        (ToolbarEvent::ToggleIconMode(true), Icons),
+        (ToolbarEvent::ToggleMoreColors(true), MoreColors),
+        (
+            ToolbarEvent::ToggleActionsSection(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::Actions.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::ToggleActionsAdvanced(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::ActionsAdvanced.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::ToggleZoomActions(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::ZoomActions.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::TogglePagesSection(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::Pages.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::ToggleBoardsSection(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::Boards.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::TogglePresets(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::Presets.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::ToggleStepSection(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::StepSection.item_id(),
+                hidden: false,
+            },
+        ),
+        (
+            ToolbarEvent::ToggleTextControls(true),
+            ItemVisibility {
+                id: ToolbarSectionFlag::TextControls.item_id(),
+                hidden: false,
+            },
+        ),
+        (ToolbarEvent::ToggleContextAwareUi(true), ContextAwareUi),
+        (ToolbarEvent::TogglePresetToasts(true), PresetToasts),
+        (ToolbarEvent::ToggleToolPreview(true), ToolPreview),
+        (ToolbarEvent::ToggleDelaySliders(true), DelaySliders),
+        (
+            ToolbarEvent::SetToolbarLayoutMode(ToolbarLayoutMode::Advanced),
+            LayoutMode,
+        ),
+        (
+            ToolbarEvent::SetSidePane(crate::ui::toolbar::SidePane::Canvas),
+            SidePane,
+        ),
+        (
+            ToolbarEvent::ToggleSideSectionCollapsed(ToolbarSideSection::Session, true),
+            CollapsedSection {
+                section: ToolbarSideSection::Session,
+                collapsed: true,
+            },
+        ),
+        (ToolbarEvent::SetTopMinimized(true), TopMinimized),
+        (
+            ToolbarEvent::SetTopDisplayMode(TopDisplayMode::Micro),
+            TopDisplayState,
+        ),
+        (ToolbarEvent::SetSideMinimized(true), SideMinimized),
+        (ToolbarEvent::CloseTopToolbar, TopMinimized),
+        (ToolbarEvent::CloseSideToolbar, SideMinimized),
+        (
+            ToolbarEvent::SetToolbarItemHidden(ids::TOP_TOOL_PEN, true),
+            ItemVisibility {
+                id: ids::TOP_TOOL_PEN,
+                hidden: true,
+            },
+        ),
+        (
+            ToolbarEvent::MoveToolbarItem {
+                group: ToolbarItemOrderGroup::TopTools,
+                id: ids::TOP_TOOL_PEN,
+                delta: 1,
+            },
+            ItemOrder(ToolbarItemOrderGroup::TopTools),
+        ),
+        (
+            ToolbarEvent::DragToolbarItemOver {
+                group: ToolbarItemOrderGroup::TopTools,
+                target_index: 2,
+            },
+            ItemOrder(ToolbarItemOrderGroup::TopTools),
+        ),
+        (
+            ToolbarEvent::ResetToolbarItemOrder(ToolbarItemOrderGroup::TopTools),
+            ItemOrder(ToolbarItemOrderGroup::TopTools),
+        ),
+        (
+            ToolbarEvent::ResetToolbarItemHiddenOverrides,
+            ResetItemVisibility,
+        ),
     ];
 
-    for event in events {
+    for (event, target) in events {
         assert_eq!(
             persistence_for(&event),
-            ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar),
-            "{event:?} should save toolbar config"
+            ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar(target)),
+            "{event:?} should save only its toolbar config target"
         );
     }
 }
@@ -202,6 +299,236 @@ fn toolbar_ui_config_target_save_leaves_sibling_fields_unchanged() {
     assert!(config.ui.show_status_board_badge);
     assert!(config.ui.show_status_page_badge);
     assert!(!config.ui.show_floating_badge_always);
+}
+
+#[test]
+fn toolbar_config_target_does_not_copy_unrelated_live_state() {
+    let mut config = crate::config::Config::default();
+    config.ui.toolbar.top_pinned = true;
+    config.ui.toolbar.side_pinned = true;
+    config.ui.toolbar.top_minimized = false;
+    config.ui.toolbar.side_active_pane = "draw".to_string();
+    config.ui.toolbar.collapsed_sections = vec!["future-section".to_string()];
+    config.ui.toolbar.top_offset = 12.0;
+    config.ui.toolbar.top_offset_y = 13.0;
+    let original_items = config.ui.toolbar.items.clone();
+
+    let mut input_state = make_test_input_state();
+    input_state.toolbar_top_pinned = false;
+    input_state.toolbar_side_pinned = false;
+    input_state.toolbar_top_minimized = true;
+    input_state.toolbar_side_pane = crate::ui::toolbar::SidePane::Settings;
+    input_state
+        .toolbar_collapsed_side_sections
+        .insert(ToolbarSideSection::Colors);
+    input_state
+        .toolbar_items
+        .set_hidden(crate::config::toolbar_item_ids::TOP_TOOL_PEN, true);
+
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        ToolbarPositions {
+            top_x: 90.0,
+            top_y: 91.0,
+            side_x: 92.0,
+            side_y: 93.0,
+        },
+        ToolbarConfigPersistenceTarget::TopPinned,
+    );
+
+    assert!(!config.ui.toolbar.top_pinned);
+    assert!(config.ui.toolbar.side_pinned);
+    assert!(!config.ui.toolbar.top_minimized);
+    assert_eq!(config.ui.toolbar.side_active_pane, "draw");
+    assert_eq!(
+        config.ui.toolbar.collapsed_sections,
+        ["future-section".to_string()]
+    );
+    assert_eq!(config.ui.toolbar.items, original_items);
+    assert_eq!(config.ui.toolbar.top_offset, 12.0);
+    assert_eq!(config.ui.toolbar.top_offset_y, 13.0);
+}
+
+#[test]
+fn toolbar_position_target_includes_the_side_drags_reconciled_top_offset() {
+    let mut config = crate::config::Config::default();
+    config.ui.toolbar.top_offset = 1.0;
+    config.ui.toolbar.top_offset_y = 2.0;
+    config.ui.toolbar.side_offset_x = 3.0;
+    config.ui.toolbar.side_offset = 4.0;
+    let input_state = make_test_input_state();
+    let positions = ToolbarPositions {
+        top_x: 10.0,
+        top_y: 20.0,
+        side_x: 30.0,
+        side_y: 40.0,
+    };
+
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        positions,
+        ToolbarConfigPersistenceTarget::TopPosition,
+    );
+    assert_eq!(config.ui.toolbar.top_offset, 10.0);
+    assert_eq!(config.ui.toolbar.top_offset_y, 20.0);
+    assert_eq!(config.ui.toolbar.side_offset_x, 3.0);
+    assert_eq!(config.ui.toolbar.side_offset, 4.0);
+
+    config.ui.toolbar.top_offset = 1.0;
+    config.ui.toolbar.top_offset_y = 2.0;
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        positions,
+        ToolbarConfigPersistenceTarget::SidePosition,
+    );
+    assert_eq!(config.ui.toolbar.top_offset, 10.0);
+    assert_eq!(config.ui.toolbar.top_offset_y, 2.0);
+    assert_eq!(config.ui.toolbar.side_offset_x, 30.0);
+    assert_eq!(config.ui.toolbar.side_offset, 40.0);
+}
+
+#[test]
+fn toolbar_item_order_target_preserves_other_groups_and_unknown_ids() {
+    use crate::config::{ToolbarItemOrderGroup, toolbar_item_ids as ids};
+
+    let mut config = crate::config::Config::default();
+    config.ui.toolbar.items.order.top_tools = vec![
+        ids::TOP_TOOL_PEN.as_str().to_string(),
+        "future-top-tool".to_string(),
+    ];
+    config.ui.toolbar.items.order.actions = vec!["future-action".to_string()];
+
+    let mut input_state = make_test_input_state();
+    assert!(input_state.toolbar_items.move_item_by(
+        ToolbarItemOrderGroup::TopTools,
+        ids::TOP_TOOL_PEN,
+        1,
+    ));
+
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        ToolbarPositions::default(),
+        ToolbarConfigPersistenceTarget::ItemOrder(ToolbarItemOrderGroup::TopTools),
+    );
+
+    assert_eq!(
+        config.ui.toolbar.items.order.actions,
+        ["future-action".to_string()]
+    );
+    assert!(
+        config
+            .ui
+            .toolbar
+            .items
+            .order
+            .top_tools
+            .contains(&"future-top-tool".to_string())
+    );
+    assert_eq!(
+        config
+            .ui
+            .toolbar
+            .items
+            .order
+            .resolved()
+            .index_of(ToolbarItemOrderGroup::TopTools, ids::TOP_TOOL_PEN),
+        Some(2)
+    );
+}
+
+#[test]
+fn toolbar_section_target_updates_only_its_override_and_compatibility_mirror() {
+    let mut config = crate::config::Config::default();
+    config.ui.toolbar.show_actions_section = true;
+    config.ui.toolbar.show_presets = true;
+    config.ui.toolbar.items.hidden = vec!["future-hidden".to_string()];
+    let input_state = make_test_input_state();
+
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        ToolbarPositions::default(),
+        ToolbarConfigPersistenceTarget::ItemVisibility {
+            id: ToolbarSectionFlag::Actions.item_id(),
+            hidden: true,
+        },
+    );
+
+    assert!(!config.ui.toolbar.show_actions_section);
+    assert!(config.ui.toolbar.show_presets);
+    assert!(
+        config
+            .ui
+            .toolbar
+            .items
+            .resolved()
+            .hidden
+            .contains(&ToolbarSectionFlag::Actions.item_id())
+    );
+    assert!(
+        config
+            .ui
+            .toolbar
+            .items
+            .hidden
+            .contains(&"future-hidden".to_string())
+    );
+}
+
+#[test]
+fn toolbar_collapsed_section_target_preserves_other_and_unknown_sections() {
+    let mut config = crate::config::Config::default();
+    config.ui.toolbar.collapsed_sections = vec![
+        "Colors".to_string(),
+        "session".to_string(),
+        "future-section".to_string(),
+    ];
+    let input_state = make_test_input_state();
+
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        ToolbarPositions::default(),
+        ToolbarConfigPersistenceTarget::CollapsedSection {
+            section: ToolbarSideSection::Colors,
+            collapsed: false,
+        },
+    );
+
+    assert_eq!(
+        config.ui.toolbar.collapsed_sections,
+        ["session".to_string(), "future-section".to_string()]
+    );
+}
+
+#[test]
+fn toolbar_layout_target_updates_only_layout_and_derived_compatibility_mirrors() {
+    let mut config = crate::config::Config::default();
+    config.ui.toolbar.layout_mode = ToolbarLayoutMode::Simple;
+    config.ui.toolbar.top_pinned = true;
+    config.ui.toolbar.items.hidden = vec!["future-hidden".to_string()];
+    let original_items = config.ui.toolbar.items.clone();
+
+    let mut input_state = make_test_input_state();
+    input_state.toolbar_layout_mode = ToolbarLayoutMode::Advanced;
+    input_state.toolbar_top_pinned = false;
+    input_state.show_presets = false;
+
+    apply_toolbar_config_target(
+        &mut config,
+        &input_state,
+        ToolbarPositions::default(),
+        ToolbarConfigPersistenceTarget::LayoutMode,
+    );
+
+    assert_eq!(config.ui.toolbar.layout_mode, ToolbarLayoutMode::Advanced);
+    assert!(!config.ui.toolbar.show_presets);
+    assert!(config.ui.toolbar.top_pinned);
+    assert_eq!(config.ui.toolbar.items, original_items);
 }
 
 #[test]
@@ -527,10 +854,9 @@ fn toolbar_persist_during_presenter_micro_writes_the_pre_presenter_top_state() {
         "micro mapping clears minimized"
     );
 
-    // A Persist(Toolbar) event during presenter mode (e.g. the pin toggle)
-    // runs `save_toolbar_pin_config`, which routes these two fields through
-    // the helpers below: the written config must keep the saved
-    // pre-presenter values, not the presenter mapping.
+    // A targeted top-display save during presenter mode routes these two
+    // fields through the helpers below: the written config must keep the
+    // saved pre-presenter values, not the presenter mapping.
     let restore = state.presenter_restore.as_ref().expect("presenter restore");
     assert!(persisted_top_minimized_value(
         state.toolbar_top_minimized,

--- a/src/backend/wayland/state/toolbar/gtk_feedback.rs
+++ b/src/backend/wayland/state/toolbar/gtk_feedback.rs
@@ -64,7 +64,7 @@ impl WaylandState {
         self.mark_gtk_drag_preview_dirty();
         if phase.is_end() {
             self.clamp_gtk_top_offset(surface_size);
-            self.finish_gtk_offset_change();
+            self.finish_gtk_offset_change(crate::backend::wayland::state::MoveDragKind::Top);
         }
     }
 
@@ -83,7 +83,7 @@ impl WaylandState {
         self.mark_gtk_drag_preview_dirty();
         if phase.is_end() {
             self.clamp_gtk_side_offset(surface_size);
-            self.finish_gtk_offset_change();
+            self.finish_gtk_offset_change(crate::backend::wayland::state::MoveDragKind::Side);
         }
     }
 
@@ -164,10 +164,10 @@ impl WaylandState {
 
     /// On drag end, persist the offset accepted against GTK's measured
     /// surface. Intermediate positions are mirrored without disk writes.
-    fn finish_gtk_offset_change(&mut self) {
+    fn finish_gtk_offset_change(&mut self, kind: crate::backend::wayland::state::MoveDragKind) {
         self.reconcile_top_base_after_drag();
         self.data.drag_top_base_x = None;
-        self.save_toolbar_pin_config();
+        self.save_toolbar_position_config(kind);
         self.begin_gtk_toolbar_drag_handoff();
     }
 }

--- a/src/config/tests/file_io.rs
+++ b/src/config/tests/file_io.rs
@@ -85,6 +85,55 @@ default_pen_color = { rgb = [0.0, 0.0, 0.0] }
 }
 
 #[test]
+fn runtime_board_reorder_does_not_materialize_unchanged_item_preferences() {
+    with_temp_config_home(|config_root| {
+        let config_dir = config_root.join(PRIMARY_CONFIG_DIR);
+        fs::create_dir_all(&config_dir).unwrap();
+        let config_file = config_dir.join("config.toml");
+        fs::write(
+            &config_file,
+            r#"[boards]
+default_board = "transparent"
+
+[[boards.items]]
+id = "transparent"
+name = "Overlay"
+background = "transparent"
+
+[[boards.items]]
+id = "whiteboard"
+name = "Whiteboard"
+background = { rgb = [0.992, 0.992, 0.992] }
+"#,
+        )
+        .unwrap();
+
+        let mut config = Config::load().expect("load board config").config;
+        config.boards.as_mut().expect("boards").items.swap(0, 1);
+        config.save().expect("save reordered boards");
+
+        let saved = fs::read_to_string(&config_file).unwrap();
+        let document = saved.parse::<toml_edit::DocumentMut>().unwrap();
+        let boards = document["boards"]["items"].as_array_of_tables().unwrap();
+        assert_eq!(
+            boards.get(0).and_then(|board| board["id"].as_str()),
+            Some("whiteboard")
+        );
+        assert_eq!(
+            boards.get(1).and_then(|board| board["id"].as_str()),
+            Some("transparent")
+        );
+        assert!(boards.iter().all(|board| !board.contains_key("pinned")));
+        assert!(
+            boards
+                .iter()
+                .all(|board| !board.contains_key("auto_adjust_pen"))
+        );
+        assert!(boards.iter().all(|board| !board.contains_key("persist")));
+    });
+}
+
+#[test]
 fn runtime_save_updates_inline_board_background_without_losing_unknown_fields() {
     with_temp_config_home(|config_root| {
         let config_dir = config_root.join(PRIMARY_CONFIG_DIR);

--- a/src/config/types/toolbar/items.rs
+++ b/src/config/types/toolbar/items.rs
@@ -220,6 +220,16 @@ impl ToolbarItemsConfig {
         self.order.reset_known_group_to_defaults(group)
     }
 
+    /// Copy one resolved known order group while preserving unknown raw ids
+    /// already stored by this config version.
+    pub(crate) fn sync_known_order_group_from(
+        &mut self,
+        source: &Self,
+        group: ToolbarItemOrderGroup,
+    ) -> bool {
+        self.set_known_order(group, source.order.resolved().ordered_ids(group))
+    }
+
     fn set_known_order(&mut self, group: ToolbarItemOrderGroup, ids: &[ToolbarItemId]) -> bool {
         self.order.set_known_group_order(group, ids)
     }

--- a/src/input/boards.rs
+++ b/src/input/boards.rs
@@ -22,6 +22,7 @@ pub use color::{
 pub use identity::{
     BoardIdChangeSet, BoardIdentityGeneration, BoundaryBoardId, BoundaryBoardIdSet,
 };
+pub(crate) use mapping::{BoardConfigChange, PendingBoardConfigUpdate};
 pub use operations::{
     BoardDeleteConfirmation, BoardDeleteOutcome, BoardDeleteRejection, BoardDeleteRequest,
     BoardDeleteTarget, BoardRestoreOutcome, BoardRestoreRejection, BoardRestoreRequest,

--- a/src/input/boards/mapping.rs
+++ b/src/input/boards/mapping.rs
@@ -5,6 +5,81 @@ use super::{
 };
 use crate::config::{BoardBackgroundConfig, BoardItemConfig, BoardsConfig};
 use crate::domain::Color;
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone)]
+pub(crate) enum BoardConfigChange {
+    Structure,
+    IdentitiesCreated(Vec<String>),
+    IdentityDeleted(String),
+    IdentityRestored(String),
+    Name(String),
+    Appearance(String),
+    Pinned(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PendingBoardConfigUpdate {
+    pub(crate) snapshot: BoardsConfig,
+    pub(crate) structure_changed: bool,
+    pub(crate) created_ids: BTreeSet<String>,
+    pub(crate) deleted_ids: BTreeSet<String>,
+    pub(crate) changed_names: BTreeSet<String>,
+    pub(crate) changed_appearances: BTreeSet<String>,
+    pub(crate) changed_pins: BTreeSet<String>,
+}
+
+impl PendingBoardConfigUpdate {
+    pub(crate) fn new(snapshot: BoardsConfig, change: BoardConfigChange) -> Self {
+        let mut update = Self {
+            snapshot,
+            structure_changed: false,
+            created_ids: BTreeSet::new(),
+            deleted_ids: BTreeSet::new(),
+            changed_names: BTreeSet::new(),
+            changed_appearances: BTreeSet::new(),
+            changed_pins: BTreeSet::new(),
+        };
+        update.record(change);
+        update
+    }
+
+    pub(crate) fn merge(&mut self, snapshot: BoardsConfig, change: BoardConfigChange) {
+        self.snapshot = snapshot;
+        self.record(change);
+    }
+
+    pub(crate) fn into_snapshot(self) -> BoardsConfig {
+        self.snapshot
+    }
+
+    fn record(&mut self, change: BoardConfigChange) {
+        match change {
+            BoardConfigChange::Structure => self.structure_changed = true,
+            BoardConfigChange::IdentitiesCreated(ids) => {
+                self.structure_changed = true;
+                self.created_ids.extend(ids);
+            }
+            BoardConfigChange::IdentityDeleted(id) => {
+                self.structure_changed = true;
+                self.deleted_ids.insert(id);
+            }
+            BoardConfigChange::IdentityRestored(id) => {
+                self.structure_changed = true;
+                self.deleted_ids.remove(&id);
+            }
+            BoardConfigChange::Name(id) => {
+                self.changed_names.insert(id);
+            }
+            BoardConfigChange::Appearance(id) => {
+                self.changed_appearances.insert(id);
+            }
+            BoardConfigChange::Pinned(id) => {
+                self.changed_pins.insert(id);
+            }
+        }
+    }
+}
 use crate::domain::color::PALETTE_BLACK;
 
 impl BoardSpec {

--- a/src/input/state/core/base/state/structs.rs
+++ b/src/input/state/core/base/state/structs.rs
@@ -23,14 +23,14 @@ use super::super::types::{
     ZoomAction,
 };
 use crate::config::{
-    Action, BoardsConfig, KeyBinding, PresenterModeConfig, QuickColorPalette,
-    RadialMenuMouseBinding, ResolvedToolbarItems, ToolPresetConfig, ToolbarItemId,
-    ToolbarItemOrderGroup, ToolbarItemsConfig,
+    Action, KeyBinding, PresenterModeConfig, QuickColorPalette, RadialMenuMouseBinding,
+    ResolvedToolbarItems, ToolPresetConfig, ToolbarItemId, ToolbarItemOrderGroup,
+    ToolbarItemsConfig,
 };
 use crate::draw::frame::ShapeSnapshot;
 use crate::draw::{Color, DirtyTracker, EraserKind, FontDescriptor, Shape, ShapeId};
 use crate::input::BoardManager;
-use crate::input::boards::{BoardRestoreRequest, PageRestoreRequest};
+use crate::input::boards::{BoardRestoreRequest, PageRestoreRequest, PendingBoardConfigUpdate};
 use crate::input::state::highlight::ClickHighlightState;
 use crate::input::{
     Key, MouseButton,
@@ -536,7 +536,7 @@ pub struct InputState {
     /// Pending preset save/clear action for backend persistence
     pub(in crate::input::state::core) pending_preset_action: Option<PresetAction>,
     /// Pending boards config update (persisted by backend)
-    pub(in crate::input::state::core) pending_board_config: Option<BoardsConfig>,
+    pub(in crate::input::state::core) pending_board_config: Option<PendingBoardConfigUpdate>,
     /// Whether the guided tour is currently active
     pub tour_active: bool,
     /// Current step in the guided tour (0-indexed)

--- a/src/input/state/core/base/types.rs
+++ b/src/input/state/core/base/types.rs
@@ -369,8 +369,8 @@ pub enum PendingBackendAction {
     BoardPdfExport(Action),
     ClearSavedToolState,
     EditKeybinding(KeybindingEditRequest),
-    /// Persist the toolbar configuration (used by keyboard-driven toolbar
-    /// state changes; toolbar-event paths persist via their event policy).
+    /// Persist the top-display preference changed by its keyboard action;
+    /// toolbar-event paths persist via their exact event-policy target.
     PersistToolbarConfig,
 }
 

--- a/src/input/state/core/board/delete_restore.rs
+++ b/src/input/state/core/board/delete_restore.rs
@@ -3,8 +3,9 @@ use super::super::base::{
 };
 use crate::domain::Action;
 use crate::input::boards::{
-    BoardDeleteOutcome, BoardDeleteRejection, BoardDeleteRequest, BoardDeleteTarget,
-    BoardIdentityGeneration, BoardRestoreOutcome, BoardRestoreRejection, BoardRestoreRequest,
+    BoardConfigChange, BoardDeleteOutcome, BoardDeleteRejection, BoardDeleteRequest,
+    BoardDeleteTarget, BoardIdentityGeneration, BoardRestoreOutcome, BoardRestoreRejection,
+    BoardRestoreRequest,
 };
 use crate::input::state::{Toast, ToastPriority};
 use std::time::{Duration, Instant};
@@ -163,7 +164,9 @@ impl InputState {
                 self.pending_board_delete = None;
                 self.clear_pending_deletes_after_board_generation_change(generation_before);
                 self.remove_board_recent(&deleted_id);
-                self.queue_board_config_save();
+                self.queue_board_config_save(BoardConfigChange::IdentityDeleted(
+                    deleted_id.clone(),
+                ));
                 self.deleted_boards.push((
                     BoardRestoreRequest {
                         board: deleted_board,
@@ -249,9 +252,19 @@ impl InputState {
         let generation_before = self.boards.board_identity_generation();
 
         match self.boards.restore_board(request) {
-            BoardRestoreOutcome::Restored { restored_name, .. } => {
+            BoardRestoreOutcome::Restored {
+                restored_id,
+                restored_name,
+                id_changed,
+                ..
+            } => {
                 self.clear_pending_deletes_after_board_generation_change(generation_before);
-                self.queue_board_config_save();
+                let change = if id_changed {
+                    BoardConfigChange::IdentitiesCreated(vec![restored_id])
+                } else {
+                    BoardConfigChange::IdentityRestored(restored_id)
+                };
+                self.queue_board_config_save(change);
                 self.finish_board_transition_from(current_spec, &current_id, false);
                 self.push_toast(
                     ToastPriority::Info,

--- a/src/input/state/core/board/delete_restore/tests.rs
+++ b/src/input/state/core/board/delete_restore/tests.rs
@@ -259,3 +259,49 @@ fn restore_deleted_page_expires_old_entries_with_supplied_now() {
         Some("No deleted page to restore.")
     );
 }
+
+#[test]
+fn delete_then_create_reused_id_tracks_distinct_identity_before_drain() {
+    let mut state = make_test_input_state();
+    assert!(state.create_board());
+    let reused_id = state.board_id().to_string();
+    let _ = state
+        .take_pending_board_config_update()
+        .expect("initial board creation update");
+
+    let requested_at = Instant::now();
+    state.delete_active_board_at(requested_at);
+    state.delete_active_board_at(requested_at + Duration::from_millis(1));
+    assert!(state.create_board());
+    assert_eq!(state.board_id(), reused_id);
+
+    let update = state
+        .take_pending_board_config_update()
+        .expect("coalesced delete and replacement update");
+    assert!(update.structure_changed);
+    assert!(update.deleted_ids.contains(&reused_id));
+    assert!(update.created_ids.contains(&reused_id));
+}
+
+#[test]
+fn delete_then_restore_same_board_cancels_pending_identity_deletion() {
+    let mut state = make_test_input_state();
+    assert!(state.create_board());
+    let restored_id = state.board_id().to_string();
+    let _ = state
+        .take_pending_board_config_update()
+        .expect("initial board creation update");
+
+    let requested_at = Instant::now();
+    let confirmed_at = requested_at + Duration::from_millis(1);
+    state.delete_active_board_at(requested_at);
+    state.delete_active_board_at(confirmed_at);
+    state.restore_deleted_board_at(confirmed_at + Duration::from_millis(1));
+
+    let update = state
+        .take_pending_board_config_update()
+        .expect("coalesced delete and restore update");
+    assert!(update.structure_changed);
+    assert!(!update.deleted_ids.contains(&restored_id));
+    assert!(!update.created_ids.contains(&restored_id));
+}

--- a/src/input/state/core/board/lifecycle.rs
+++ b/src/input/state/core/board/lifecycle.rs
@@ -1,4 +1,5 @@
 use super::super::base::InputState;
+use crate::input::boards::BoardConfigChange;
 
 impl InputState {
     pub(super) fn mark_board_surface_dirty(&mut self) {
@@ -16,11 +17,18 @@ impl InputState {
         self.mark_board_surface_changed();
     }
 
-    pub(crate) fn queue_board_config_save(&mut self) {
+    pub(crate) fn queue_board_config_save(&mut self, change: BoardConfigChange) {
         if !self.boards.persist_customizations() {
             return;
         }
-        self.pending_board_config = Some(self.boards.to_config());
+        let snapshot = self.boards.to_config();
+        if let Some(update) = &mut self.pending_board_config {
+            update.merge(snapshot, change);
+        } else {
+            self.pending_board_config = Some(crate::input::boards::PendingBoardConfigUpdate::new(
+                snapshot, change,
+            ));
+        }
     }
 
     pub(super) fn prepare_active_page_content_change(&mut self) {

--- a/src/input/state/core/board/pages.rs
+++ b/src/input/state/core/board/pages.rs
@@ -1,5 +1,6 @@
 use super::super::base::InputState;
 use crate::draw::Color;
+use crate::input::boards::BoardConfigChange;
 use crate::input::state::{Toast, ToastPriority};
 use crate::input::{BoardBackground, runtime_contrast_pen_color};
 
@@ -38,7 +39,8 @@ impl InputState {
             return false;
         }
         board.spec.name = trimmed.to_string();
-        self.queue_board_config_save();
+        let board_id = board.spec.id.clone();
+        self.queue_board_config_save(BoardConfigChange::Name(board_id));
         self.mark_board_surface_dirty();
         true
     }
@@ -70,7 +72,8 @@ impl InputState {
         if let Some(color) = active_pen_color {
             self.set_pen_color_from_board(color);
         }
-        self.queue_board_config_save();
+        let board_id = self.boards.board_states()[index].spec.id.clone();
+        self.queue_board_config_save(BoardConfigChange::Appearance(board_id));
         self.mark_board_surface_dirty();
         true
     }
@@ -80,7 +83,8 @@ impl InputState {
             return false;
         };
         board.spec.pinned = !board.spec.pinned;
-        self.queue_board_config_save();
+        let board_id = board.spec.id.clone();
+        self.queue_board_config_save(BoardConfigChange::Pinned(board_id));
         self.mark_board_surface_dirty();
         true
     }
@@ -89,7 +93,7 @@ impl InputState {
         if !self.boards.move_board(from, to) {
             return false;
         }
-        self.queue_board_config_save();
+        self.queue_board_config_save(BoardConfigChange::Structure);
         self.mark_board_surface_dirty();
         true
     }

--- a/src/input/state/core/board/switch.rs
+++ b/src/input/state/core/board/switch.rs
@@ -1,4 +1,5 @@
 use super::super::base::InputState;
+use crate::input::boards::BoardConfigChange;
 use crate::input::state::{Toast, ToastPriority};
 use crate::input::{BOARD_ID_TRANSPARENT, BoardSpec};
 
@@ -64,7 +65,6 @@ impl InputState {
         );
         if created {
             let name = self.boards.active_board_name().to_string();
-            self.queue_board_config_save();
             self.push_toast(
                 ToastPriority::Info,
                 "board.switch",
@@ -130,7 +130,9 @@ impl InputState {
         if let Some(new_id) = self.boards.duplicate_active_board() {
             self.clear_pending_deletes_after_board_generation_change(generation_before);
             self.record_board_recent(&new_id);
-            self.queue_board_config_save();
+            self.queue_board_config_save(BoardConfigChange::IdentitiesCreated(vec![
+                new_id.clone(),
+            ]));
             let name = self.boards.active_board_name();
             self.push_toast(
                 ToastPriority::Info,
@@ -190,7 +192,12 @@ impl InputState {
         }
 
         let current_spec = self.boards.active_board().spec.clone();
-        let prev_count = self.boards.board_count();
+        let ids_before = self
+            .boards
+            .board_states()
+            .iter()
+            .map(|board| board.spec.id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
         let generation_before = self.boards.board_identity_generation();
         self.cancel_active_interaction();
         let switched = switch(&mut self.boards);
@@ -204,8 +211,15 @@ impl InputState {
         if target_spec.id == current_id {
             return false;
         }
-        if self.boards.board_count() > prev_count {
-            self.queue_board_config_save();
+        let created_ids = self
+            .boards
+            .board_states()
+            .iter()
+            .filter(|board| !ids_before.contains(&board.spec.id))
+            .map(|board| board.spec.id.clone())
+            .collect::<Vec<_>>();
+        if !created_ids.is_empty() {
+            self.queue_board_config_save(BoardConfigChange::IdentitiesCreated(created_ids));
         }
         self.clear_pending_deletes_after_board_generation_change(generation_before);
         self.finish_board_transition_from(current_spec, current_id, true);

--- a/src/input/state/core/utility/pending.rs
+++ b/src/input/state/core/utility/pending.rs
@@ -4,6 +4,7 @@ use super::super::base::{
     ZoomAction,
 };
 use crate::config::BoardsConfig;
+use crate::input::boards::PendingBoardConfigUpdate;
 
 #[allow(dead_code)]
 impl InputState {
@@ -44,6 +45,12 @@ impl InputState {
 
     /// Takes and clears any pending board config update.
     pub fn take_pending_board_config(&mut self) -> Option<BoardsConfig> {
+        self.pending_board_config
+            .take()
+            .map(PendingBoardConfigUpdate::into_snapshot)
+    }
+
+    pub(crate) fn take_pending_board_config_update(&mut self) -> Option<PendingBoardConfigUpdate> {
         self.pending_board_config.take()
     }
 
@@ -93,6 +100,7 @@ mod tests {
     use super::*;
     use crate::config::{Action, BoardsConfig, KeybindingsConfig, PresenterModeConfig};
     use crate::draw::{Color, FontDescriptor};
+    use crate::input::boards::BoardConfigChange;
     use crate::input::{ClickHighlightSettings, EraserMode};
 
     fn make_state() -> InputState {
@@ -202,7 +210,10 @@ mod tests {
             default_board: "blackboard".to_string(),
             ..BoardsConfig::default()
         };
-        state.pending_board_config = Some(config.clone());
+        state.pending_board_config = Some(PendingBoardConfigUpdate::new(
+            config.clone(),
+            BoardConfigChange::Structure,
+        ));
 
         let taken = state.take_pending_board_config().expect("board config");
         assert_eq!(taken.default_board, "blackboard");

--- a/src/ui/toolbar/model/event_policy.rs
+++ b/src/ui/toolbar/model/event_policy.rs
@@ -1,7 +1,10 @@
-use crate::config::{Action, action_label, action_short_label};
+use crate::config::{
+    Action, ToolbarItemId, ToolbarItemOrderGroup, ToolbarSectionFlag, action_label,
+    action_short_label,
+};
 use crate::input::Tool;
 
-use super::super::ToolbarEvent;
+use super::super::{ToolbarEvent, ToolbarSideSection};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ToolbarEventPolicy {
@@ -33,10 +36,39 @@ pub(crate) enum ToolbarPersistence {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolbarPersistenceTarget {
-    Toolbar,
+    Toolbar(ToolbarConfigPersistenceTarget),
     Ui(ToolbarUiPersistenceTarget),
     History,
     ClickHighlight,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolbarConfigPersistenceTarget {
+    LayoutMode,
+    ItemVisibility {
+        id: ToolbarItemId,
+        hidden: bool,
+    },
+    ResetItemVisibility,
+    ItemOrder(ToolbarItemOrderGroup),
+    TopPinned,
+    SidePinned,
+    TopMinimized,
+    TopDisplayState,
+    SideMinimized,
+    SidePane,
+    CollapsedSection {
+        section: ToolbarSideSection,
+        collapsed: bool,
+    },
+    Icons,
+    MoreColors,
+    ContextAwareUi,
+    PresetToasts,
+    ToolPreview,
+    DelaySliders,
+    TopPosition,
+    SidePosition,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -182,38 +214,95 @@ pub(crate) fn action_for_clear_preset(slot: usize) -> Option<Action> {
 }
 
 fn persistence_for_event(event: &ToolbarEvent) -> ToolbarPersistence {
+    use ToolbarConfigPersistenceTarget::*;
     use ToolbarPersistenceTarget::*;
     use ToolbarUiPersistenceTarget::*;
     match event {
-        ToolbarEvent::PinTopToolbar(_)
-        | ToolbarEvent::PinSideToolbar(_)
-        | ToolbarEvent::ToggleIconMode(_)
-        | ToolbarEvent::ToggleMoreColors(_)
-        | ToolbarEvent::ToggleActionsSection(_)
-        | ToolbarEvent::ToggleActionsAdvanced(_)
-        | ToolbarEvent::ToggleZoomActions(_)
-        | ToolbarEvent::TogglePagesSection(_)
-        | ToolbarEvent::ToggleBoardsSection(_)
-        | ToolbarEvent::TogglePresets(_)
-        | ToolbarEvent::ToggleStepSection(_)
-        | ToolbarEvent::ToggleTextControls(_)
-        | ToolbarEvent::ToggleContextAwareUi(_)
-        | ToolbarEvent::TogglePresetToasts(_)
-        | ToolbarEvent::ToggleToolPreview(_)
-        | ToolbarEvent::ToggleDelaySliders(_)
-        | ToolbarEvent::SetToolbarLayoutMode(_)
-        | ToolbarEvent::SetSidePane(_)
-        | ToolbarEvent::SetTopMinimized(_)
-        | ToolbarEvent::SetTopDisplayMode(_)
-        | ToolbarEvent::SetSideMinimized(_)
-        | ToolbarEvent::CloseTopToolbar
-        | ToolbarEvent::CloseSideToolbar
-        | ToolbarEvent::ToggleSideSectionCollapsed(_, _)
-        | ToolbarEvent::SetToolbarItemHidden(_, _)
-        | ToolbarEvent::MoveToolbarItem { .. }
-        | ToolbarEvent::DragToolbarItemOver { .. }
-        | ToolbarEvent::ResetToolbarItemOrder(_)
-        | ToolbarEvent::ResetToolbarItemHiddenOverrides => ToolbarPersistence::Persist(Toolbar),
+        ToolbarEvent::PinTopToolbar(_) => ToolbarPersistence::Persist(Toolbar(TopPinned)),
+        ToolbarEvent::PinSideToolbar(_) => ToolbarPersistence::Persist(Toolbar(SidePinned)),
+        ToolbarEvent::ToggleIconMode(_) => ToolbarPersistence::Persist(Toolbar(Icons)),
+        ToolbarEvent::ToggleMoreColors(_) => ToolbarPersistence::Persist(Toolbar(MoreColors)),
+        ToolbarEvent::ToggleActionsSection(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::Actions.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::ToggleActionsAdvanced(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::ActionsAdvanced.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::ToggleZoomActions(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::ZoomActions.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::TogglePagesSection(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::Pages.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::ToggleBoardsSection(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::Boards.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::TogglePresets(show) => ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+            id: ToolbarSectionFlag::Presets.item_id(),
+            hidden: !show,
+        })),
+        ToolbarEvent::ToggleStepSection(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::StepSection.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::ToggleTextControls(show) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: ToolbarSectionFlag::TextControls.item_id(),
+                hidden: !show,
+            }))
+        }
+        ToolbarEvent::ToggleContextAwareUi(_) => {
+            ToolbarPersistence::Persist(Toolbar(ContextAwareUi))
+        }
+        ToolbarEvent::TogglePresetToasts(_) => ToolbarPersistence::Persist(Toolbar(PresetToasts)),
+        ToolbarEvent::ToggleToolPreview(_) => ToolbarPersistence::Persist(Toolbar(ToolPreview)),
+        ToolbarEvent::ToggleDelaySliders(_) => ToolbarPersistence::Persist(Toolbar(DelaySliders)),
+        ToolbarEvent::SetToolbarLayoutMode(_) => ToolbarPersistence::Persist(Toolbar(LayoutMode)),
+        ToolbarEvent::SetSidePane(_) => ToolbarPersistence::Persist(Toolbar(SidePane)),
+        ToolbarEvent::SetTopMinimized(_) | ToolbarEvent::CloseTopToolbar => {
+            ToolbarPersistence::Persist(Toolbar(TopMinimized))
+        }
+        ToolbarEvent::SetTopDisplayMode(_) => ToolbarPersistence::Persist(Toolbar(TopDisplayState)),
+        ToolbarEvent::SetSideMinimized(_) | ToolbarEvent::CloseSideToolbar => {
+            ToolbarPersistence::Persist(Toolbar(SideMinimized))
+        }
+        ToolbarEvent::ToggleSideSectionCollapsed(section, collapsed) => {
+            ToolbarPersistence::Persist(Toolbar(CollapsedSection {
+                section: *section,
+                collapsed: *collapsed,
+            }))
+        }
+        ToolbarEvent::SetToolbarItemHidden(id, hidden) => {
+            ToolbarPersistence::Persist(Toolbar(ItemVisibility {
+                id: *id,
+                hidden: *hidden,
+            }))
+        }
+        ToolbarEvent::MoveToolbarItem { group, .. }
+        | ToolbarEvent::DragToolbarItemOver { group, .. }
+        | ToolbarEvent::ResetToolbarItemOrder(group) => {
+            ToolbarPersistence::Persist(Toolbar(ItemOrder(*group)))
+        }
+        ToolbarEvent::ResetToolbarItemHiddenOverrides => {
+            ToolbarPersistence::Persist(Toolbar(ResetItemVisibility))
+        }
         ToolbarEvent::ToggleCustomSection(_) => ToolbarPersistence::Persist(History),
         ToolbarEvent::ToggleStatusBar(_) => ToolbarPersistence::Persist(Ui(StatusBar)),
         ToolbarEvent::ToggleStatusBoardBadge(_) => {
@@ -226,7 +315,94 @@ fn persistence_for_event(event: &ToolbarEvent) -> ToolbarPersistence {
         ToolbarEvent::SelectTool(Tool::Highlight)
         | ToolbarEvent::ToggleAllHighlight(_)
         | ToolbarEvent::ToggleHighlightToolRing(_) => ToolbarPersistence::Persist(ClickHighlight),
-        _ => ToolbarPersistence::RuntimeOnly,
+        ToolbarEvent::SelectTool(_)
+        | ToolbarEvent::SetColor(_)
+        | ToolbarEvent::SetQuickColor { .. }
+        | ToolbarEvent::SetColorHsv { .. }
+        | ToolbarEvent::SetThickness(_)
+        | ToolbarEvent::NudgeThickness(_)
+        | ToolbarEvent::SetMarkerOpacity(_)
+        | ToolbarEvent::NudgeMarkerOpacity(_)
+        | ToolbarEvent::SetEraserMode(_)
+        | ToolbarEvent::SetFont(_)
+        | ToolbarEvent::SetFontSize(_)
+        | ToolbarEvent::NudgeFontSize(_)
+        | ToolbarEvent::ToggleFill(_)
+        | ToolbarEvent::SetPolygonSides(_)
+        | ToolbarEvent::NudgePolygonSides(_)
+        | ToolbarEvent::ToggleArrowLabels(_)
+        | ToolbarEvent::ResetArrowLabelCounter
+        | ToolbarEvent::ResetStepMarkerCounter
+        | ToolbarEvent::SetUndoDelay(_)
+        | ToolbarEvent::SetRedoDelay(_)
+        | ToolbarEvent::UndoAll
+        | ToolbarEvent::RedoAll
+        | ToolbarEvent::UndoAllDelayed
+        | ToolbarEvent::RedoAllDelayed
+        | ToolbarEvent::Undo
+        | ToolbarEvent::Redo
+        | ToolbarEvent::ClearCanvas { .. }
+        | ToolbarEvent::CaptureScreenshot
+        | ToolbarEvent::PagePrev
+        | ToolbarEvent::PageNext
+        | ToolbarEvent::PageNew
+        | ToolbarEvent::PageDuplicate
+        | ToolbarEvent::PageDelete
+        | ToolbarEvent::BoardPrev
+        | ToolbarEvent::BoardNext
+        | ToolbarEvent::BoardNew
+        | ToolbarEvent::BoardDelete
+        | ToolbarEvent::BoardDuplicate
+        | ToolbarEvent::BoardRename
+        | ToolbarEvent::ToggleBoardPicker
+        | ToolbarEvent::EnterTextMode
+        | ToolbarEvent::EnterStickyNoteMode
+        | ToolbarEvent::ToggleFreeze
+        | ToolbarEvent::ZoomIn
+        | ToolbarEvent::ZoomOut
+        | ToolbarEvent::ResetZoom
+        | ToolbarEvent::ToggleZoomLock
+        | ToolbarEvent::RefreshZoomCapture
+        | ToolbarEvent::ApplyPreset(_)
+        | ToolbarEvent::SavePreset(_)
+        | ToolbarEvent::ClearPreset(_)
+        | ToolbarEvent::OpenSession
+        | ToolbarEvent::OpenRecentSession(_)
+        | ToolbarEvent::SaveSessionAs
+        | ToolbarEvent::SaveSessionAsConfirm(_)
+        | ToolbarEvent::SaveSessionAsCancel
+        | ToolbarEvent::SessionInfo
+        | ToolbarEvent::ClearSession
+        | ToolbarEvent::OpenConfigurator
+        | ToolbarEvent::OpenConfigFile
+        | ToolbarEvent::OpenCommandPalette
+        | ToolbarEvent::SetCustomUndoDelay(_)
+        | ToolbarEvent::SetCustomRedoDelay(_)
+        | ToolbarEvent::SetCustomUndoSteps(_)
+        | ToolbarEvent::SetCustomRedoSteps(_)
+        | ToolbarEvent::CustomUndo
+        | ToolbarEvent::CustomRedo
+        | ToolbarEvent::ToggleTopOverflow(_)
+        | ToolbarEvent::ToggleSessionPopover(_)
+        | ToolbarEvent::ToggleSettingsPopover(_)
+        | ToolbarEvent::ToggleCanvasPopover(_)
+        | ToolbarEvent::ScrollTopPopover(_)
+        | ToolbarEvent::CopyHexColor
+        | ToolbarEvent::PasteHexColor
+        | ToolbarEvent::EditHexColor
+        | ToolbarEvent::OpenColorPickerPopup
+        | ToolbarEvent::OpenPrecisionEntry(_)
+        | ToolbarEvent::CommitPrecisionEntry { .. }
+        | ToolbarEvent::CancelPrecisionEntry
+        | ToolbarEvent::AdjustSelectionProperty { .. }
+        | ToolbarEvent::PickScreenColor
+        | ToolbarEvent::ScrollSidePane(_)
+        | ToolbarEvent::StartToolbarItemDrag { .. }
+        | ToolbarEvent::SetToolbarItemCustomizationOpen(_)
+        | ToolbarEvent::SetToolbarItemCustomizationGroup(_)
+        | ToolbarEvent::ToggleShapePicker(_)
+        | ToolbarEvent::MoveTopToolbar { .. }
+        | ToolbarEvent::MoveSideToolbar { .. } => ToolbarPersistence::RuntimeOnly,
     }
 }
 

--- a/src/ui/toolbar/model/mod.rs
+++ b/src/ui/toolbar/model/mod.rs
@@ -28,10 +28,10 @@ pub(crate) use control::{
 };
 #[allow(unused_imports)]
 pub(crate) use event_policy::{
-    ToolbarBackendRoute, ToolbarEventPolicy, ToolbarPersistence, ToolbarPersistenceTarget,
-    ToolbarPreApplyEffect, ToolbarUiPersistenceTarget, action_for_apply_preset,
-    action_for_clear_preset, action_for_event, action_for_save_preset, action_for_tool,
-    short_label_for_event, tooltip_label_for_event,
+    ToolbarBackendRoute, ToolbarConfigPersistenceTarget, ToolbarEventPolicy, ToolbarPersistence,
+    ToolbarPersistenceTarget, ToolbarPreApplyEffect, ToolbarUiPersistenceTarget,
+    action_for_apply_preset, action_for_clear_preset, action_for_event, action_for_save_preset,
+    action_for_tool, short_label_for_event, tooltip_label_for_event,
 };
 #[allow(unused_imports)]
 pub(crate) use header::{SideHeaderModel, board_chip_label, layout_mode_control};
@@ -324,7 +324,9 @@ mod tests {
         );
         assert_eq!(
             ToolbarEventPolicy::for_event(&ToolbarEvent::SetSidePane(SidePane::Canvas)).persistence,
-            ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar)
+            ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar(
+                ToolbarConfigPersistenceTarget::SidePane
+            ))
         );
         assert_eq!(
             ToolbarEventPolicy::for_event(&ToolbarEvent::ToggleSideSectionCollapsed(
@@ -332,7 +334,12 @@ mod tests {
                 true,
             ))
             .persistence,
-            ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar)
+            ToolbarPersistence::Persist(ToolbarPersistenceTarget::Toolbar(
+                ToolbarConfigPersistenceTarget::CollapsedSection {
+                    section: crate::ui::toolbar::ToolbarSideSection::Colors,
+                    collapsed: true,
+                }
+            ))
         );
         assert_eq!(
             ToolbarEventPolicy::for_event(&ToolbarEvent::ScrollSidePane(12.0)).persistence,


### PR DESCRIPTION
## Summary

- Route toolbar actions to exact config fields instead of saving the entire toolbar state.
- Preserve unrelated and unknown toolbar settings during runtime saves.
- Save board structure, names, appearance, and pin changes independently.
- Prevent board reorder/create/delete operations from copying unrelated live state into `config.toml`.
- Persist the reconciled top-toolbar position after side-toolbar drags.
- Distinguish newly created boards from deleted boards that reused the same ID.

## Why

Runtime interactions could previously save a complete in-memory toolbar or board snapshot.

For example, moving a toolbar could also write its pin state, hidden tools, and other settings.
Similarly, changing board structure could save unrelated board pin or appearance state.

The existing lossless config path preserves comments and formatting, but it does not prevent these unrelated values from being written. This PR scopes every save to the setting the user actually changed.

## Scope

This is an incremental fix for #293.

`config.toml` still stores these preferences and may change when the corresponding actions are used. This PR makes those  writes precise and safe; moving runtime-only UI state into separate storage will be handled in follow-up work.