### PR TITLE
build(nix): add nixpkgs recipe parity checks

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Check version metadata
         run: bash tools/check-version-consistency.sh --release-version "${{ steps.meta.outputs.version }}"
 
+      - name: Check nixpkgs recipe dependencies
+        run: ./tools/check-nixpkgs-recipe.py
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Check package repository layout
         run: bash tools/test-package-repo-layout.sh
 
+      - name: Check nixpkgs recipe dependencies
+        run: ./tools/check-nixpkgs-recipe.py
+
       - name: Check Rust source coverage
         run: ./tools/check-rust-source-coverage.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ packaging/**
 !packaging/icons/
 !packaging/icons/*.png
 !packaging/icons/*.svg
+!packaging/nixpkgs/
+!packaging/nixpkgs/package.nix
+!packaging/nixpkgs/README.md
 !packaging/wayscriber.desktop
 !packaging/wayscriber-configurator.desktop
 

--- a/README.md
+++ b/README.md
@@ -195,11 +195,11 @@ Pick the path that matches your setup:
 | Fast CLI install with auto-updates on Debian/Ubuntu/Mint/Pop!_OS | [Debian and Ubuntu](#debian-and-ubuntu) |
 | Fast CLI install with auto-updates on Fedora/RHEL/Rocky/Alma/Nobara | [Fedora and RHEL](#fedora-and-rhel) |
 | Arch, Manjaro, CachyOS, or another Arch-based distro | [AUR](#arch-linux-aur), preferably `wayscriber-bin` for the prebuilt package |
-| Nix profile, `nix run`, or NixOS flake setup | [NixOS and Nix](#nixos-and-nix) |
+| NixOS, or the Nix package manager on another distro | [NixOS and Nix](#nixos-and-nix) — `nixpkgs` for the standard install, the project flake for the newest release and the Configurator |
 | One-off package (browser or terminal) without adding a repo | [GitHub Releases](#github-releases-one-off) |
 | Hacking on wayscriber or building a local binary | [From source](#from-source) |
 
-Repo, AUR, and Nix installs are the best default for CLI users because they use the normal system update flow. GitHub `.deb`/`.rpm` downloads are one-off installs (no auto-updates); use them only when you do not want to add a repo.
+Distro repositories, the AUR, and declarative NixOS installs are the best default for CLI users because they follow the normal system update flow. Packages installed with `nix profile` are updated separately with `nix profile upgrade`. GitHub `.deb`/`.rpm` downloads are one-off installs (no auto-updates); use them only when you do not want to add a repo.
 
 Install the main `wayscriber` package first. `wayscriber-configurator` is an optional GUI settings app and does not include the `wayscriber` binary.
 
@@ -248,63 +248,134 @@ For a one-off `.rpm` without adding the repo, see [GitHub Releases](#github-rele
 ### Arch Linux (AUR)
 
 Also use this path for Manjaro, CachyOS, and other Arch-based distros.
+The examples use `yay` as the default AUR helper; equivalent `paru` commands are shown for each package.
 
 ```bash
-yay -S wayscriber-bin    # prebuilt binary
-# or:
-yay -S wayscriber        # build from source
+# Prebuilt binary:
+yay -S wayscriber-bin
+paru -S wayscriber-bin
+
+# Or build from source:
+yay -S wayscriber
+paru -S wayscriber
+
 # Optional GUI configurator:
 yay -S wayscriber-configurator
+paru -S wayscriber-configurator
 ```
-
-Use your preferred AUR helper if you do not use `yay`.
 
 ### NixOS and Nix
 
-**Run without installing:**
-```bash
-nix run github:devmobasa/wayscriber -- --active
-```
+Wayscriber is packaged in [`nixpkgs`](https://search.nixos.org/packages?query=wayscriber). On NixOS, install it declaratively. `nix profile` is mainly useful when running Nix on another Linux distro.
 
-**Install to profile:**
-```bash
-nix profile install github:devmobasa/wayscriber
-# Optional GUI configurator:
-nix profile install github:devmobasa/wayscriber#wayscriber-configurator
-```
+**Which version you get:**
 
-**Add to NixOS configuration (flake-based):**
+| Source | Tracks |
+|--------|--------|
+| `nixpkgs-unstable` | Follows Wayscriber releases, usually within a few weeks |
+| Stable channels (`nixos-25.11`, `nixos-26.05`, …) | Pinned when the release branch was cut; version bumps are not backported |
+| This project's flake | The tag or branch recorded in your `flake.lock` |
+
+If you are on a stable NixOS channel and want the newest release, use [the project flake](#latest-release-and-configurator) rather than waiting for `nixpkgs`.
+
+**NixOS, from nixpkgs** — add Wayscriber to `configuration.nix` or another NixOS module:
 ```nix
-# flake.nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    wayscriber.url = "github:devmobasa/wayscriber";
-  };
+{ pkgs, ... }:
 
-  outputs = { nixpkgs, wayscriber, ... }: {
-    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [{
-        environment.systemPackages = [
-          wayscriber.packages.x86_64-linux.default
-        ];
-      }];
-    };
-  };
+{
+  environment.systemPackages = with pkgs; [
+    wayscriber
+
+    # Optional screenshot and clipboard helpers on wlroots compositors:
+    grim
+    slurp
+    wl-clipboard
+  ];
 }
 ```
 
-**Development shell:**
-```bash
-nix develop github:devmobasa/wayscriber
+Then rebuild with `sudo nixos-rebuild switch`, or `sudo nixos-rebuild switch --flake .#myhost` for a flake-based configuration.
+
+**Home Manager:**
+```nix
+{ pkgs, ... }:
+
+{
+  home.packages = [ pkgs.wayscriber ];
+}
 ```
 
-Unpinned GitHub flake URLs follow the default branch. Pin a release tag when you want reproducible release installs:
+Then run `home-manager switch`.
+
+The `nixpkgs` build installs the `wayscriber` binary. The desktop entry, icons, and the `wayscriber.service` systemd user unit come with the flake packages below, which also provide the optional Configurator.
+
+**Try without installing:**
 ```bash
-nix run 'github:devmobasa/wayscriber?ref=v0.9.19' -- --active
-nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19'
-nix profile install 'github:devmobasa/wayscriber?ref=v0.9.19#wayscriber-configurator'
+# The nixpkgs version:
+nix run nixpkgs#wayscriber -- --active
+# Or the current upstream development branch:
+nix run github:devmobasa/wayscriber -- --active
+```
+
+`nix run` does not add `wayscriber` to your `PATH`.
+
+<a id="latest-release-and-configurator"></a>
+**Latest release and Configurator on NixOS**
+
+The project flake provides release-pinned packages plus the optional Configurator. Replace `RELEASE_TAG` with a published tag, such as the one shown on the [latest release](https://github.com/devmobasa/wayscriber/releases/latest), when adding the input to your existing `flake.nix`:
+```nix
+inputs.wayscriber.url = "github:devmobasa/wayscriber?ref=RELEASE_TAG";
+```
+
+Make it available in `outputs`:
+```nix
+outputs = { nixpkgs, wayscriber, ... }: {
+  # Your existing outputs...
+};
+```
+
+Then add this module to the `modules` list of your `nixosSystem`:
+```nix
+({ pkgs, ... }:
+
+  let
+    wayscriberPackages =
+      wayscriber.packages.${pkgs.stdenv.hostPlatform.system};
+  in
+  {
+    environment.systemPackages = [
+      wayscriberPackages.wayscriber
+      wayscriberPackages.wayscriber-configurator
+    ];
+
+    # Required before `systemctl --user enable --now wayscriber.service` works.
+    systemd.packages = [ wayscriberPackages.wayscriber ];
+  }
+)
+```
+
+Your `flake.lock` pins the exact Wayscriber revision. To upgrade to a newer release, change `RELEASE_TAG` in `flake.nix` to the new published tag, then update only this input:
+```bash
+nix flake update wayscriber
+sudo nixos-rebuild switch --flake .#myhost
+```
+
+**Nix on another Linux distro** — when running the Nix package manager on Ubuntu, Fedora, or elsewhere, a user profile install is reasonable:
+```bash
+nix profile install nixpkgs#wayscriber
+```
+
+For the current upstream development branch and the optional Configurator:
+```bash
+nix profile install github:devmobasa/wayscriber#wayscriber
+nix profile install github:devmobasa/wayscriber#wayscriber-configurator
+```
+
+Profile installs do not update with the rest of the system; upgrade them with `nix profile upgrade wayscriber` (and `nix profile upgrade wayscriber-configurator`), or remove them with `nix profile remove wayscriber`.
+
+**Development shell** (for contributing or building locally, not for installing):
+```bash
+nix develop github:devmobasa/wayscriber
 ```
 
 ### GitHub Releases (one-off)
@@ -470,7 +541,12 @@ Prefer a GUI? Open `wayscriber-configurator`, go to the **Daemon** tab, and clic
 
 Bind `wayscriber --daemon-toggle` to a global shortcut in your compositor or desktop environment. The configurator's **Daemon** tab can also do this: set a shortcut and click **Apply Shortcut** (GNOME: writes a GNOME custom shortcut; KDE/Plasma: writes the systemd drop-in env `WAYSCRIBER_PORTAL_SHORTCUT` for portal global shortcuts).
 
-Hyprland:
+Hyprland Lua config (`~/.config/hypr/bindings.lua`):
+```lua
+o.bind("SUPER + D", "Toggle Wayscriber", "wayscriber --daemon-toggle")
+```
+
+Traditional Hyprland config (`~/.config/hypr/hyprland.conf`):
 ```conf
 bind = SUPER, D, exec, wayscriber --daemon-toggle
 ```
@@ -516,6 +592,17 @@ on shorter or scaled displays:
 Supported desktops use a theme-adaptive symbolic tray icon. Hosts that do not reliably resolve named icons (including Omarchy/Quickshell, Noctalia/Quickshell, and COSMIC) automatically receive scale-aware colored pixmaps, including a 48px HiDPI rendition. Set `[tray].icon_style` to `"auto"` (default), `"symbolic"`, or `"colored"` to choose the main tray icon style; restart the daemon after changing it. Use `--no-tray` or `WAYSCRIBER_NO_TRAY=1` if you don't have a system tray. If the tray icon is still blank or the menu shows square placeholders, start the daemon with `WAYSCRIBER_TRAY_FORCE_PIXMAP=1`; this environment override takes precedence over the TOML setting.
 
 **Alternative — compositor autostart instead of systemd:**
+
+For Hyprland Lua, add these to the matching files:
+```lua
+-- ~/.config/hypr/autostart.lua
+o.launch_on_start("wayscriber --daemon")
+
+-- ~/.config/hypr/bindings.lua
+o.bind("SUPER + D", "Toggle Wayscriber", "wayscriber --daemon-toggle")
+```
+
+Traditional Hyprland config:
 ```conf
 exec-once = wayscriber --daemon
 bind = SUPER, D, exec, wayscriber --daemon-toggle
@@ -541,7 +628,12 @@ wayscriber --freeze   # start with screen frozen
 
 `whiteboard` and `blackboard` are built in; `blueprint` is an example of a custom board defined in `config.toml` (`[[boards.items]]` — see [Configuration](#configuration)).
 
-Bind to a key (Hyprland example):
+Bind to a key (Hyprland Lua config):
+```lua
+o.bind("SUPER + D", "Open Wayscriber", "wayscriber --active")
+```
+
+Traditional Hyprland config:
 ```conf
 bind = SUPER, D, exec, wayscriber --active
 ```
@@ -923,7 +1015,13 @@ Enabled user services start when you log in, not at boot — if the daemon is mi
 loginctl enable-linger $USER
 ```
 
-Or use compositor autostart instead:
+Or use compositor autostart instead. For Hyprland Lua, add this to
+`~/.config/hypr/autostart.lua`:
+```lua
+o.launch_on_start("wayscriber --daemon")
+```
+
+Traditional Hyprland config:
 ```conf
 exec-once = wayscriber --daemon
 ```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,7 +64,13 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 systemctl --user enable --now wayscriber.service
 ```
 
-Add the toggle keybinding to `~/.config/hypr/hyprland.conf`:
+For Hyprland Lua, add the toggle to `~/.config/hypr/bindings.lua`:
+
+```lua
+o.bind("SUPER + D", "Toggle Wayscriber", "wayscriber --daemon-toggle")
+```
+
+For a traditional Hyprland config, add it to `~/.config/hypr/hyprland.conf`:
 
 ```conf
 # wayscriber - Screen annotation daemon (Super+D to toggle)
@@ -76,7 +82,17 @@ If your shortcut environment does not resolve `wayscriber` from `PATH`, use the 
 
 ### Method 2: Daemon autostart via compositor (no systemd)
 
-Add to `~/.config/hypr/hyprland.conf`:
+For Hyprland Lua, add these to the matching files:
+
+```lua
+-- ~/.config/hypr/autostart.lua
+o.launch_on_start("wayscriber --daemon")
+
+-- ~/.config/hypr/bindings.lua
+o.bind("SUPER + D", "Toggle Wayscriber", "wayscriber --daemon-toggle")
+```
+
+For a traditional Hyprland config, add this to `~/.config/hypr/hyprland.conf`:
 
 ```conf
 # wayscriber - Screen annotation daemon (Super+D to toggle)
@@ -96,7 +112,18 @@ Now press <kbd>Super+D</kbd> to toggle the overlay on/off!
 Light passthrough needs compositor/global shortcuts because Wayscriber deliberately passes keyboard and pointer input to the app below while passthrough is active.
 The default <kbd>F6</kbd> binding is a Wayscriber in-overlay shortcut, not an OS-level shortcut; do not rely on it to exit after passthrough starts. Use the bindings below for reliable control.
 
-The configurator can install a native Hyprland include file for this. Manual equivalent for Arch + Hyprland:
+For Hyprland Lua, add the manual bindings to `~/.config/hypr/bindings.lua`:
+
+```lua
+local wayscriber = "wayscriber"
+
+o.bind("F6", "Toggle Wayscriber light passthrough", wayscriber .. " --light-toggle")
+o.bind("XF86Tools", "Toggle Wayscriber light passthrough", wayscriber .. " --light-toggle")
+o.bind("SUPER + ALT + D", "Toggle Wayscriber light drawing", wayscriber .. " --light-draw-toggle")
+```
+
+The configurator can install a native include file for traditional Hyprland
+configs. Its manual equivalent is:
 
 ```conf
 # wayscriber - light passthrough controls
@@ -115,7 +142,7 @@ bind = , mouse:275, exec, $wayscriber --light-toggle
 ```
 
 Use `--light-draw-on` on key/button press and `--light-draw-off` on release for draw-while-held.
-The `unbind` lines prevent duplicate manual bindings for these same keys from firing twice.
+In the traditional config example, the `unbind` lines prevent duplicate manual bindings for these same keys from firing twice.
 If your shortcut environment does not resolve `wayscriber`, replace it with the absolute path from `command -v wayscriber`.
 
 ### Light passthrough on KDE Plasma / Fedora KDE
@@ -227,7 +254,7 @@ Press <kbd>Escape</kbd> (should hide overlay)
 - Restart terminal after PATH change
 
 **Want different key?**
-- Edit hyprland.conf
+- Edit `bindings.lua` or `hyprland.conf`, depending on your Hyprland config format
 - Examples:
   - `SUPER, D` → <kbd>Super+D</kbd>
   - `ALT, D` → <kbd>Alt+D</kbd>
@@ -237,7 +264,7 @@ Press <kbd>Escape</kbd> (should hide overlay)
 
 ```bash
 rm ~/.local/bin/wayscriber
-# Remove keybind from hyprland.conf
+# Remove the keybind from bindings.lua or hyprland.conf
 ```
 
 ## Recommended Setup
@@ -245,11 +272,7 @@ rm ~/.local/bin/wayscriber
 **Best setup (daemon mode):**
 
 1. Install: `./tools/install.sh`
-2. Add to hyprland.conf:
-   ```conf
-   exec-once = wayscriber --daemon
-   bind = SUPER, D, exec, wayscriber --daemon-toggle
-   ```
+2. Add the daemon autostart and toggle binding using [Method 2](#method-2-daemon-autostart-via-compositor-no-systemd) above.
 3. Reload: `hyprctl reload`
 4. Use: Press <kbd>Super+D</kbd> to toggle overlay
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       let
         pkgs = import nixpkgs { inherit system; };
         version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+        servicePath = pkgs.lib.makeBinPath [ pkgs.grim pkgs.slurp pkgs.wl-clipboard ];
       in {
         packages = {
           wayscriber = pkgs.rustPlatform.buildRustPackage {
@@ -20,7 +21,10 @@
 
             cargoLock.lockFile = ./Cargo.lock;
 
-            nativeBuildInputs = with pkgs; [ pkg-config ];
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              wrapGAppsHook4
+            ];
 
             buildInputs = with pkgs; [
               cairo
@@ -34,6 +38,11 @@
             postInstall = ''
               install -Dm644 packaging/wayscriber.desktop $out/share/applications/wayscriber.desktop
               install -Dm644 packaging/wayscriber.service $out/lib/systemd/user/wayscriber.service
+              substituteInPlace $out/lib/systemd/user/wayscriber.service \
+                --replace-fail "/bin/sh" "${pkgs.runtimeShell}" \
+                --replace-fail "/usr/bin/wayscriber" "$out/bin/wayscriber" \
+                --replace-fail "/usr/local/bin:/usr/bin:/bin" \
+                  "${servicePath}:/run/current-system/sw/bin:/etc/profiles/per-user/%u/bin:%h/.nix-profile/bin"
               for size in 16 19 22 24 38 64 128; do
                 for category in apps status; do
                   install -Dm644 packaging/icons/wayscriber-$size.png \

--- a/packaging/AGENTS.md
+++ b/packaging/AGENTS.md
@@ -6,10 +6,12 @@
 ## Architecture
 - Package manifests describe the wayscriber binary and configurator package outputs.
 - `PKGBUILD` and `.SRCINFO` represent Arch/AUR packaging metadata.
+- `nixpkgs/package.nix` mirrors the recipe owned by nixpkgs; it is a submission draft, not a build input.
 - Desktop files, icons, and `wayscriber.service` define installed desktop and daemon integration.
 
 ## Invariants
 - Keep `package.wayscriber.yaml`, `package.configurator.yaml`, `PKGBUILD`, `.SRCINFO`, desktop files, service unit, icons, and release scripts aligned.
+- A new system library requirement must reach `nixpkgs/package.nix` and `flake.nix` together; the nixpkgs bot bumps versions but never build inputs.
 - Packaging hotfix versions may differ from Cargo versions only according to the existing versioning policy.
 - Do not change daemon service semantics without checking daemon runtime and configurator daemon setup.
 
@@ -18,4 +20,5 @@
 
 ## Validation
 - Run `tools/check-version-consistency.sh` and `tools/test-package-repo-layout.sh` for package/version changes.
+- Run `tools/check-nixpkgs-recipe.py` when dependencies, default features, or Nix build inputs change.
 - Run `git diff --check` for metadata-only edits.

--- a/packaging/nixpkgs/README.md
+++ b/packaging/nixpkgs/README.md
@@ -1,0 +1,71 @@
+# nixpkgs recipe
+
+`package.nix` is our copy of the Wayscriber recipe that lives in `nixpkgs` at
+`pkgs/by-name/wa/wayscriber/package.nix`.
+
+We do not own that file — `nixpkgs` does. This copy exists so that:
+
+- packaging changes here (new system libraries, new installed files) are visible
+  in the same commit as the change that requires them, and
+- `tools/check-nixpkgs-recipe.py` can fail CI when a default Cargo feature needs
+  a system library the `nixpkgs` build does not declare.
+
+## How versions reach nixpkgs
+
+Version bumps are opened automatically by the `nixpkgs-update` bot (R. Ryantm)
+because the recipe carries `passthru.updateScript = nix-update-script { }`.
+Every bump since `init at 0.7.2` has come from that bot, usually within a few
+weeks of a release. We do not need to send routine version bumps ourselves.
+
+`nixpkgs-unstable` follows releases. Stable NixOS branches (`nixos-26.05`, …)
+keep whatever version existed when the branch was cut; version bumps are not
+backported. Point stable-channel users at the project flake instead.
+
+What the bot cannot do is change the build itself. When a release adds a system
+dependency or a new installed file, someone has to send a real PR — otherwise
+the next bot PR fails to build and stalls.
+
+## Submitting a change
+
+1. Fork and clone `NixOS/nixpkgs`, then copy this file over
+   `pkgs/by-name/wa/wayscriber/package.nix`.
+2. Fill in the hashes (`hash` and `cargoHash` are `lib.fakeHash` here):
+
+   ```bash
+   nix-shell -p nix-update --run "nix-update --version <version> wayscriber"
+   ```
+
+3. Build and smoke-test it:
+
+   ```bash
+   nix-build -A wayscriber
+   ./result/bin/wayscriber --version
+   ```
+
+4. Commit with the `nixpkgs` convention, one logical change per commit:
+
+   ```
+   wayscriber: add GTK4 toolbar dependencies
+   wayscriber: 0.9.21 -> 0.9.22
+   ```
+
+5. Open the PR against `master`. Do not target a stable release branch.
+
+## Getting review notifications
+
+`meta.maintainers` currently lists only `leiserfg`. Adding ourselves means the
+bot's bump PRs request our review, which is the most effective way to keep the
+package current. It is a two-part change in the same PR:
+
+1. Add an entry to `maintainers/maintainer-list.nix` (name, GitHub handle,
+   GitHub ID).
+2. Add that handle to `meta.maintainers` here.
+
+Adding the handle to `meta.maintainers` without the maintainer-list entry breaks
+evaluation, so both parts must land together.
+
+## Differences from the flake
+
+`flake.nix` in the repository root builds from the working tree and also builds
+`wayscriber-configurator`. This recipe builds a tagged release and ships the
+main binary only — `nixpkgs` has no Configurator package today.

--- a/packaging/nixpkgs/package.nix
+++ b/packaging/nixpkgs/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  runtimeShell,
+  wrapGAppsHook4,
+  cairo,
+  grim,
+  gtk4,
+  gtk4-layer-shell,
+  libxkbcommon,
+  pango,
+  slurp,
+  wayland,
+  wl-clipboard,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wayscriber";
+  version = "0.9.22";
+
+  src = fetchFromGitHub {
+    owner = "devmobasa";
+    repo = "wayscriber";
+    tag = "v${finalAttrs.version}";
+    # Refresh with `nix-update wayscriber` inside a nixpkgs checkout before
+    # submitting; see ./README.md.
+    hash = lib.fakeHash;
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  # Keep in sync with the default feature set in Cargo.toml; the GTK inputs are
+  # required by the `toolbar-gtk` default feature.
+  # Checked by tools/check-nixpkgs-recipe.py.
+  buildInputs = [
+    cairo
+    gtk4
+    gtk4-layer-shell
+    libxkbcommon
+    pango
+    wayland
+  ];
+
+  cargoHash = lib.fakeHash;
+
+  postInstall = ''
+    install -Dm644 packaging/wayscriber.desktop \
+      $out/share/applications/wayscriber.desktop
+    install -Dm644 packaging/wayscriber.service \
+      $out/lib/systemd/user/wayscriber.service
+    substituteInPlace $out/lib/systemd/user/wayscriber.service \
+      --replace-fail "/bin/sh" "${runtimeShell}" \
+      --replace-fail "/usr/bin/wayscriber" "$out/bin/wayscriber" \
+      --replace-fail "/usr/local/bin:/usr/bin:/bin" \
+        "${lib.makeBinPath [ grim slurp wl-clipboard ]}:/run/current-system/sw/bin:/etc/profiles/per-user/%u/bin:%h/.nix-profile/bin"
+
+    for size in 16 19 22 24 38 64 128; do
+      for category in apps status; do
+        install -Dm644 packaging/icons/wayscriber-$size.png \
+          $out/share/icons/hicolor/''${size}x''${size}/$category/wayscriber.png
+      done
+    done
+
+    install -Dm644 packaging/icons/wayscriber.svg \
+      $out/share/icons/hicolor/scalable/apps/wayscriber.svg
+    install -Dm644 packaging/icons/wayscriber-symbolic.svg \
+      $out/share/icons/hicolor/symbolic/apps/wayscriber-symbolic.svg
+
+    install -Dm644 config.example.toml \
+      $out/share/doc/wayscriber/config.example.toml
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ZoomIt-like screen annotation tool for Wayland compositors, written in Rust";
+    homepage = "https://wayscriber.com";
+    changelog = "https://github.com/devmobasa/wayscriber/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      leiserfg
+    ];
+    mainProgram = "wayscriber";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/tools/README.md
+++ b/tools/README.md
@@ -91,6 +91,22 @@ Packaging-only hotfix policy:
   - Usage: `./tools/build-package-repos.sh`
   - Env: `ARTIFACT_ROOT`, `OUTPUT_ROOT`, `GPG_PRIVATE_KEY_B64`, etc.
 
+## nixpkgs
+
+Wayscriber is packaged in `nixpkgs`, where version bumps are opened
+automatically by the nixpkgs-update bot. The bot only rewrites the version and
+hashes, so build-level changes still need a pull request from us. See
+`packaging/nixpkgs/README.md`.
+
+- **check-nixpkgs-recipe.py** - Check the nixpkgs build declares what the default features need
+  - Uses locked Cargo metadata, so it works with Python 3.10 without an extra TOML parser
+  - Maps every direct normal Cargo dependency, including target-specific dependencies, to the nixpkgs system packages it links
+  - Keeps required native inputs, including the GTK application wrapper, aligned between the recipe and flake
+  - Fails when a Linux default-feature dependency is missing from `packaging/nixpkgs/package.nix` or `flake.nix`
+  - Fails on any new direct normal dependency until its system requirements are declared
+  - Runs as a hard gate in GitHub CI and before release packaging
+  - Usage: `./tools/check-nixpkgs-recipe.py`
+
 ## AUR (Arch User Repository)
 
 - **update-aur.sh** - Interactive AUR update

--- a/tools/check-nixpkgs-recipe.py
+++ b/tools/check-nixpkgs-recipe.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Fail when a default Cargo feature needs a system library the Nix builds omit.
+
+The nixpkgs recipe (`packaging/nixpkgs/package.nix`, mirrored from
+`pkgs/by-name/wa/wayscriber/package.nix`) is bumped automatically by the
+nixpkgs-update bot, which only rewrites the version and hashes. When a release
+enables a dependency that links a C library, the bot's next pull request fails
+to build unless a human has already added that library. This check catches the
+mismatch here instead.
+
+Every direct normal dependency in Cargo.toml must appear in SYSTEM_LIBRARIES,
+mapped to the nixpkgs attributes it needs (an empty tuple for pure Rust crates).
+A new normal dependency therefore fails this check until its system requirements
+are stated.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CARGO_TOML = Path("Cargo.toml")
+RECIPE = Path("packaging/nixpkgs/package.nix")
+FLAKE = Path("flake.nix")
+FLAKE_PACKAGE_MARKER = "wayscriber = pkgs.rustPlatform.buildRustPackage"
+LINUX_TARGET = "x86_64-unknown-linux-gnu"
+
+# Native tools/hooks required by the default GTK-enabled package.
+NATIVE_BUILD_INPUTS = {"pkg-config", "wrapGAppsHook4"}
+
+# Direct dependency -> nixpkgs attributes its build or link step requires.
+# Attributes that nixpkgs propagates through another entry are left out: pango
+# propagates cairo, glib and harfbuzz, and gtk4 propagates its own stack.
+SYSTEM_LIBRARIES: dict[str, tuple[str, ...]] = {
+    "anyhow": (),
+    "cairo-rs": ("cairo",),
+    "flate2": (),
+    "glib": (),
+    "gtk4": ("gtk4",),
+    "gtk4-layer-shell": ("gtk4-layer-shell",),
+    "ksni": (),
+    "libc": (),
+    "log": (),
+    "pango": ("pango",),
+    "pangocairo": ("pango", "cairo"),
+    "png": (),
+    "schemars": (),
+    "serde": (),
+    "serde_ignored": (),
+    "serde_json": (),
+    "smithay-client-toolkit": ("libxkbcommon",),
+    "tokio": (),
+    "toml": (),
+    "toml_edit": (),
+    "unicode-segmentation": (),
+    "wayland-client": ("wayland",),
+    "wayland-protocols": (),
+    "wayland-protocols-wlr": (),
+    "zbus": (),
+    "zune-jpeg": (),
+}
+
+
+class RecipeError(RuntimeError):
+    """The recipe or flake could not be inspected."""
+
+
+def read_text(path: Path) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def load_metadata() -> tuple[dict, dict, dict[str, str]]:
+    """Load Cargo's parsed manifest and Linux default-feature dependency graph."""
+    try:
+        result = subprocess.run(
+            [
+                "cargo",
+                "metadata",
+                "--locked",
+                "--format-version",
+                "1",
+                "--filter-platform",
+                LINUX_TARGET,
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise RecipeError(f"could not run cargo metadata: {error}") from error
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RecipeError(f"cargo metadata failed: {detail}")
+
+    try:
+        metadata = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RecipeError(f"could not parse cargo metadata: {error}") from error
+
+    manifest_path = str((REPO_ROOT / CARGO_TOML).resolve())
+    manifest = next(
+        (
+            package
+            for package in metadata.get("packages", [])
+            if package.get("manifest_path") == manifest_path
+        ),
+        None,
+    )
+    if manifest is None:
+        raise RecipeError(f"cargo metadata did not contain {CARGO_TOML}")
+
+    resolve = metadata.get("resolve") or {}
+    node = next(
+        (entry for entry in resolve.get("nodes", []) if entry.get("id") == manifest.get("id")),
+        None,
+    )
+    if node is None:
+        raise RecipeError(f"cargo metadata did not resolve {CARGO_TOML}")
+
+    package_names = {
+        package["id"]: package["name"]
+        for package in metadata.get("packages", [])
+        if "id" in package and "name" in package
+    }
+    return manifest, node, package_names
+
+
+def direct_normal_dependencies(manifest: dict) -> set[str]:
+    """All declared direct normal dependencies, including target-specific ones."""
+    return {
+        dependency["name"]
+        for dependency in manifest.get("dependencies", [])
+        if dependency.get("kind") is None and "name" in dependency
+    }
+
+
+def crates_enabled_by_default(node: dict, package_names: dict[str, str]) -> set[str]:
+    """Direct normal dependencies resolved for a default-feature Linux build."""
+    crates: set[str] = set()
+    for dependency in node.get("deps", []):
+        if not any(kind.get("kind") is None for kind in dependency.get("dep_kinds", [])):
+            continue
+        package_id = dependency.get("pkg")
+        if package_id not in package_names:
+            raise RecipeError(f"cargo metadata did not describe dependency {package_id!r}")
+        crates.add(package_names[package_id])
+    return crates
+
+
+def nix_list_entries(text: str, attribute: str, *, start: int = 0) -> list[str]:
+    """Return the identifiers inside the first `attribute = [ ... ];` after start."""
+    # The lookbehind keeps `buildInputs` from matching inside `nativeBuildInputs`
+    # should a future edit change its capitalisation.
+    pattern = re.compile(
+        rf"(?<![A-Za-z]){re.escape(attribute)}\s*=\s*(?:with\s+[\w.]+;\s*)?\[(.*?)\]",
+        re.DOTALL,
+    )
+    match = pattern.search(text, start)
+    if match is None:
+        return []
+    body = re.sub(r"#[^\n]*", "", match.group(1))
+    return re.findall(r"[A-Za-z_][A-Za-z0-9_'-]*(?:\.[A-Za-z0-9_'-]+)*", body)
+
+
+def recipe_inputs() -> tuple[set[str], set[str], set[str]]:
+    text = read_text(RECIPE)
+    native_build_inputs = set(nix_list_entries(text, "nativeBuildInputs"))
+    build_inputs = set(nix_list_entries(text, "buildInputs"))
+
+    arguments_match = re.match(r"\s*\{(.*?)\}\s*:", text, re.DOTALL)
+    if arguments_match is None:
+        raise RecipeError(f"{RECIPE}: could not read the function argument set")
+    arguments = set(re.findall(r"[A-Za-z_][A-Za-z0-9_'-]*", arguments_match.group(1)))
+
+    if not native_build_inputs:
+        raise RecipeError(f"{RECIPE}: no nativeBuildInputs list found")
+    if not build_inputs:
+        raise RecipeError(f"{RECIPE}: no buildInputs list found")
+    return native_build_inputs, build_inputs, arguments
+
+
+def flake_inputs() -> tuple[set[str], set[str]]:
+    text = read_text(FLAKE)
+    marker = text.find(FLAKE_PACKAGE_MARKER)
+    if marker == -1:
+        raise RecipeError(
+            f"{FLAKE}: could not find `{FLAKE_PACKAGE_MARKER}`; "
+            "update FLAKE_PACKAGE_MARKER after restructuring the flake"
+        )
+
+    native_build_inputs = set(nix_list_entries(text, "nativeBuildInputs", start=marker))
+    build_inputs = set(nix_list_entries(text, "buildInputs", start=marker))
+    if not native_build_inputs:
+        raise RecipeError(
+            f"{FLAKE}: no nativeBuildInputs list found for the wayscriber package"
+        )
+    if not build_inputs:
+        raise RecipeError(f"{FLAKE}: no buildInputs list found for the wayscriber package")
+    return native_build_inputs, build_inputs
+
+
+def main() -> int:
+    try:
+        manifest, node, package_names = load_metadata()
+        crates = crates_enabled_by_default(node, package_names)
+        recipe_native, declared_recipe, recipe_arguments = recipe_inputs()
+        flake_native, declared_flake = flake_inputs()
+    except (OSError, RecipeError) as error:
+        print(f"nixpkgs recipe check failed: {error}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+
+    unmapped = sorted(direct_normal_dependencies(manifest) - set(SYSTEM_LIBRARIES))
+    for crate in unmapped:
+        errors.append(
+            f"dependency `{crate}` has no entry in SYSTEM_LIBRARIES; add the nixpkgs "
+            "attributes it needs (or an empty tuple for a pure Rust crate)"
+        )
+
+    required: dict[str, set[str]] = {}
+    for crate in sorted(crates):
+        for attribute in SYSTEM_LIBRARIES.get(crate, ()):
+            required.setdefault(attribute, set()).add(crate)
+
+    for attribute in sorted(NATIVE_BUILD_INPUTS):
+        if attribute not in recipe_native:
+            errors.append(f"{RECIPE}: nativeBuildInputs is missing `{attribute}`")
+        if attribute not in recipe_arguments:
+            errors.append(f"{RECIPE}: function arguments are missing `{attribute}`")
+        if attribute not in flake_native:
+            errors.append(f"{FLAKE}: nativeBuildInputs is missing `{attribute}`")
+
+    for attribute, sources in sorted(required.items()):
+        reason = ", ".join(sorted(sources))
+        if attribute not in declared_recipe:
+            errors.append(f"{RECIPE}: buildInputs is missing `{attribute}` (required by {reason})")
+        if attribute not in recipe_arguments:
+            errors.append(f"{RECIPE}: function arguments are missing `{attribute}`")
+        if attribute not in declared_flake:
+            errors.append(f"{FLAKE}: buildInputs is missing `{attribute}` (required by {reason})")
+
+    if errors:
+        print("nixpkgs recipe check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        print(
+            "\nThe nixpkgs-update bot only rewrites version and hashes. A missing build "
+            "input here means the next automated bump fails to build in nixpkgs; see "
+            "packaging/nixpkgs/README.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"nixpkgs recipe OK: {len(crates)} default-feature dependencies require "
+        f"{len(required)} system package(s) ({', '.join(sorted(required))}), "
+        f"plus {len(NATIVE_BUILD_INPUTS)} native input(s), "
+        "all declared in packaging/nixpkgs/package.nix and flake.nix."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-version-consistency.sh
+++ b/tools/check-version-consistency.sh
@@ -13,6 +13,10 @@ Checks that release/version metadata agrees across:
   * packaging/.SRCINFO
   * flake.nix
 
+Also rejects hardcoded release tags in README.md install examples, which go
+stale on the next release. Use a placeholder such as RELEASE_TAG, or link to
+the latest release, instead.
+
 Repo packaging metadata is a release template and must use sha256sums=('SKIP').
 Release/AUR automation writes the real source archive checksum after the tag
 exists.
@@ -204,6 +208,19 @@ require_template_sha256sums(
 flake_text = read_text("flake.nix")
 if "builtins.fromTOML (builtins.readFile ./Cargo.toml)" not in flake_text:
     errors.append("flake.nix package version should be derived from Cargo.toml")
+
+# Install examples that pin a concrete tag are stale one release later.
+readme_pin_patterns = (
+    (r"wayscriber\?ref=v?\d+\.\d+\.\d+(?:\.\d+)?", "pinned flake ref"),
+    (r"/releases/(?:tag|download)/v?\d+\.\d+\.\d+(?:\.\d+)?", "pinned release URL"),
+)
+readme_text = read_text("README.md")
+for pattern, label in readme_pin_patterns:
+    for match in sorted(set(re.findall(pattern, readme_text))):
+        errors.append(
+            f"README.md: {label} '{match}' goes stale on the next release; "
+            "use a RELEASE_TAG placeholder or link to /releases/latest"
+        )
 
 if errors:
     print("Version consistency check failed:", file=sys.stderr)

--- a/tools/lint-and-test.sh
+++ b/tools/lint-and-test.sh
@@ -7,6 +7,7 @@ cd "$REPO_ROOT"
 
 bash tools/check-version-consistency.sh
 bash tools/test-package-repo-layout.sh
+./tools/check-nixpkgs-recipe.py
 ./tools/check-rust-source-coverage.py
 ./tools/check-process-sites.py
 cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- track a mirror of the upstream `nixpkgs` Wayscriber recipe and document the submission workflow
- add a Cargo-metadata check that keeps default-feature system dependencies aligned across `package.nix` and `flake.nix`
- run the recipe check in local CI, GitHub CI, and release packaging
- fix the flake-installed systemd service paths and helper-tool `PATH`
- expand NixOS, Nix profile, AUR, and Hyprland Lua installation documentation
- reject version-pinned README examples that would become stale after a release

## Why

The `nixpkgs-update` bot updates versions and hashes, but it cannot add new build inputs or installed files. Tracking the recipe and validating its system dependencies here lets CI catch packaging drift before the next automated nixpkgs bump fails.