### PR TITLE
feat(command-palette): highlight query matches and soften the panel shadow

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,6 +13,7 @@ mod primitives;
 mod properties_panel;
 mod radial_menu;
 mod status;
+mod text_highlight;
 pub mod theme;
 mod toasts;
 mod tour;

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -36,8 +36,14 @@ const COMMAND_PALETTE_SHORTCUT_BADGE_RADIUS: f64 = 3.0;
 const COMMAND_PALETTE_SHORTCUT_MIN_DESC_WIDTH: f64 = 48.0;
 const COMMAND_PALETTE_INPUT_HINT: &str =
     "Enter run • Ctrl+E edit • Ctrl+Delete unbind • Ctrl+R reset • Esc close";
-/// Offset of the frame drop shadow below/right of the palette.
-const FRAME_SHADOW_OFFSET: f64 = 4.0;
+/// Maximum extent of the frame drop shadow below/right of the palette. Also
+/// the damage-region padding, so the softest (furthest) shadow layer is
+/// always covered — keep the layer offsets in `draw_command_palette_frame`
+/// at or below this.
+const FRAME_SHADOW_OFFSET: f64 = 12.0;
+/// Outer, softer layer of the two-layer drop shadow (lighter than the inner
+/// `SHADOW` layer; mirrors the help overlay frame).
+const FRAME_SHADOW_SOFT: (f64, f64, f64, f64) = (0.0, 0.0, 0.0, 0.22);
 const TOOLTIP_PADDING_X: f64 = 8.0;
 const TOOLTIP_PADDING_Y: f64 = 5.0;
 const TOOLTIP_POINTER_OFFSET: f64 = 12.0;
@@ -350,11 +356,24 @@ fn draw_command_palette_frame(
     ctx.rectangle(0.0, 0.0, screen_width, screen_height);
     let _ = ctx.fill();
 
-    constants::set_color(ctx, SHADOW);
+    // Two-layer drop shadow for a softer edge: a lighter outer layer offset
+    // to the shadow's full extent, then the denser inner layer closer in.
+    constants::set_color(ctx, FRAME_SHADOW_SOFT);
     draw_rounded_rect(
         ctx,
         x + FRAME_SHADOW_OFFSET,
         y + FRAME_SHADOW_OFFSET,
+        palette_width,
+        height,
+        RADIUS_LG,
+    );
+    let _ = ctx.fill();
+
+    constants::set_color(ctx, SHADOW);
+    draw_rounded_rect(
+        ctx,
+        x + FRAME_SHADOW_OFFSET * 0.5,
+        y + FRAME_SHADOW_OFFSET * 0.5,
         palette_width,
         height,
         RADIUS_LG,

--- a/src/ui/command_palette/command_palette_row.rs
+++ b/src/ui/command_palette/command_palette_row.rs
@@ -2,10 +2,12 @@ use crate::config::KeybindingsConfig;
 use crate::config::action_meta::ActionMeta;
 use crate::input::InputState;
 use crate::input::state::COMMAND_PALETTE_ITEM_HEIGHT;
+use crate::input::state::query_tokens;
 use crate::input::state::{
     COMMAND_PALETTE_ROW_ACTION_COUNT, COMMAND_PALETTE_ROW_ACTION_GAP,
     COMMAND_PALETTE_ROW_ACTION_SIZE, COMMAND_PALETTE_ROW_ICON_GAP, COMMAND_PALETTE_ROW_ICON_SIZE,
 };
+use crate::ui::text_highlight::{HighlightStyle, draw_highlight, find_match_range};
 use crate::ui_text::{UiTextStyle, draw_text_baseline};
 
 use super::super::constants::{self, BG_INPUT_SELECTION, RADIUS_SM, TEXT_DESCRIPTION, TEXT_WHITE};
@@ -83,6 +85,18 @@ pub(super) fn render_command_row(
         );
     }
     let label_x = inner_x + 10.0 + COMMAND_PALETTE_ROW_ICON_SIZE + COMMAND_PALETTE_ROW_ICON_GAP;
+
+    // Accent backdrop behind the label characters the query matched, so the
+    // user sees why a command surfaced. Drawn before the text so the glyphs
+    // sit on top; fuzzy-only (subsequence) matches draw nothing.
+    draw_label_match_highlights(
+        ctx,
+        &input_state.command_palette_query,
+        cmd.label,
+        label_x,
+        label_y,
+        styles.label.size,
+    );
 
     constants::set_color(ctx, constants::with_alpha(TEXT_WHITE, text_alpha));
     render_command_row_label(ctx, cmd.label, label_x, label_y, styles);
@@ -173,6 +187,36 @@ fn render_command_row_label(
     styles: &CommandPaletteRowStyle,
 ) {
     draw_text_baseline(ctx, styles.label, label, x, y, None);
+}
+
+/// Draw the accent match backdrop for each query token that appears in the
+/// label as a literal (case-insensitive) substring. The label text itself is
+/// drawn by the caller afterwards, over these boxes.
+fn draw_label_match_highlights(
+    ctx: &cairo::Context,
+    query: &str,
+    label: &str,
+    label_x: f64,
+    label_y: f64,
+    label_size: f64,
+) {
+    let query = query.trim();
+    if query.is_empty() {
+        return;
+    }
+    let query_lower = query.to_ascii_lowercase();
+    let (hr, hg, hb, ha) = constants::with_alpha(constants::ACCENT_PRIMARY, 0.30);
+    let style = HighlightStyle {
+        font_family: COMMAND_PALETTE_FONT_FAMILY,
+        font_size: label_size,
+        font_weight: cairo::FontWeight::Normal,
+        color: [hr, hg, hb, ha],
+    };
+    for token in query_tokens(&query_lower) {
+        if let Some(range) = find_match_range(label, token) {
+            draw_highlight(ctx, label_x, label_y, label, range, &style);
+        }
+    }
 }
 
 pub(super) fn render_command_row_shortcut_badge(

--- a/src/ui/help_overlay/search.rs
+++ b/src/ui/help_overlay/search.rs
@@ -6,19 +6,11 @@ use super::types::Row;
 use crate::input::state::{action_meta_token_score, fuzzy_score, query_tokens};
 use crate::ui_text::{UiTextStyle, draw_text_baseline};
 
-const ELLIPSIS: &str = "\u{2026}";
+// Substring match highlighting is shared with the command palette; matching
+// itself is fuzzy (see [`row_matches`]), so a fuzzy-only match draws none.
+pub(crate) use crate::ui::text_highlight::{HighlightStyle, draw_highlight, find_match_range};
 
-/// Substring range for match highlighting only; matching itself is fuzzy
-/// (see [`row_matches`]), so a fuzzy-only match simply draws no highlight.
-pub(crate) fn find_match_range(haystack: &str, needle_lower: &str) -> Option<(usize, usize)> {
-    if needle_lower.is_empty() {
-        return None;
-    }
-    let haystack_lower = haystack.to_ascii_lowercase();
-    haystack_lower
-        .find(needle_lower)
-        .map(|start| (start, start + needle_lower.len()))
-}
+const ELLIPSIS: &str = "\u{2026}";
 
 /// Fuzzy row match: every query token must fuzzy-match the shortcut string
 /// (`key`), the visible action description, or — for rows that carry an action
@@ -46,68 +38,6 @@ pub(crate) fn title_matches(title: &str, needle_lower: &str) -> bool {
         return false;
     }
     tokens.iter().all(|token| fuzzy_score(token, title) > 0)
-}
-
-pub(crate) struct HighlightStyle<'a> {
-    pub(crate) font_family: &'a str,
-    pub(crate) font_size: f64,
-    pub(crate) font_weight: cairo::FontWeight,
-    pub(crate) color: [f64; 4],
-}
-
-pub(crate) fn draw_highlight(
-    ctx: &cairo::Context,
-    x: f64,
-    baseline: f64,
-    text: &str,
-    range: (usize, usize),
-    style: &HighlightStyle<'_>,
-) {
-    let (start, end) = range;
-    if start >= end || end > text.len() {
-        return;
-    }
-    if !text.is_char_boundary(start) || !text.is_char_boundary(end) {
-        return;
-    }
-    let prefix = &text[..start];
-    let matched = &text[start..end];
-    if matched.is_empty() {
-        return;
-    }
-
-    let prefix_extents = text_extents_for(
-        ctx,
-        style.font_family,
-        cairo::FontSlant::Normal,
-        style.font_weight,
-        style.font_size,
-        prefix,
-    );
-    let match_extents = text_extents_for(
-        ctx,
-        style.font_family,
-        cairo::FontSlant::Normal,
-        style.font_weight,
-        style.font_size,
-        matched,
-    );
-
-    let pad_x = 2.0;
-    let pad_y = 2.0;
-    let highlight_x = x + prefix_extents.width() - pad_x;
-    let highlight_y = baseline + match_extents.y_bearing() - pad_y;
-    let highlight_width = match_extents.width() + pad_x * 2.0;
-    let highlight_height = match_extents.height() + pad_y * 2.0;
-
-    ctx.set_source_rgba(
-        style.color[0],
-        style.color[1],
-        style.color[2],
-        style.color[3],
-    );
-    ctx.rectangle(highlight_x, highlight_y, highlight_width, highlight_height);
-    let _ = ctx.fill();
 }
 
 pub(crate) fn draw_segmented_text(

--- a/src/ui/text_highlight.rs
+++ b/src/ui/text_highlight.rs
@@ -1,0 +1,110 @@
+//! Shared substring match-highlighting for search UIs (help overlay,
+//! command palette). Matching itself is fuzzy; this only draws a background
+//! behind a literal substring range, so a fuzzy-only (subsequence) match
+//! simply draws no highlight — the same graceful degradation both callers
+//! want.
+
+use super::primitives::text_extents_for;
+
+/// Case-insensitive substring range (byte offsets) of `needle_lower` inside
+/// `haystack`, or `None` when it does not appear literally. `needle_lower`
+/// must already be lowercased by the caller.
+pub(crate) fn find_match_range(haystack: &str, needle_lower: &str) -> Option<(usize, usize)> {
+    if needle_lower.is_empty() {
+        return None;
+    }
+    let haystack_lower = haystack.to_ascii_lowercase();
+    haystack_lower
+        .find(needle_lower)
+        .map(|start| (start, start + needle_lower.len()))
+}
+
+pub(crate) struct HighlightStyle<'a> {
+    pub(crate) font_family: &'a str,
+    pub(crate) font_size: f64,
+    pub(crate) font_weight: cairo::FontWeight,
+    pub(crate) color: [f64; 4],
+}
+
+/// Fill a padded rectangle behind the glyphs of `text[range]`, positioned
+/// from the text's left edge `x` and `baseline`. The caller draws the text
+/// itself over the top afterwards.
+pub(crate) fn draw_highlight(
+    ctx: &cairo::Context,
+    x: f64,
+    baseline: f64,
+    text: &str,
+    range: (usize, usize),
+    style: &HighlightStyle<'_>,
+) {
+    let (start, end) = range;
+    if start >= end || end > text.len() {
+        return;
+    }
+    if !text.is_char_boundary(start) || !text.is_char_boundary(end) {
+        return;
+    }
+    let prefix = &text[..start];
+    let matched = &text[start..end];
+    if matched.is_empty() {
+        return;
+    }
+
+    let prefix_extents = text_extents_for(
+        ctx,
+        style.font_family,
+        cairo::FontSlant::Normal,
+        style.font_weight,
+        style.font_size,
+        prefix,
+    );
+    let match_extents = text_extents_for(
+        ctx,
+        style.font_family,
+        cairo::FontSlant::Normal,
+        style.font_weight,
+        style.font_size,
+        matched,
+    );
+
+    let pad_x = 2.0;
+    let pad_y = 2.0;
+    let highlight_x = x + prefix_extents.width() - pad_x;
+    let highlight_y = baseline + match_extents.y_bearing() - pad_y;
+    let highlight_width = match_extents.width() + pad_x * 2.0;
+    let highlight_height = match_extents.height() + pad_y * 2.0;
+
+    ctx.set_source_rgba(
+        style.color[0],
+        style.color[1],
+        style.color[2],
+        style.color[3],
+    );
+    ctx.rectangle(highlight_x, highlight_y, highlight_width, highlight_height);
+    let _ = ctx.fill();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_match_range_matches_against_a_mixed_case_haystack() {
+        // The needle is pre-lowercased by contract; only the haystack is
+        // lowered here, so a mixed-case label still matches.
+        assert_eq!(find_match_range("Toggle Toolbar", "tool"), Some((7, 11)));
+        assert_eq!(find_match_range("Toggle Toolbar", "toggle"), Some((0, 6)));
+    }
+
+    #[test]
+    fn find_match_range_returns_none_for_absent_or_empty() {
+        assert_eq!(find_match_range("Zoom In", "xyz"), None);
+        assert_eq!(find_match_range("Zoom In", ""), None);
+    }
+
+    #[test]
+    fn find_match_range_reports_byte_offsets_for_the_first_occurrence() {
+        // Two occurrences: the first one wins.
+        assert_eq!(find_match_range("a b a", "a"), Some((0, 1)));
+    }
+}

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -165,6 +165,22 @@ fn render_help_overlay_without_frozen_shortcuts_draws_content() {
 }
 
 #[test]
+fn render_command_palette_with_query_draws_content() {
+    // Exercises the match-highlight path: an open palette with a query that
+    // literally appears in some command labels must render without panicking
+    // and draw pixels (highlight boxes + rows).
+    let (mut surface, ctx) = surface_with_context(900, 700);
+    let mut input = make_input_state();
+    input.command_palette_open = true;
+    input.command_palette_query = "tool".to_string();
+
+    wayscriber::ui::render_command_palette(&ctx, &input, 900, 700);
+
+    drop(ctx);
+    assert!(surface_has_pixels(&mut surface));
+}
+
+#[test]
 fn render_keybinding_capture_draws_content() {
     let (mut surface, ctx) = surface_with_context(800, 600);
     let mut input = make_input_state();


### PR DESCRIPTION
## Summary

- Highlight literal query matches in command-palette result labels with a subtle accent backdrop.
- Preserve existing fuzzy matching behavior; subsequence-only matches remain unhighlighted.
- Replace the flat panel shadow with a softer two-layer shadow and expand damage bounds to cover it.
- Share substring-highlighting logic between the command palette and help overlay to keep both search interfaces consistent.