### PR TITLE
fix(toolbar): stabilize popovers and fit Advanced settings

### DIFF
--- a/src/backend/wayland/toolbar/view/top.rs
+++ b/src/backend/wayland/toolbar/view/top.rs
@@ -250,11 +250,12 @@ pub fn top_extra_height(snapshot: &ToolbarSnapshot) -> f64 {
     if snapshot.top_minimized || snapshot.top_micro_active() {
         return 0.0;
     }
-    build::shape_popover_height(snapshot)
-        + build::ring_row_height(snapshot)
-        + build::style_pill_height(snapshot)
-        + build::overflow_height(snapshot)
-        + menus::menu_popover_height(snapshot)
+    let plan = plan_top_strip(snapshot);
+    build::shape_popover_height_planned(snapshot, &plan)
+        + build::ring_row_height_planned(snapshot, &plan)
+        + build::style_pill_height_planned(snapshot, &plan)
+        + build::overflow_height_planned(snapshot, &plan)
+        + menus::menu_popover_height_planned(snapshot, &plan)
 }
 
 /// Scroll bounds for the open Canvas/Session/Settings popover as
@@ -262,7 +263,8 @@ pub fn top_extra_height(snapshot: &ToolbarSnapshot) -> f64 {
 /// while no menu popover is open. The wheel path scrolls against these the
 /// way `side_scroll_bounds` served the retired side palette.
 pub fn top_popover_scroll_bounds(snapshot: &ToolbarSnapshot) -> Option<(f64, f64)> {
-    menus::menu_scroll_bounds(snapshot)
+    let plan = plan_top_strip(snapshot);
+    menus::menu_scroll_bounds_planned(snapshot, &plan)
 }
 
 /// Natural width of the strip: the left-to-right content walk plus the

--- a/src/backend/wayland/toolbar/view/top/build.rs
+++ b/src/backend/wayland/toolbar/view/top/build.rs
@@ -18,8 +18,8 @@ use super::super::tree::WidgetTree;
 use super::{
     MINI_LABEL_FONT_SIZE, TOP_CHIP_SIZE, TOP_COMPACT_CHROME, TOP_COMPACT_GAP,
     TOP_COMPACT_MARGIN_RIGHT, TOP_DIVIDER_SPAN, TOP_LABEL_FONT_SIZE, TOP_SWATCH_GAP,
-    TOP_SWATCH_SIZE, TopStripPlan, bar_band_height, base_bar_height, plan_top_strip,
-    planned_button_size, planned_gap, planned_island_metrics, planned_use_icons,
+    TOP_SWATCH_SIZE, TopStripPlan, bar_band_height, base_bar_height, planned_button_size,
+    planned_gap, planned_island_metrics, planned_use_icons,
 };
 
 pub(super) fn build_top_view_planned(
@@ -384,7 +384,7 @@ pub(super) fn build_top_view_planned(
     // --- Canvas/Session/Settings popovers: the re-hosted side panes ----------
     if let Some(anchor) = overflow_anchor {
         let popover_anchor = popover_anchor_below_ring(anchor, snapshot, plan, y, btn_h);
-        super::menus::push_menu_popover(&mut tree, snapshot, popover_anchor, (width, height));
+        super::menus::push_menu_popover(&mut tree, snapshot, plan, popover_anchor, (width, height));
     }
 
     tree
@@ -554,14 +554,13 @@ fn push_option_row(
     }
 }
 
-pub(super) fn shape_popover_height(snapshot: &ToolbarSnapshot) -> f64 {
+pub(super) fn shape_popover_height_planned(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> f64 {
     if !snapshot.shape_picker_open || !model::TopToolbarSpec::shape_picker_visible(snapshot) {
         return 0.0;
     }
-    let plan = plan_top_strip(snapshot);
     let is_simple = snapshot.layout_mode == crate::config::ToolbarLayoutMode::Simple;
-    let (_, btn_h) = planned_button_size(snapshot, &plan);
-    let gap = planned_gap(&plan);
+    let (_, btn_h) = planned_button_size(snapshot, plan);
+    let gap = planned_gap(plan);
     let pad = ToolbarLayoutSpec::TOP_POPOVER_PAD;
     let rows = model::visible_shape_picker_rows(snapshot, is_simple);
     let option_rows = shape_option_rows(snapshot);
@@ -896,11 +895,6 @@ pub(super) fn base_band_height(snapshot: &ToolbarSnapshot) -> f64 {
     }
 }
 
-pub(super) fn style_pill_height(snapshot: &ToolbarSnapshot) -> f64 {
-    let plan = plan_top_strip(snapshot);
-    style_pill_height_planned(snapshot, &plan)
-}
-
 pub(super) fn style_pill_height_planned(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> f64 {
     if !model::StylePillSpec::visible(snapshot, plan) {
         return 0.0;
@@ -910,11 +904,6 @@ pub(super) fn style_pill_height_planned(snapshot: &ToolbarSnapshot, plan: &TopSt
 
 /// The highlight ring row grows the bar only while the highlight tool is
 /// active — the lane is no longer permanently reserved.
-pub(super) fn ring_row_height(snapshot: &ToolbarSnapshot) -> f64 {
-    let plan = plan_top_strip(snapshot);
-    ring_row_height_planned(snapshot, &plan)
-}
-
 pub(super) fn ring_row_height_planned(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> f64 {
     if !model::TopToolbarSpec::contextual_highlight_ring_visible(snapshot, plan) {
         return 0.0;
@@ -951,19 +940,18 @@ fn popover_anchor_below_ring(
     (anchor.0, bottom - anchor.3, anchor.2, anchor.3)
 }
 
-pub(super) fn overflow_height(snapshot: &ToolbarSnapshot) -> f64 {
+pub(super) fn overflow_height_planned(snapshot: &ToolbarSnapshot, plan: &TopStripPlan) -> f64 {
     if !snapshot.top_overflow_open {
         return 0.0;
     }
-    let plan = plan_top_strip(snapshot);
-    let dropped_count = model::TopToolbarSpec::overflow_control_count(snapshot, &plan);
+    let dropped_count = model::TopToolbarSpec::overflow_control_count(snapshot, plan);
     if dropped_count == 0 {
         return 0.0;
     }
-    let (_, btn_h) = planned_button_size(snapshot, &plan);
+    let (_, btn_h) = planned_button_size(snapshot, plan);
     let cols = dropped_count.min(5);
     let rows = dropped_count.div_ceil(cols) as f64;
-    rows * btn_h + (rows - 1.0) * planned_gap(&plan) + 8.0 * 2.0 + 6.0 + 4.0
+    rows * btn_h + (rows - 1.0) * planned_gap(plan) + 8.0 * 2.0 + 6.0 + 4.0
 }
 
 fn tool_button_node(

--- a/src/backend/wayland/toolbar/view/top/menus.rs
+++ b/src/backend/wayland/toolbar/view/top/menus.rs
@@ -98,13 +98,15 @@ fn content_height(nodes: &[WidgetNode]) -> f64 {
 /// popover: the base band plus every row stacked above it (shapes grid,
 /// contextual highlight-ring row, style pill, overflow menu). Deliberately
 /// excludes the popover's own height, so it never depends on the cap it
-/// feeds — no circularity with `menu_popover_height`.
-fn menu_top_offset(snapshot: &ToolbarSnapshot) -> f64 {
+/// feeds — no circularity with `menu_popover_height`. The caller-provided
+/// plan is also intentional: this helper runs while a planned tree is being
+/// built, so re-planning here would recurse through that same tree build.
+fn menu_top_offset(snapshot: &ToolbarSnapshot, plan: &super::TopStripPlan) -> f64 {
     super::build::base_band_height(snapshot)
-        + super::build::shape_popover_height(snapshot)
-        + super::build::ring_row_height(snapshot)
-        + super::build::style_pill_height(snapshot)
-        + super::build::overflow_height(snapshot)
+        + super::build::shape_popover_height_planned(snapshot, plan)
+        + super::build::ring_row_height_planned(snapshot, plan)
+        + super::build::style_pill_height_planned(snapshot, plan)
+        + super::build::overflow_height_planned(snapshot, plan)
 }
 
 /// Visible content-height cap for the open menu popover. Screen-aware when
@@ -113,11 +115,11 @@ fn menu_top_offset(snapshot: &ToolbarSnapshot) -> f64 {
 /// past the screen bottom (short screens scroll instead of clipping the
 /// footer buttons). Falls back to the fixed `MENU_MAX_CONTENT_H` when the
 /// output height is unknown (unit tests), preserving the legacy behavior.
-fn menu_viewport_cap(snapshot: &ToolbarSnapshot) -> f64 {
+fn menu_viewport_cap(snapshot: &ToolbarSnapshot, plan: &super::TopStripPlan) -> f64 {
     match snapshot.top_available_height {
         Some(available_h) => {
             let available = available_h
-                - menu_top_offset(snapshot)
+                - menu_top_offset(snapshot, plan)
                 - MENU_ANCHOR_GAP
                 - MENU_PAD * 2.0
                 - MENU_BOTTOM_MARGIN;
@@ -130,19 +132,25 @@ fn menu_viewport_cap(snapshot: &ToolbarSnapshot) -> f64 {
 /// Scroll bounds for the open Canvas/Session/Settings popover as
 /// (natural_height, viewport_height), both in pre-scale spec units; `None`
 /// while no menu popover is open. Max scroll = (natural - viewport).max(0).
-pub(super) fn menu_scroll_bounds(snapshot: &ToolbarSnapshot) -> Option<(f64, f64)> {
+pub(super) fn menu_scroll_bounds_planned(
+    snapshot: &ToolbarSnapshot,
+    plan: &super::TopStripPlan,
+) -> Option<(f64, f64)> {
     let (_, nodes) = open_menu_content(snapshot)?;
     let natural = content_height(&nodes);
-    Some((natural, natural.min(menu_viewport_cap(snapshot))))
+    Some((natural, natural.min(menu_viewport_cap(snapshot, plan))))
 }
 
 /// Extra surface height the open Canvas/Session/Settings popover needs below the
 /// band (mirrors `overflow_height`).
-pub(super) fn menu_popover_height(snapshot: &ToolbarSnapshot) -> f64 {
+pub(super) fn menu_popover_height_planned(
+    snapshot: &ToolbarSnapshot,
+    plan: &super::TopStripPlan,
+) -> f64 {
     let Some((_, nodes)) = open_menu_content(snapshot) else {
         return 0.0;
     };
-    let viewport = content_height(&nodes).min(menu_viewport_cap(snapshot));
+    let viewport = content_height(&nodes).min(menu_viewport_cap(snapshot, plan));
     MENU_ANCHOR_GAP + viewport + MENU_PAD * 2.0 + MENU_BOTTOM_MARGIN
 }
 
@@ -150,6 +158,7 @@ pub(super) fn menu_popover_height(snapshot: &ToolbarSnapshot) -> f64 {
 pub(super) fn push_menu_popover(
     tree: &mut WidgetTree,
     snapshot: &ToolbarSnapshot,
+    plan: &super::TopStripPlan,
     anchor: (f64, f64, f64, f64),
     bounds: (f64, f64),
 ) {
@@ -157,7 +166,7 @@ pub(super) fn push_menu_popover(
         return;
     };
     let natural = content_height(&nodes);
-    let viewport = natural.min(menu_viewport_cap(snapshot));
+    let viewport = natural.min(menu_viewport_cap(snapshot, plan));
     let max_scroll = (natural - viewport).max(0.0);
     let scroll = if max_scroll > 0.0 {
         snapshot.top_popover_scroll.clamp(0.0, max_scroll)

--- a/src/backend/wayland/toolbar/view/top/tests.rs
+++ b/src/backend/wayland/toolbar/view/top/tests.rs
@@ -1263,6 +1263,7 @@ fn canvas_popover_step_section_carries_toggles_steppers_and_delay_sliders() {
 fn canvas_popover_scrolls_when_all_sections_exceed_the_viewport() {
     let mut snapshot = snapshot();
     snapshot.canvas_popover_open = true;
+    snapshot.top_available_height = Some(360.0);
     snapshot.show_boards_section = true;
     snapshot.show_pages_section = true;
     snapshot.show_zoom_actions = true;
@@ -1588,9 +1589,14 @@ fn tall_popover_content_caps_the_panel_and_scrolls_internally() {
     let mut snapshot = snapshot();
     snapshot.settings_popover_open = true;
     snapshot.customize_items_open = true;
-    // The Top controls group lists enough rows to exceed the cap.
     snapshot.customize_items_group =
         Some(crate::ui::toolbar::ToolbarItemCustomizeGroup::TopControls);
+    // An explicitly short output exercises internal scrolling independently
+    // of how much content fits under the normal-screen fallback cap.
+    snapshot.top_available_height = Some(360.0);
+
+    let (natural, viewport) = top_popover_scroll_bounds(&snapshot).expect("settings scroll bounds");
+    assert!(natural > viewport, "short output must cap tall content");
 
     let (w, h) = top_size(&snapshot);
     let tree = build_top_view(&snapshot, w as f64, h as f64);
@@ -1598,7 +1604,7 @@ fn tall_popover_content_caps_the_panel_and_scrolls_internally() {
         .node_by_id(&"top.menu.settings.panel".into())
         .expect("settings popover panel");
     assert!(
-        panel.rect.3 <= super::menus::MENU_MAX_CONTENT_H + 2.0 * 10.0 + 1e-9,
+        panel.rect.3 <= viewport + 2.0 * 10.0 + 1e-9,
         "panel height capped: {}",
         panel.rect.3
     );
@@ -1667,7 +1673,7 @@ fn tall_content_fills_a_tall_screen_without_scrolling() {
     snapshot.settings_popover_open = true;
     snapshot.customize_items_open = true;
     snapshot.customize_items_group =
-        Some(crate::ui::toolbar::ToolbarItemCustomizeGroup::TopControls);
+        Some(crate::ui::toolbar::ToolbarItemCustomizeGroup::SideSections);
 
     // Without a known output height, the fixed fallback cap still scrolls.
     let (natural, capped) =
@@ -1772,16 +1778,12 @@ fn top_popover_scroll_bounds_serve_the_wheel_path() {
     snapshot.customize_items_open = true;
     snapshot.customize_items_group =
         Some(crate::ui::toolbar::ToolbarItemCustomizeGroup::TopControls);
+    snapshot.top_available_height = Some(360.0);
     let (natural, viewport) =
         top_popover_scroll_bounds(&snapshot).expect("bounds while the settings popover is open");
-    assert_eq!(
-        viewport,
-        super::menus::MENU_MAX_CONTENT_H,
-        "tall content caps at the viewport"
-    );
     assert!(
         natural > viewport,
-        "the Top-controls list overflows the cap"
+        "the Top-controls list overflows a short-screen viewport"
     );
 
     // The wheel bounds and the scrollbar the tree builds agree on the exact

--- a/src/backend/wayland/toolbar/view/top/tests.rs
+++ b/src/backend/wayland/toolbar/view/top/tests.rs
@@ -1049,6 +1049,29 @@ fn overflow_menu_always_carries_the_canvas_session_and_settings_entries() {
     ));
 }
 
+#[test]
+fn runtime_sized_menu_popovers_do_not_reenter_strip_planning() {
+    for name in ["canvas", "session", "settings"] {
+        let mut snapshot = snapshot();
+        snapshot.top_viewport_max = Some(1280.0);
+        snapshot.top_available_height = Some(720.0);
+        match name {
+            "canvas" => snapshot.canvas_popover_open = true,
+            "session" => snapshot.session_popover_open = true,
+            "settings" => snapshot.settings_popover_open = true,
+            _ => unreachable!(),
+        }
+
+        let (width, height) = top_size(&snapshot);
+        let tree = build_top_view(&snapshot, width as f64, height as f64);
+        assert!(
+            tree.node_by_id(&format!("top.menu.{name}.panel").into())
+                .is_some(),
+            "{name} popover should build under runtime width and height constraints"
+        );
+    }
+}
+
 fn canvas_tree_has_event(tree: &WidgetTree, event: &ToolbarEvent) -> bool {
     tree.nodes().iter().any(|node| {
         node.id.as_str().starts_with("top.menu.canvas.")

--- a/src/toolbar_gtk/view/top_bar/tests.rs
+++ b/src/toolbar_gtk/view/top_bar/tests.rs
@@ -1993,12 +1993,30 @@ fn actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window() {
     );
 
     let mut settings_snapshot = regular.clone();
+    settings_snapshot.layout_mode = ToolbarLayoutMode::Advanced;
     settings_snapshot.settings_popover_open = true;
+    settings_snapshot.runtime_ui_persistence = Some(RuntimeUiPersistenceSnapshot {
+        path: "/home/user/.local/share/wayscriber/runtime-ui.toml".into(),
+        mode: RuntimeUiPersistenceMode::Supported,
+        detail: None,
+        recovery_artifacts: Vec::new(),
+    });
     let settings_model =
         model::ToolbarSettingsModel::for_popover(&settings_snapshot).expect("settings model");
     let settings_content = menu_top.build_settings_popover_content(&settings_snapshot, 1.0);
+    let settings_scroller = settings_content
+        .clone()
+        .downcast::<gtk4::ScrolledWindow>()
+        .expect("settings popover scroll viewport");
     let settings_panel = find_widget_named(&settings_content, "top.menu.settings.panel")
         .expect("settings popover panel box");
+    let (_, settings_natural_height, _, _) =
+        settings_panel.measure(gtk4::Orientation::Vertical, -1);
+    assert!(
+        settings_natural_height <= settings_scroller.max_content_height(),
+        "Advanced settings runtime footer should fit without clipping: natural={settings_natural_height}, cap={}",
+        settings_scroller.max_content_height()
+    );
 
     // Toggle parity: one check button per pane toggle, same order/state.
     let mut checks: Vec<gtk4::CheckButton> = Vec::new();

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -606,9 +606,10 @@ pub mod toolbar {
     /// the GTK canvas popover sizes its viewport from it, so they cannot drift.
     pub const CANVAS_MENU_CONTENT_W: f64 = 292.0;
     /// Cap on the Session/Settings popover's visible content height, in
-    /// spec units; taller content scrolls internally. Shared by the builtin
-    /// scroll viewport and the GTK `ScrolledWindow` max content height.
-    pub const MENU_MAX_CONTENT_H: f64 = 420.0;
+    /// spec units. This fits the default Advanced settings controls and
+    /// runtime-state footer; taller content still scrolls internally. Shared
+    /// by the builtin scroll viewport and the GTK `ScrolledWindow` cap.
+    pub const MENU_MAX_CONTENT_H: f64 = 500.0;
     /// Checkbox indicator square size
     pub const CHECKBOX_SIZE: f64 = 14.0;
     /// Boxed shortcut badge font size


### PR DESCRIPTION
## Summary

- Prevent recursive top-strip planning when opening the Canvas, Session, or Settings popovers with runtime output dimensions.
- Reuse the existing strip plan throughout popover sizing and placement.
- Increase the shared menu viewport cap from 420 to 500 so the Advanced settings runtime footer fits cleanly.
- Preserve internal scrolling when content exceeds the available screen height.

## User impact

- Opening the three toolbar menu popovers no longer causes a stack-overflow crash.
- The full “Reset runtime preferences” button is visible in Advanced settings.
- Popovers remain usable on shorter displays.