### PR TITLE
Add hidden toolbar recovery hint

### DIFF
--- a/src/input/state/core/status_hud.rs
+++ b/src/input/state/core/status_hud.rs
@@ -103,8 +103,8 @@ impl InputState {
     /// Check a release at (x, y) against the status HUD segments. On a
     /// segment hit, opens the matching surface directly (board picker, color
     /// picker popup, radial menu at the pointer) and/or returns the action
-    /// for the backend to dispatch (help). Returns `(hit, action)` mirroring
-    /// toast release resolver.
+    /// for the backend to dispatch (help, toolbar restore). Returns
+    /// `(hit, action)` mirroring toast release resolver.
     pub(crate) fn check_status_hud_click(&mut self, x: i32, y: i32) -> (bool, Option<Action>) {
         // `status_hud_contains` also applies the open-overlay guard, so a
         // release cannot activate a chip when an overlay opened between the
@@ -144,6 +144,7 @@ impl InputState {
                 (true, None)
             }
             StatusHudSegmentKind::Help => (true, Some(Action::ToggleHelp)),
+            StatusHudSegmentKind::Toolbar => (true, Some(Action::ToggleToolbar)),
         }
     }
 }

--- a/src/input/state/core/tool_controls/toolbar.rs
+++ b/src/input/state/core/tool_controls/toolbar.rs
@@ -9,7 +9,15 @@ pub(crate) const CLEAR_UNDO_TOAST_MS: u64 = 2000;
 impl InputState {
     /// Sets toolbar visibility flag (controls both top and side). Returns true if toggled.
     pub fn set_toolbar_visible(&mut self, visible: bool) -> bool {
-        let any_change = self.toolbar_visible != visible
+        // Showing must also count a cycle-hidden (F2) top strip as a
+        // change: under the default pill side layout every raw flag can be
+        // true while no surface is visible, and the raw-flag comparison
+        // alone would swallow the restore (F9, the onboarding toast's Show
+        // action, and the status-bar hint chip all dispatch ToggleToolbar
+        // into this setter).
+        let unhide_top = visible && self.toolbar_top_display_mode == TopDisplayMode::Hidden;
+        let any_change = unhide_top
+            || self.toolbar_visible != visible
             || self.toolbar_top_visible != visible
             || self.toolbar_side_visible != visible;
 

--- a/src/input/state/tests/status_hud.rs
+++ b/src/input/state/tests/status_hud.rs
@@ -128,6 +128,75 @@ fn status_hud_click_help_segment_returns_toggle_help_action() {
 }
 
 #[test]
+fn status_hud_click_toolbar_hint_returns_toggle_toolbar_action() {
+    let mut input = create_test_input_state();
+
+    // The hint chip only exists while every toolbar surface is hidden.
+    update_hud_layout(&mut input, 1280, 720);
+    let layout = input.status_hud_layout().expect("status hud layout");
+    assert!(
+        !layout
+            .segments
+            .iter()
+            .any(|segment| segment.kind == StatusHudSegmentKind::Toolbar),
+        "toolbar hint must not show while the toolbar is visible"
+    );
+
+    input.set_toolbar_visible(false);
+    update_hud_layout(&mut input, 1280, 720);
+    let (x, y) = segment_center(&input, StatusHudSegmentKind::Toolbar);
+
+    let (hit, action) = input.check_status_hud_click(x, y);
+    assert!(hit);
+    assert_eq!(action, Some(Action::ToggleToolbar));
+    // The action is dispatched by the backend; no surface opens here.
+    assert!(!input.is_board_picker_open());
+    assert!(!input.is_color_picker_popup_open());
+    assert!(!input.is_radial_menu_open());
+}
+
+/// End-to-end recovery in the shipping default state: pill side layout
+/// (side palette retired) with the top strip F2-cycled to Hidden leaves
+/// every raw visibility flag true while no surface is visible. The hint
+/// chip must appear there, and dispatching its returned action must
+/// actually restore the toolbar — the advertised recovery cannot be a
+/// no-op.
+#[test]
+fn status_hud_toolbar_hint_recovers_cycle_hidden_strip_under_pill_layout() {
+    let mut input = create_test_input_state();
+    input.init_toolbar_side_layout_from_config(crate::config::ToolbarSideLayout::Pill);
+    input.handle_action(Action::CycleToolbarDisplay); // micro
+    input.handle_action(Action::CycleToolbarDisplay); // hidden
+    assert!(!input.toolbar_visible());
+
+    update_hud_layout(&mut input, 1280, 720);
+    let (x, y) = segment_center(&input, StatusHudSegmentKind::Toolbar);
+    let (hit, action) = input.check_status_hud_click(x, y);
+    assert!(hit);
+    let action = action.expect("toolbar hint chip returns an action");
+    assert_eq!(action, Action::ToggleToolbar);
+
+    // Dispatch the returned action exactly as the backend does.
+    input.handle_action(action);
+    assert!(
+        input.toolbar_visible(),
+        "clicking the recovery chip must restore the toolbar"
+    );
+
+    // The hint disappears on the next layout pass.
+    update_hud_layout(&mut input, 1280, 720);
+    assert!(
+        !input
+            .status_hud_layout()
+            .expect("status hud layout")
+            .segments
+            .iter()
+            .any(|segment| segment.kind == StatusHudSegmentKind::Toolbar),
+        "hint must clear once the toolbar is back"
+    );
+}
+
+#[test]
 fn status_hud_click_between_segments_consumes_without_action() {
     let mut input = create_test_input_state();
     update_hud_layout(&mut input, 1280, 720);

--- a/src/input/state/tests/toolbar_display.rs
+++ b/src/input/state/tests/toolbar_display.rs
@@ -75,6 +75,29 @@ fn toggle_toolbar_show_restores_a_cycle_hidden_top_strip() {
 }
 
 #[test]
+fn toggle_toolbar_restores_a_cycle_hidden_strip_under_pill_layout() {
+    let mut state = create_test_input_state();
+    // The shipping default: the side palette is retired by the pill layout,
+    // so a cycle-hidden top strip leaves NO visible toolbar surface while
+    // every raw visibility flag stays true. The raw-flag early return in
+    // set_toolbar_visible used to swallow the restore in exactly this
+    // state, leaving F9 (and everything else dispatching ToggleToolbar)
+    // dead.
+    state.init_toolbar_side_layout_from_config(crate::config::ToolbarSideLayout::Pill);
+    state.handle_action(Action::CycleToolbarDisplay); // micro
+    state.handle_action(Action::CycleToolbarDisplay); // hidden
+    assert!(
+        !state.toolbar_visible(),
+        "cycle-hidden under pill must leave no visible surface"
+    );
+
+    // A single ToggleToolbar press must bring the strip back.
+    state.handle_action(Action::ToggleToolbar);
+    assert!(state.toolbar_visible());
+    assert_eq!(state.top_display_state(), TopDisplayMode::Full);
+}
+
+#[test]
 fn micro_form_survives_a_visibility_toggle() {
     let mut state = create_test_input_state();
     state.handle_action(Action::CycleToolbarDisplay); // micro

--- a/src/ui/status/bar.rs
+++ b/src/ui/status/bar.rs
@@ -9,7 +9,7 @@ use super::badges::{
 };
 use crate::config::{Action, StatusPosition, action_display_label};
 use crate::input::{BoardBackground, DrawingState, InputState, TextInputMode, Tool};
-use crate::label_format::format_binding_labels;
+use crate::label_format::{format_binding_labels, join_binding_labels};
 use crate::ui::toolbar::bindings::action_for_tool;
 use crate::ui_text::{UiTextExtents, UiTextStyle, measure_text, text_layout};
 
@@ -63,6 +63,9 @@ pub enum StatusHudSegmentKind {
     Tool,
     /// Help hint chip: toggles the help overlay.
     Help,
+    /// Hidden-toolbar hint chip (shown only while no toolbar surface is
+    /// visible): restores the toolbar.
+    Toolbar,
 }
 
 /// One laid-out run of pill content on the shared single-line baseline.
@@ -473,6 +476,22 @@ fn build_cluster_pieces(input_state: &InputState) -> Vec<StatusHudPiece> {
         pieces.push(StatusHudPiece::text(
             action_display_label(Action::SelectHighlightTool).to_string(),
             None,
+            true,
+        ));
+    }
+
+    // Hidden-toolbar hint: when every toolbar surface is gone (F9 toggle or
+    // F2 cycle-hidden), point at the way back so an accidental hide is
+    // recoverable from the status bar alone. Clicking the chip restores the
+    // toolbar directly. Suppressed while presenter mode owns toolbar
+    // visibility (the toggle is a no-op there), and shed first when the
+    // width budget binds.
+    if !input_state.toolbar_visible()
+        && !(input_state.presenter_mode && input_state.presenter_mode_config.hide_toolbars)
+    {
+        pieces.push(StatusHudPiece::text(
+            toolbar_hint_label(input_state),
+            Some(StatusHudSegmentKind::Toolbar),
             true,
         ));
     }
@@ -933,6 +952,17 @@ fn help_binding_label(input_state: &InputState) -> String {
     format_binding_labels(&labels)
 }
 
+/// Hidden-toolbar hint chip text, styled like the help chip: "{binding}
+/// Toolbar" (e.g. "F9 Toolbar"), or bare "Toolbar" when the toggle is
+/// unbound (the chip stays clickable either way).
+fn toolbar_hint_label(input_state: &InputState) -> String {
+    let labels = input_state.action_binding_labels(Action::ToggleToolbar);
+    match join_binding_labels(&labels) {
+        Some(binding) => format!("{binding} Toolbar"),
+        None => "Toolbar".to_string(),
+    }
+}
+
 fn tool_action_label(tool: Tool) -> &'static str {
     action_for_tool(tool)
         .map(action_display_label)
@@ -1168,6 +1198,45 @@ mod tests {
             "help chip should shed under a tight budget"
         );
         assert!(narrow.pill_width <= 400.0 * STATUS_BAR_MAX_WIDTH_FRACTION + 1e-6);
+    }
+
+    /// The hidden-toolbar hint chip appears only while no toolbar surface is
+    /// visible, carries the toggle binding, and never shows while presenter
+    /// mode owns toolbar visibility (the toggle is a no-op there).
+    #[test]
+    fn toolbar_hint_chip_appears_only_while_toolbar_hidden() {
+        let style = StatusBarStyle::default();
+        let mut state = make_state();
+
+        let has_chip = |state: &InputState| {
+            compute_status_hud_layout(state, StatusPosition::BottomLeft, &style, 1920, 1080)
+                .expect("layout")
+                .segments
+                .iter()
+                .any(|s| s.kind == StatusHudSegmentKind::Toolbar)
+        };
+
+        // Toolbars visible: no hint.
+        assert!(!has_chip(&state));
+
+        // All toolbar surfaces hidden: the hint appears with the F9 binding.
+        state.set_toolbar_visible(false);
+        assert!(has_chip(&state));
+        let layout =
+            compute_status_hud_layout(&state, StatusPosition::BottomLeft, &style, 1920, 1080)
+                .expect("layout");
+        assert!(
+            layout.runs.iter().any(|run| matches!(
+                run,
+                StatusHudRun::Text { text, .. } if text == "F9 Toolbar"
+            )),
+            "expected the default-binding hint text"
+        );
+
+        // Presenter mode with hide_toolbars: the hint must not tease a
+        // toggle that presenter mode suppresses.
+        state.presenter_mode = true;
+        assert!(!has_chip(&state));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a clickable toolbar recovery hint to the status HUD when no toolbar surface is visible
- Show the current toolbar shortcut in the hint, with a fallback when unbound
- Restore F2 cycle-hidden toolbars correctly under the default Pill layout
- Fix the same recovery path for F9 and the onboarding “Show” action
- Suppress the hint while presenter mode owns toolbar visibility