### PR TITLE
perf(toolbar-gtk): remove multi-second settings toggle stalls

### DIFF
--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -322,6 +322,7 @@ pub(super) fn run_event_loop(
             // compositor close) would otherwise be dropped. Durable edits are
             // flushed here, alongside the final session save.
             state.persist_pending_config_edits();
+            state.shutdown_config_writer();
             if let Err(err) = session_save::persist_session(state) {
                 warn!("Failed to save session state: {}", err);
                 session_save::notify_session_failure(state, &err);

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -151,6 +151,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
     let palette_recents_store = crate::palette_recents::PaletteRecentsStore::load();
     input_state.set_command_palette_recents(palette_recents_store.recents().to_vec());
     let palette_recents = crate::palette_recents::PaletteRecentsWriter::new(palette_recents_store);
+    let config_writer = crate::backend::wayland::config_writer::ConfigWriter::new();
 
     apply_initial_mode(backend, &config, &mut input_state);
 
@@ -175,6 +176,7 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
     let mut state = WaylandState::new(WaylandStateInit {
         globals: setup.state_globals,
         config,
+        config_writer,
         input_state,
         onboarding,
         palette_recents,

--- a/src/backend/wayland/config_writer.rs
+++ b/src/backend/wayland/config_writer.rs
@@ -1,0 +1,431 @@
+//! Background persistence for small runtime-authored config preferences.
+//!
+//! The Wayland dispatch thread only queues typed mutations. A single worker
+//! batches nearby edits, reloads the latest config document, and performs the
+//! durable atomic write so an fsync cannot delay input feedback.
+
+use crate::config::{
+    Config, ConfigDocument, QuickColorWrite, StatusBarItem, ToolPresetConfig, ToolbarItemId,
+    ToolbarItemVisibilitySetting, ToolbarLayoutMode, ToolbarSectionFlag, ToolbarSectionVisibility,
+    TopDisplayMode,
+};
+use crate::draw::Color;
+use crate::input::boards::PendingBoardConfigUpdate;
+use anyhow::Result;
+use log::{debug, warn};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const WRITE_DEBOUNCE: Duration = Duration::from_millis(75);
+const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(250);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone)]
+pub(in crate::backend::wayland) enum ConfigMutation {
+    ToolbarLayout {
+        mode: ToolbarLayoutMode,
+        sections: ToolbarSectionVisibility,
+    },
+    ToolbarSectionVisibility {
+        id: ToolbarItemId,
+        setting: ToolbarItemVisibilitySetting,
+        flag: ToolbarSectionFlag,
+        visible: bool,
+    },
+    ToolbarTopDisplayMode(TopDisplayMode),
+    ToolbarUseIcons(bool),
+    ToolbarShowMoreColors(bool),
+    ToolbarContextAwareUi(bool),
+    ToolbarPresetToasts(bool),
+    ToolbarToolPreview(bool),
+    ToolbarDelaySliders(bool),
+    ToolbarTopPosition {
+        x: f64,
+        y: f64,
+    },
+    ToolbarSidePosition {
+        top_x: f64,
+        side_x: f64,
+        side_y: f64,
+    },
+    ShowStatusBar(bool),
+    StatusBarInteractive(bool),
+    StatusBarItem {
+        item: StatusBarItem,
+        visible: bool,
+    },
+    StatusBoardBadge(bool),
+    StatusPageBadge(bool),
+    FloatingBadgeAlways(bool),
+    FloatingBadge(bool),
+    ZoomChip(bool),
+    HistoryCustomSection(bool),
+    ClickHighlight {
+        enabled: Option<bool>,
+        show_on_highlight_tool: bool,
+    },
+    BoardConfig(Box<PendingBoardConfigUpdate>),
+    PresetSlot {
+        slot: usize,
+        preset: Option<Box<ToolPresetConfig>>,
+    },
+    QuickColor {
+        index: usize,
+        color: Color,
+    },
+}
+
+impl ConfigMutation {
+    /// Apply one typed edit to a loaded config. A false return means the
+    /// mutation's externally editable target disappeared before persistence.
+    pub(in crate::backend::wayland) fn apply(&self, config: &mut Config) -> bool {
+        match self {
+            Self::ToolbarLayout { mode, sections } => {
+                config.ui.toolbar.layout_mode = *mode;
+                apply_section_visibility(config, *sections);
+            }
+            Self::ToolbarSectionVisibility {
+                id,
+                setting,
+                flag,
+                visible,
+            } => {
+                config
+                    .ui
+                    .toolbar
+                    .items
+                    .set_visibility_setting(*id, *setting);
+                apply_section_compatibility_mirror(config, *flag, *visible);
+            }
+            Self::ToolbarTopDisplayMode(mode) => config.ui.toolbar.top_display_mode = *mode,
+            Self::ToolbarUseIcons(value) => config.ui.toolbar.use_icons = *value,
+            Self::ToolbarShowMoreColors(value) => config.ui.toolbar.show_more_colors = *value,
+            Self::ToolbarContextAwareUi(value) => config.ui.toolbar.context_aware_ui = *value,
+            Self::ToolbarPresetToasts(value) => config.ui.toolbar.show_preset_toasts = *value,
+            Self::ToolbarToolPreview(value) => config.ui.toolbar.show_tool_preview = *value,
+            Self::ToolbarDelaySliders(value) => config.ui.toolbar.show_delay_sliders = *value,
+            Self::ToolbarTopPosition { x, y } => {
+                config.ui.toolbar.top_offset = *x;
+                config.ui.toolbar.top_offset_y = *y;
+            }
+            Self::ToolbarSidePosition {
+                top_x,
+                side_x,
+                side_y,
+            } => {
+                config.ui.toolbar.top_offset = *top_x;
+                config.ui.toolbar.side_offset_x = *side_x;
+                config.ui.toolbar.side_offset = *side_y;
+            }
+            Self::ShowStatusBar(value) => config.ui.show_status_bar = *value,
+            Self::StatusBarInteractive(value) => config.ui.status_bar_interactive = *value,
+            Self::StatusBarItem { item, visible } => {
+                config.ui.set_status_bar_item_visible(*item, *visible);
+            }
+            Self::StatusBoardBadge(value) => config.ui.show_status_board_badge = *value,
+            Self::StatusPageBadge(value) => config.ui.show_status_page_badge = *value,
+            Self::FloatingBadgeAlways(value) => config.ui.show_floating_badge_always = *value,
+            Self::FloatingBadge(value) => config.ui.show_floating_badge = *value,
+            Self::ZoomChip(value) => config.ui.toolbar.show_zoom_chip = *value,
+            Self::HistoryCustomSection(value) => config.history.custom_section_enabled = *value,
+            Self::ClickHighlight {
+                enabled,
+                show_on_highlight_tool,
+            } => {
+                if let Some(enabled) = enabled {
+                    config.ui.click_highlight.enabled = *enabled;
+                }
+                config.ui.click_highlight.show_on_highlight_tool = *show_on_highlight_tool;
+            }
+            Self::BoardConfig(update) => {
+                crate::backend::wayland::state::apply_board_config_update_to_config(
+                    config,
+                    update.as_ref().clone(),
+                );
+            }
+            Self::PresetSlot { slot, preset } => {
+                config.presets.set_slot(*slot, preset.as_deref().cloned());
+            }
+            Self::QuickColor { index, color } => {
+                return !matches!(
+                    config.drawing.quick_colors.set_color_at(*index, *color),
+                    QuickColorWrite::SlotMissing
+                );
+            }
+        }
+        true
+    }
+
+    fn key(&self) -> Option<ConfigMutationKey> {
+        let key = match *self {
+            Self::ToolbarLayout { .. } => ConfigMutationKey::ToolbarLayout,
+            Self::ToolbarSectionVisibility { id, .. } => {
+                ConfigMutationKey::ToolbarSectionVisibility(id)
+            }
+            Self::ToolbarTopDisplayMode(_) => ConfigMutationKey::ToolbarTopDisplayMode,
+            Self::ToolbarUseIcons(_) => ConfigMutationKey::ToolbarUseIcons,
+            Self::ToolbarShowMoreColors(_) => ConfigMutationKey::ToolbarShowMoreColors,
+            Self::ToolbarContextAwareUi(_) => ConfigMutationKey::ToolbarContextAwareUi,
+            Self::ToolbarPresetToasts(_) => ConfigMutationKey::ToolbarPresetToasts,
+            Self::ToolbarToolPreview(_) => ConfigMutationKey::ToolbarToolPreview,
+            Self::ToolbarDelaySliders(_) => ConfigMutationKey::ToolbarDelaySliders,
+            Self::ToolbarTopPosition { .. } => ConfigMutationKey::ToolbarTopPosition,
+            Self::ToolbarSidePosition { .. } => ConfigMutationKey::ToolbarSidePosition,
+            Self::ShowStatusBar(_) => ConfigMutationKey::ShowStatusBar,
+            Self::StatusBarInteractive(_) => ConfigMutationKey::StatusBarInteractive,
+            Self::StatusBarItem { item, .. } => ConfigMutationKey::StatusBarItem(item),
+            Self::StatusBoardBadge(_) => ConfigMutationKey::StatusBoardBadge,
+            Self::StatusPageBadge(_) => ConfigMutationKey::StatusPageBadge,
+            Self::FloatingBadgeAlways(_) => ConfigMutationKey::FloatingBadgeAlways,
+            Self::FloatingBadge(_) => ConfigMutationKey::FloatingBadge,
+            Self::ZoomChip(_) => ConfigMutationKey::ZoomChip,
+            Self::HistoryCustomSection(_) => ConfigMutationKey::HistoryCustomSection,
+            // `enabled: None` deliberately leaves one field untouched, so
+            // replacing an earlier request could discard that field's edit.
+            Self::ClickHighlight { .. } => return None,
+            // Board updates carry merge metadata and must remain ordered.
+            Self::BoardConfig(_) => return None,
+            Self::PresetSlot { slot, .. } => ConfigMutationKey::PresetSlot(slot),
+            Self::QuickColor { index, .. } => ConfigMutationKey::QuickColor(index),
+        };
+        Some(key)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConfigMutationKey {
+    ToolbarLayout,
+    ToolbarSectionVisibility(ToolbarItemId),
+    ToolbarTopDisplayMode,
+    ToolbarUseIcons,
+    ToolbarShowMoreColors,
+    ToolbarContextAwareUi,
+    ToolbarPresetToasts,
+    ToolbarToolPreview,
+    ToolbarDelaySliders,
+    ToolbarTopPosition,
+    ToolbarSidePosition,
+    ShowStatusBar,
+    StatusBarInteractive,
+    StatusBarItem(StatusBarItem),
+    StatusBoardBadge,
+    StatusPageBadge,
+    FloatingBadgeAlways,
+    FloatingBadge,
+    ZoomChip,
+    HistoryCustomSection,
+    PresetSlot(usize),
+    QuickColor(usize),
+}
+
+fn apply_section_visibility(config: &mut Config, sections: ToolbarSectionVisibility) {
+    config.ui.toolbar.show_actions_section = sections.show_actions_section;
+    config.ui.toolbar.show_actions_advanced = sections.show_actions_advanced;
+    config.ui.toolbar.show_zoom_actions = sections.show_zoom_actions;
+    config.ui.toolbar.show_pages_section = sections.show_pages_section;
+    config.ui.toolbar.show_boards_section = sections.show_boards_section;
+    config.ui.toolbar.show_presets = sections.show_presets;
+    config.ui.toolbar.show_step_section = sections.show_step_section;
+    config.ui.toolbar.show_text_controls = sections.show_text_controls;
+    config.ui.toolbar.show_settings_section = sections.show_settings_section;
+}
+
+fn apply_section_compatibility_mirror(
+    config: &mut Config,
+    flag: ToolbarSectionFlag,
+    visible: bool,
+) {
+    match flag {
+        ToolbarSectionFlag::Actions => config.ui.toolbar.show_actions_section = visible,
+        ToolbarSectionFlag::ActionsAdvanced => {
+            config.ui.toolbar.show_actions_advanced = visible;
+        }
+        ToolbarSectionFlag::ZoomActions => config.ui.toolbar.show_zoom_actions = visible,
+        ToolbarSectionFlag::Pages => config.ui.toolbar.show_pages_section = visible,
+        ToolbarSectionFlag::Boards => config.ui.toolbar.show_boards_section = visible,
+        ToolbarSectionFlag::Presets => config.ui.toolbar.show_presets = visible,
+        ToolbarSectionFlag::StepSection => config.ui.toolbar.show_step_section = visible,
+        ToolbarSectionFlag::TextControls => config.ui.toolbar.show_text_controls = visible,
+    }
+}
+
+enum WriterCommand {
+    Apply(ConfigMutation),
+    Shutdown,
+}
+
+type PersistMutations = Box<dyn FnMut(&[ConfigMutation]) -> Result<()> + Send>;
+
+/// Event-loop facade for the channel-owned config writer.
+pub(in crate::backend::wayland) struct ConfigWriter {
+    sender: Option<Sender<WriterCommand>>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl ConfigWriter {
+    pub(in crate::backend::wayland) fn new() -> Self {
+        match Config::get_config_path() {
+            Ok(path) => Self::for_path(path),
+            Err(error) => {
+                warn!("Runtime config persistence is unavailable: {error:#}");
+                Self::unavailable()
+            }
+        }
+    }
+
+    fn for_path(path: PathBuf) -> Self {
+        Self::spawn(Box::new(move |mutations| {
+            persist_mutations_to_path(&path, mutations)
+        }))
+    }
+
+    fn spawn(persist: PersistMutations) -> Self {
+        let (sender, receiver) = channel();
+        let worker = thread::Builder::new()
+            .name("wayscriber-config-writer".to_string())
+            .spawn(move || run_writer(receiver, persist));
+
+        match worker {
+            Ok(worker) => Self {
+                sender: Some(sender),
+                worker: Some(worker),
+            },
+            Err(error) => {
+                warn!("Failed to start runtime config writer: {error}");
+                Self::unavailable()
+            }
+        }
+    }
+
+    fn unavailable() -> Self {
+        Self {
+            sender: None,
+            worker: None,
+        }
+    }
+
+    /// Queue a mutation without doing filesystem work on the caller.
+    #[must_use = "a false return means the preference was not queued"]
+    pub(in crate::backend::wayland) fn request(&self, mutation: &ConfigMutation) -> bool {
+        self.sender
+            .as_ref()
+            .is_some_and(|sender| sender.send(WriterCommand::Apply(mutation.clone())).is_ok())
+    }
+
+    /// Flush queued mutations and wait for the writer to finish.
+    pub(in crate::backend::wayland) fn shutdown(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            let _ = sender.send(WriterCommand::Shutdown);
+        }
+        if let Some(worker) = self.worker.take()
+            && worker.join().is_err()
+        {
+            warn!("Runtime config writer thread panicked");
+        }
+    }
+}
+
+impl Drop for ConfigWriter {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+enum WorkerEvent {
+    Command(WriterCommand),
+    Timeout,
+    Disconnected,
+}
+
+fn receive_worker_event(
+    receiver: &Receiver<WriterCommand>,
+    timeout: Option<Duration>,
+) -> WorkerEvent {
+    match timeout {
+        Some(timeout) => match receiver.recv_timeout(timeout) {
+            Ok(command) => WorkerEvent::Command(command),
+            Err(RecvTimeoutError::Timeout) => WorkerEvent::Timeout,
+            Err(RecvTimeoutError::Disconnected) => WorkerEvent::Disconnected,
+        },
+        None => match receiver.recv() {
+            Ok(command) => WorkerEvent::Command(command),
+            Err(_) => WorkerEvent::Disconnected,
+        },
+    }
+}
+
+fn run_writer(receiver: Receiver<WriterCommand>, mut persist: PersistMutations) {
+    let mut pending = Vec::new();
+    let mut write_after = None;
+    let mut retry_delay = INITIAL_RETRY_DELAY;
+
+    loop {
+        match receive_worker_event(&receiver, write_after) {
+            WorkerEvent::Command(WriterCommand::Apply(mutation)) => {
+                if let Some(key) = mutation.key() {
+                    pending.retain(|queued: &ConfigMutation| queued.key() != Some(key));
+                }
+                pending.push(mutation);
+                write_after = Some(WRITE_DEBOUNCE);
+            }
+            WorkerEvent::Command(WriterCommand::Shutdown) | WorkerEvent::Disconnected => {
+                persist_before_shutdown(&mut persist, &pending);
+                return;
+            }
+            WorkerEvent::Timeout => match persist(&pending) {
+                Ok(()) => {
+                    debug!("Processed {} runtime config edit(s)", pending.len());
+                    pending.clear();
+                    write_after = None;
+                    retry_delay = INITIAL_RETRY_DELAY;
+                }
+                Err(error) => {
+                    warn!(
+                        "Failed to persist {} runtime config edit(s); retrying: {error:#}",
+                        pending.len()
+                    );
+                    write_after = Some(retry_delay);
+                    retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+                }
+            },
+        }
+    }
+}
+
+fn persist_before_shutdown(persist: &mut PersistMutations, pending: &[ConfigMutation]) {
+    if pending.is_empty() {
+        return;
+    }
+    match persist(pending) {
+        Ok(()) => debug!(
+            "Processed {} runtime config edit(s) during shutdown",
+            pending.len()
+        ),
+        Err(error) => warn!(
+            "Failed to persist {} runtime config edit(s) during shutdown: {error:#}",
+            pending.len()
+        ),
+    }
+}
+
+fn persist_mutations_to_path(path: &Path, mutations: &[ConfigMutation]) -> Result<()> {
+    let document = ConfigDocument::load_from_path(path)?;
+    let mut config = document.config().clone();
+    let mut applied = false;
+    for mutation in mutations {
+        if mutation.apply(&mut config) {
+            applied = true;
+        } else if let ConfigMutation::QuickColor { index, .. } = mutation {
+            warn!("Quick color slot {index} is no longer in config.toml; recolor was not saved");
+        }
+    }
+    if applied {
+        document.save(config)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/wayland/config_writer/tests.rs
+++ b/src/backend/wayland/config_writer/tests.rs
@@ -1,0 +1,343 @@
+use super::*;
+use crate::input::boards::{BoardConfigChange, PendingBoardConfigUpdate};
+use std::fs;
+use std::sync::mpsc;
+use std::time::Instant;
+
+#[test]
+fn request_does_not_wait_for_an_in_flight_write() {
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let mut block_first_write = true;
+    let persist = Box::new(move |_mutations: &[ConfigMutation]| {
+        if block_first_write {
+            block_first_write = false;
+            let _ = entered_tx.send(());
+            release_rx
+                .recv()
+                .map_err(|error| anyhow::anyhow!("release signal missing: {error}"))?;
+        }
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(false)));
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("the test writer should enter its first persistence call");
+
+    let started = Instant::now();
+    let queued = writer.request(&ConfigMutation::ToolbarShowMoreColors(true));
+    let elapsed = started.elapsed();
+
+    let _ = release_tx.send(());
+    writer.shutdown();
+
+    assert!(queued);
+    assert!(
+        elapsed < Duration::from_millis(50),
+        "queueing must not wait for the blocked persistence call"
+    );
+}
+
+#[test]
+fn shutdown_coalesces_rapid_mutations_into_one_write() {
+    let (batches_tx, batches_rx) = mpsc::channel();
+    let persist = Box::new(move |mutations: &[ConfigMutation]| {
+        batches_tx
+            .send(mutations.len())
+            .map_err(|error| anyhow::anyhow!("batch observer disconnected: {error}"))?;
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(false)));
+    assert!(writer.request(&ConfigMutation::ToolbarShowMoreColors(true)));
+    writer.shutdown();
+
+    assert_eq!(
+        batches_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("shutdown should flush one batch"),
+        2
+    );
+    assert!(
+        batches_rx.try_recv().is_err(),
+        "the two rapid edits should share one durable write"
+    );
+}
+
+#[test]
+fn every_wayland_config_family_shares_the_writer_batch() {
+    let (batches_tx, batches_rx) = mpsc::channel();
+    let persist = Box::new(move |mutations: &[ConfigMutation]| {
+        let kinds: Vec<_> = mutations
+            .iter()
+            .map(|mutation| match mutation {
+                ConfigMutation::BoardConfig(_) => "board",
+                ConfigMutation::PresetSlot { .. } => "preset",
+                ConfigMutation::QuickColor { .. } => "quick-color",
+                _ => "toolbar",
+            })
+            .collect();
+        batches_tx
+            .send(kinds)
+            .map_err(|error| anyhow::anyhow!("batch observer disconnected: {error}"))?;
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+    let boards = Config::default().resolved_boards();
+
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(false)));
+    assert!(writer.request(&ConfigMutation::BoardConfig(Box::new(
+        PendingBoardConfigUpdate::new(boards, BoardConfigChange::Structure),
+    ))));
+    assert!(writer.request(&ConfigMutation::PresetSlot {
+        slot: 1,
+        preset: None,
+    }));
+    assert!(writer.request(&ConfigMutation::QuickColor {
+        index: 0,
+        color: Color {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        },
+    }));
+    writer.shutdown();
+
+    assert_eq!(
+        batches_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("shutdown should flush one shared config batch"),
+        ["toolbar", "board", "preset", "quick-color"]
+    );
+}
+
+#[test]
+fn repeated_edits_to_one_preference_keep_only_the_latest_value() {
+    let (batches_tx, batches_rx) = mpsc::channel();
+    let persist = Box::new(move |mutations: &[ConfigMutation]| {
+        let mut config = Config::default();
+        for mutation in mutations {
+            let _ = mutation.apply(&mut config);
+        }
+        batches_tx
+            .send((mutations.len(), config.ui.toolbar.use_icons))
+            .map_err(|error| anyhow::anyhow!("batch observer disconnected: {error}"))?;
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(false)));
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(true)));
+    writer.shutdown();
+
+    assert_eq!(
+        batches_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("shutdown should flush the coalesced edit"),
+        (1, true)
+    );
+}
+
+#[test]
+fn board_edits_remain_ordered_instead_of_being_coalesced() {
+    let (batches_tx, batches_rx) = mpsc::channel();
+    let persist = Box::new(move |mutations: &[ConfigMutation]| {
+        batches_tx
+            .send(mutations.len())
+            .map_err(|error| anyhow::anyhow!("batch observer disconnected: {error}"))?;
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+    let boards = Config::default().resolved_boards();
+
+    assert!(writer.request(&ConfigMutation::BoardConfig(Box::new(
+        PendingBoardConfigUpdate::new(boards.clone(), BoardConfigChange::Structure),
+    ))));
+    assert!(writer.request(&ConfigMutation::BoardConfig(Box::new(
+        PendingBoardConfigUpdate::new(boards, BoardConfigChange::Structure),
+    ))));
+    writer.shutdown();
+
+    assert_eq!(
+        batches_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("shutdown should flush both ordered board edits"),
+        2
+    );
+}
+
+#[test]
+fn partial_click_highlight_edits_remain_ordered() {
+    let (batches_tx, batches_rx) = mpsc::channel();
+    let persist = Box::new(move |mutations: &[ConfigMutation]| {
+        let mut config = Config::default();
+        for mutation in mutations {
+            let _ = mutation.apply(&mut config);
+        }
+        batches_tx
+            .send((
+                mutations.len(),
+                config.ui.click_highlight.enabled,
+                config.ui.click_highlight.show_on_highlight_tool,
+            ))
+            .map_err(|error| anyhow::anyhow!("batch observer disconnected: {error}"))?;
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+
+    assert!(writer.request(&ConfigMutation::ClickHighlight {
+        enabled: Some(true),
+        show_on_highlight_tool: false,
+    }));
+    assert!(writer.request(&ConfigMutation::ClickHighlight {
+        enabled: None,
+        show_on_highlight_tool: true,
+    }));
+    writer.shutdown();
+
+    assert_eq!(
+        batches_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("shutdown should preserve both partial edits"),
+        (2, true, true)
+    );
+}
+
+#[test]
+fn a_failed_write_is_retained_for_the_shutdown_retry() {
+    let (attempts_tx, attempts_rx) = mpsc::channel();
+    let mut fail_first = true;
+    let persist = Box::new(move |_mutations: &[ConfigMutation]| {
+        let _ = attempts_tx.send(());
+        if fail_first {
+            fail_first = false;
+            return Err(anyhow::anyhow!("injected write failure"));
+        }
+        Ok(())
+    });
+    let mut writer = ConfigWriter::spawn(persist);
+
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(false)));
+    attempts_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("the first write should be attempted");
+    writer.shutdown();
+
+    attempts_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("shutdown should retry the retained mutation");
+}
+
+#[test]
+fn each_batch_reloads_and_preserves_the_latest_document() {
+    let temp = crate::test_temp::tempdir().expect("tempdir should succeed");
+    let path = temp.path().join("config.toml");
+    fs::write(
+        &path,
+        "# external heading\n[ui.toolbar]\nuse_icons = true\nfuture_setting = \"keep\"\n",
+    )
+    .expect("test config should be written");
+
+    persist_mutations_to_path(&path, &[ConfigMutation::ToolbarUseIcons(false)])
+        .expect("mutation should persist");
+
+    let written = fs::read_to_string(&path).expect("persisted config should be readable");
+    assert!(written.contains("# external heading"));
+    assert!(written.contains("future_setting = \"keep\""));
+    let reloaded = ConfigDocument::load_from_path(&path).expect("saved config should parse");
+    assert!(!reloaded.config().ui.toolbar.use_icons);
+}
+
+#[test]
+fn mixed_runtime_mutations_persist_through_one_document_revision() {
+    let temp = crate::test_temp::tempdir().expect("tempdir should succeed");
+    let path = temp.path().join("config.toml");
+    fs::write(&path, "[ui.toolbar]\nuse_icons = true\n").expect("test config should be written");
+
+    let baseline = Config::default();
+    let mut boards = baseline.resolved_boards();
+    let board_id = boards.items[0].id.clone();
+    boards.items[0].name = "Writer board".to_string();
+    let board_update =
+        PendingBoardConfigUpdate::new(boards, BoardConfigChange::Name(board_id.clone()));
+    let color = Color {
+        r: 0.13,
+        g: 0.27,
+        b: 0.41,
+        a: 1.0,
+    };
+    let preset = ToolPresetConfig {
+        name: Some("Writer preset".to_string()),
+        tool: crate::input::Tool::Pen,
+        color: crate::config::ColorSpec::from(color),
+        size: 7.0,
+        tool_settings: None,
+        eraser_kind: None,
+        eraser_mode: None,
+        marker_opacity: None,
+        fill_enabled: None,
+        font_size: None,
+        text_background_enabled: None,
+        arrow_length: None,
+        arrow_angle: None,
+        arrow_head_at_end: None,
+        polygon_sides: None,
+        show_status_bar: None,
+        drag_tools: None,
+    };
+
+    persist_mutations_to_path(
+        &path,
+        &[
+            ConfigMutation::ToolbarUseIcons(false),
+            ConfigMutation::BoardConfig(Box::new(board_update)),
+            ConfigMutation::PresetSlot {
+                slot: 1,
+                preset: Some(Box::new(preset)),
+            },
+            ConfigMutation::QuickColor { index: 0, color },
+        ],
+    )
+    .expect("the shared runtime mutation batch should persist");
+
+    let reloaded = ConfigDocument::load_from_path(path).expect("saved config should parse");
+    let config = reloaded.config();
+    assert!(!config.ui.toolbar.use_icons);
+    assert_eq!(
+        config
+            .boards
+            .as_ref()
+            .and_then(|saved| saved.items.iter().find(|board| board.id == board_id))
+            .map(|board| board.name.as_str()),
+        Some("Writer board")
+    );
+    assert_eq!(
+        config
+            .presets
+            .get_slot(1)
+            .and_then(|saved| saved.name.as_deref()),
+        Some("Writer preset")
+    );
+    assert_eq!(
+        config.drawing.quick_colors.effective_entries()[0].color,
+        crate::config::ColorSpec::from(color)
+    );
+}
+
+#[test]
+fn shutdown_flushes_the_real_document_writer() {
+    let temp = crate::test_temp::tempdir().expect("tempdir should succeed");
+    let path = temp.path().join("config.toml");
+    fs::write(&path, "[ui.toolbar]\nuse_icons = true\n").expect("test config should be written");
+    let mut writer = ConfigWriter::for_path(path.clone());
+
+    assert!(writer.request(&ConfigMutation::ToolbarUseIcons(false)));
+    writer.shutdown();
+
+    let reloaded = ConfigDocument::load_from_path(path).expect("saved config should parse");
+    assert!(!reloaded.config().ui.toolbar.use_icons);
+}

--- a/src/backend/wayland/mod.rs
+++ b/src/backend/wayland/mod.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod capture;
 mod clipboard;
+mod config_writer;
 mod frozen;
 mod frozen_geometry;
 mod handlers;

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -95,6 +95,7 @@ use super::{
 
 mod activation;
 mod boards;
+pub(in crate::backend::wayland) use boards::apply_board_config_update_to_config;
 mod buffer_damage;
 mod canvas_layer;
 mod capture;
@@ -150,6 +151,7 @@ pub(in crate::backend::wayland) struct WaylandGlobals {
 pub(in crate::backend::wayland) struct WaylandStateInit {
     pub globals: WaylandGlobals,
     pub config: Config,
+    pub config_writer: super::config_writer::ConfigWriter,
     pub input_state: InputState,
     pub onboarding: crate::onboarding::OnboardingStore,
     pub palette_recents: crate::palette_recents::PaletteRecentsWriter,
@@ -205,6 +207,8 @@ pub(super) struct WaylandState {
 
     // Configuration
     pub(super) config: Config,
+    /// Channel-owned writer for runtime-authored config preferences.
+    pub(super) config_writer: super::config_writer::ConfigWriter,
     pub(super) runtime_ui: Option<crate::backend::wayland::runtime_ui_state::ToolbarRuntimeState>,
     pub(super) runtime_ui_unavailable: Option<crate::ui::toolbar::RuntimeUiPersistenceSnapshot>,
     pub(super) runtime_ui_unavailable_previews:

--- a/src/backend/wayland/state/boards.rs
+++ b/src/backend/wayland/state/boards.rs
@@ -3,16 +3,17 @@ use crate::input::DrawingState;
 use crate::input::boards::PendingBoardConfigUpdate;
 
 use super::WaylandState;
+use crate::backend::wayland::config_writer::ConfigMutation;
 
 impl WaylandState {
     pub(in crate::backend::wayland) fn apply_board_config_update(
         &mut self,
         update: PendingBoardConfigUpdate,
     ) {
-        apply_board_config_update_to_config(&mut self.config, update);
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to save board config: {}", err);
-        } else {
+        if self.queue_config_mutation(
+            ConfigMutation::BoardConfig(Box::new(update)),
+            "board config persistence",
+        ) {
             self.refresh_runtime_ui_config_seeds();
         }
     }
@@ -154,7 +155,7 @@ impl WaylandState {
     }
 }
 
-fn apply_board_config_update_to_config(
+pub(in crate::backend::wayland) fn apply_board_config_update_to_config(
     config: &mut crate::config::Config,
     update: PendingBoardConfigUpdate,
 ) {
@@ -165,7 +166,9 @@ fn apply_board_config_update_to_config(
     {
         config.boards = Some(config.resolved_boards());
     }
-    let boards = config.boards.as_mut().expect("resolved boards are present");
+    let Some(boards) = config.boards.as_mut() else {
+        return;
+    };
     let PendingBoardConfigUpdate {
         snapshot,
         structure_changed,

--- a/src/backend/wayland/state/core/init.rs
+++ b/src/backend/wayland/state/core/init.rs
@@ -7,6 +7,7 @@ impl WaylandState {
         let WaylandStateInit {
             globals,
             config,
+            config_writer,
             input_state,
             onboarding,
             palette_recents,
@@ -129,6 +130,7 @@ impl WaylandState {
             canvas_layer_cache: super::super::canvas_layer::CanvasLayerCache::new(),
             spotlight_dimmed_last_frame: false,
             config,
+            config_writer,
             runtime_ui,
             runtime_ui_unavailable,
             runtime_ui_unavailable_previews: Default::default(),

--- a/src/backend/wayland/state/toolbar/events/persistence.rs
+++ b/src/backend/wayland/state/toolbar/events/persistence.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::QuickColorWrite;
+use crate::backend::wayland::config_writer::ConfigMutation;
 use crate::ui::toolbar::model::{ToolbarConfigPersistenceTarget, ToolbarUiPersistenceTarget};
 
 pub(super) fn persisted_tool_preview_value(current: bool, presenter_restore: Option<bool>) -> bool {
@@ -17,54 +17,45 @@ pub(super) fn persisted_top_display_mode_value(
     presenter_restore.unwrap_or(current).persisted()
 }
 
+#[cfg(test)]
 pub(super) fn apply_toolbar_ui_config_target(
     config: &mut crate::config::Config,
     input_state: &InputState,
     target: ToolbarUiPersistenceTarget,
 ) {
-    match target {
-        ToolbarUiPersistenceTarget::StatusBar => {
-            config.ui.show_status_bar = input_state.show_status_bar;
-        }
-        ToolbarUiPersistenceTarget::StatusBarInteractive => {
-            config.ui.status_bar_interactive = input_state.status_bar_interactive;
-        }
-        ToolbarUiPersistenceTarget::StatusBarItem(item) => {
-            config
-                .ui
-                .set_status_bar_item_visible(item, input_state.status_bar_item_visible(item));
-        }
-        ToolbarUiPersistenceTarget::StatusBoardBadge => {
-            config.ui.show_status_board_badge = input_state.show_status_board_badge;
-        }
-        ToolbarUiPersistenceTarget::StatusPageBadge => {
-            config.ui.show_status_page_badge = input_state.show_status_page_badge;
-        }
-        ToolbarUiPersistenceTarget::FloatingBadgeAlways => {
-            config.ui.show_floating_badge_always = input_state.show_floating_badge_always;
-        }
-        ToolbarUiPersistenceTarget::FloatingBadge => {
-            config.ui.show_floating_badge = input_state.show_floating_badge;
-        }
-        ToolbarUiPersistenceTarget::ZoomChip => {
-            config.ui.toolbar.show_zoom_chip = input_state.show_zoom_chip;
-        }
-    }
+    let _ = toolbar_ui_config_mutation(input_state, target).apply(config);
 }
 
-fn apply_toolbar_ui_visibility_value(
-    config: &mut crate::config::Config,
+fn toolbar_ui_config_mutation(
+    input_state: &InputState,
     target: ToolbarUiPersistenceTarget,
-    visible: bool,
-) {
+) -> ConfigMutation {
     match target {
+        ToolbarUiPersistenceTarget::StatusBar => {
+            ConfigMutation::ShowStatusBar(input_state.show_status_bar)
+        }
+        ToolbarUiPersistenceTarget::StatusBarInteractive => {
+            ConfigMutation::StatusBarInteractive(input_state.status_bar_interactive)
+        }
+        ToolbarUiPersistenceTarget::StatusBarItem(item) => ConfigMutation::StatusBarItem {
+            item,
+            visible: input_state.status_bar_item_visible(item),
+        },
+        ToolbarUiPersistenceTarget::StatusBoardBadge => {
+            ConfigMutation::StatusBoardBadge(input_state.show_status_board_badge)
+        }
+        ToolbarUiPersistenceTarget::StatusPageBadge => {
+            ConfigMutation::StatusPageBadge(input_state.show_status_page_badge)
+        }
+        ToolbarUiPersistenceTarget::FloatingBadgeAlways => {
+            ConfigMutation::FloatingBadgeAlways(input_state.show_floating_badge_always)
+        }
         ToolbarUiPersistenceTarget::FloatingBadge => {
-            config.ui.show_floating_badge = visible;
+            ConfigMutation::FloatingBadge(input_state.show_floating_badge)
         }
         ToolbarUiPersistenceTarget::ZoomChip => {
-            config.ui.toolbar.show_zoom_chip = visible;
+            ConfigMutation::ZoomChip(input_state.show_zoom_chip)
         }
-        _ => unreachable!("only master-visibility targets carry authored values"),
     }
 }
 
@@ -76,111 +67,113 @@ pub(super) struct ToolbarPositions {
     pub(super) side_y: f64,
 }
 
-fn apply_all_section_compatibility_mirrors(
-    config: &mut crate::config::Config,
-    input_state: &InputState,
-) {
-    config.ui.toolbar.show_actions_section = input_state.show_actions_section;
-    config.ui.toolbar.show_actions_advanced = input_state.show_actions_advanced;
-    config.ui.toolbar.show_zoom_actions = input_state.show_zoom_actions;
-    config.ui.toolbar.show_pages_section = input_state.show_pages_section;
-    config.ui.toolbar.show_boards_section = input_state.show_boards_section;
-    config.ui.toolbar.show_presets = input_state.show_presets;
-    config.ui.toolbar.show_step_section = input_state.show_step_section;
-    config.ui.toolbar.show_text_controls = input_state.show_text_controls;
-    config.ui.toolbar.show_settings_section = input_state.show_settings_section;
-}
-
-fn apply_section_compatibility_mirror(
-    config: &mut crate::config::Config,
-    flag: crate::config::ToolbarSectionFlag,
-    visible: bool,
-) {
-    use crate::config::ToolbarSectionFlag;
-
-    match flag {
-        ToolbarSectionFlag::Actions => config.ui.toolbar.show_actions_section = visible,
-        ToolbarSectionFlag::ActionsAdvanced => {
-            config.ui.toolbar.show_actions_advanced = visible;
-        }
-        ToolbarSectionFlag::ZoomActions => config.ui.toolbar.show_zoom_actions = visible,
-        ToolbarSectionFlag::Pages => config.ui.toolbar.show_pages_section = visible,
-        ToolbarSectionFlag::Boards => config.ui.toolbar.show_boards_section = visible,
-        ToolbarSectionFlag::Presets => config.ui.toolbar.show_presets = visible,
-        ToolbarSectionFlag::StepSection => config.ui.toolbar.show_step_section = visible,
-        ToolbarSectionFlag::TextControls => config.ui.toolbar.show_text_controls = visible,
-    }
-}
-
+#[cfg(test)]
 pub(super) fn apply_toolbar_config_target(
     config: &mut crate::config::Config,
     input_state: &InputState,
     positions: ToolbarPositions,
     target: ToolbarConfigPersistenceTarget,
 ) {
+    let _ = toolbar_config_mutation(input_state, positions, target).apply(config);
+}
+
+fn toolbar_config_mutation(
+    input_state: &InputState,
+    positions: ToolbarPositions,
+    target: ToolbarConfigPersistenceTarget,
+) -> ConfigMutation {
     use ToolbarConfigPersistenceTarget::*;
 
     match target {
-        LayoutMode => {
-            config.ui.toolbar.layout_mode = input_state.toolbar_layout_mode;
-            apply_all_section_compatibility_mirrors(config, input_state);
-        }
+        LayoutMode => ConfigMutation::ToolbarLayout {
+            mode: input_state.toolbar_layout_mode,
+            sections: crate::config::ToolbarSectionVisibility {
+                show_actions_section: input_state.show_actions_section,
+                show_actions_advanced: input_state.show_actions_advanced,
+                show_zoom_actions: input_state.show_zoom_actions,
+                show_pages_section: input_state.show_pages_section,
+                show_boards_section: input_state.show_boards_section,
+                show_presets: input_state.show_presets,
+                show_step_section: input_state.show_step_section,
+                show_text_controls: input_state.show_text_controls,
+                show_settings_section: input_state.show_settings_section,
+            },
+        },
         SectionVisibility(flag) => {
             let id = flag.item_id();
             let setting =
                 crate::config::item_visibility_setting(&input_state.resolved_toolbar_items, id);
-            config.ui.toolbar.items.set_visibility_setting(id, setting);
             let visible = crate::config::resolve_section_visibility(
                 input_state.toolbar_layout_mode,
                 &input_state.toolbar_mode_overrides,
                 &input_state.resolved_toolbar_items,
             )
             .get(flag);
-            apply_section_compatibility_mirror(config, flag, visible);
+            ConfigMutation::ToolbarSectionVisibility {
+                id,
+                setting,
+                flag,
+                visible,
+            }
         }
-        TopDisplayMode => {
-            config.ui.toolbar.top_display_mode = persisted_top_display_mode_value(
-                input_state.toolbar_top_display_mode,
-                input_state
-                    .presenter_restore
-                    .as_ref()
-                    .and_then(|restore| restore.toolbar_top_display_mode),
-            );
-        }
-        Icons => config.ui.toolbar.use_icons = input_state.toolbar_use_icons,
-        MoreColors => config.ui.toolbar.show_more_colors = input_state.show_more_colors,
-        ContextAwareUi => config.ui.toolbar.context_aware_ui = input_state.context_aware_ui,
-        PresetToasts => config.ui.toolbar.show_preset_toasts = input_state.show_preset_toasts,
-        ToolPreview => {
-            config.ui.toolbar.show_tool_preview = persisted_tool_preview_value(
-                input_state.show_tool_preview,
-                input_state
-                    .presenter_restore
-                    .as_ref()
-                    .and_then(|restore| restore.show_tool_preview),
-            );
-        }
-        DelaySliders => config.ui.toolbar.show_delay_sliders = input_state.show_delay_sliders,
-        TopPosition => {
-            config.ui.toolbar.top_offset = positions.top_x;
-            config.ui.toolbar.top_offset_y = positions.top_y;
-        }
+        TopDisplayMode => ConfigMutation::ToolbarTopDisplayMode(persisted_top_display_mode_value(
+            input_state.toolbar_top_display_mode,
+            input_state
+                .presenter_restore
+                .as_ref()
+                .and_then(|restore| restore.toolbar_top_display_mode),
+        )),
+        Icons => ConfigMutation::ToolbarUseIcons(input_state.toolbar_use_icons),
+        MoreColors => ConfigMutation::ToolbarShowMoreColors(input_state.show_more_colors),
+        ContextAwareUi => ConfigMutation::ToolbarContextAwareUi(input_state.context_aware_ui),
+        PresetToasts => ConfigMutation::ToolbarPresetToasts(input_state.show_preset_toasts),
+        ToolPreview => ConfigMutation::ToolbarToolPreview(persisted_tool_preview_value(
+            input_state.show_tool_preview,
+            input_state
+                .presenter_restore
+                .as_ref()
+                .and_then(|restore| restore.show_tool_preview),
+        )),
+        DelaySliders => ConfigMutation::ToolbarDelaySliders(input_state.show_delay_sliders),
+        TopPosition => ConfigMutation::ToolbarTopPosition {
+            x: positions.top_x,
+            y: positions.top_y,
+        },
         SidePosition => {
             // A side drag can change whether the side palette overlaps the
             // top strip. Drag completion reconciles the top strip's X offset
             // against that new base before saving, so persist the derived X
             // together with the side position. The top Y value is unrelated.
-            config.ui.toolbar.top_offset = positions.top_x;
-            config.ui.toolbar.side_offset_x = positions.side_x;
-            config.ui.toolbar.side_offset = positions.side_y;
+            ConfigMutation::ToolbarSidePosition {
+                top_x: positions.top_x,
+                side_x: positions.side_x,
+                side_y: positions.side_y,
+            }
         }
     }
 }
 
 impl WaylandState {
+    pub(in crate::backend::wayland) fn queue_config_mutation(
+        &mut self,
+        mutation: ConfigMutation,
+        description: &str,
+    ) -> bool {
+        if self.config_writer.request(&mutation) {
+            // Keep the runtime baseline aligned with accepted writes. The
+            // worker owns retrying the same mutation, so a later config edit
+            // cannot reintroduce the stale pre-request value while it waits.
+            let _ = mutation.apply(&mut self.config);
+            log::debug!("Queued {description}");
+            true
+        } else {
+            log::warn!("Failed to queue {description}; runtime value remains session-only");
+            false
+        }
+    }
+
     pub(super) fn save_toolbar_config(&mut self, target: ToolbarConfigPersistenceTarget) {
-        apply_toolbar_config_target(
-            &mut self.config,
+        let mutation = toolbar_config_mutation(
             &self.input_state,
             ToolbarPositions {
                 top_x: self.data.toolbar_top_offset,
@@ -190,12 +183,7 @@ impl WaylandState {
             },
             target,
         );
-
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to save toolbar config: {}", err);
-        } else {
-            log::debug!("Saved toolbar config");
-        }
+        self.queue_config_mutation(mutation, "toolbar config persistence");
     }
 
     pub(in crate::backend::wayland) fn save_toolbar_position_config(&mut self, kind: MoveDragKind) {
@@ -214,71 +202,53 @@ impl WaylandState {
         &mut self,
         visible: bool,
     ) {
-        self.save_toolbar_ui_visibility_config(ToolbarUiPersistenceTarget::FloatingBadge, visible);
+        self.queue_config_mutation(
+            ConfigMutation::FloatingBadge(visible),
+            "floating badge visibility persistence",
+        );
     }
 
     pub(in crate::backend::wayland) fn save_zoom_chip_visibility_config(&mut self, visible: bool) {
-        self.save_toolbar_ui_visibility_config(ToolbarUiPersistenceTarget::ZoomChip, visible);
-    }
-
-    fn save_toolbar_ui_visibility_config(
-        &mut self,
-        target: ToolbarUiPersistenceTarget,
-        visible: bool,
-    ) {
-        let save_result = crate::config::Config::update_file(|config| {
-            apply_toolbar_ui_visibility_value(config, target, visible);
-        });
-        match save_result {
-            Ok(()) => {
-                apply_toolbar_ui_visibility_value(&mut self.config, target, visible);
-                log::debug!("Saved toolbar UI visibility config");
-            }
-            Err(err) => log::warn!("Failed to save toolbar UI visibility config: {}", err),
-        }
+        self.queue_config_mutation(
+            ConfigMutation::ZoomChip(visible),
+            "zoom chip visibility persistence",
+        );
     }
 
     pub(super) fn save_toolbar_ui_config(&mut self, target: ToolbarUiPersistenceTarget) {
-        let save_result = crate::config::Config::update_file(|config| {
-            apply_toolbar_ui_config_target(config, &self.input_state, target);
-        });
-
-        match save_result {
-            Ok(()) => {
-                // Keep the runtime's config baseline aligned only after the
-                // durable write succeeds. On failure the live InputState value
-                // remains in effect, but cannot hitchhike on a later save.
-                apply_toolbar_ui_config_target(&mut self.config, &self.input_state, target);
-                log::debug!("Saved toolbar UI config");
-            }
-            Err(err) => log::warn!("Failed to save toolbar UI config: {}", err),
-        }
+        let mutation = toolbar_ui_config_mutation(&self.input_state, target);
+        self.queue_config_mutation(mutation, "toolbar UI config persistence");
     }
 
     pub(super) fn save_toolbar_history_config(&mut self) {
-        self.config.history.custom_section_enabled = self.input_state.custom_section_enabled;
-
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to save toolbar history config: {}", err);
-        } else {
-            log::debug!("Saved toolbar history config");
-        }
+        self.queue_config_mutation(
+            ConfigMutation::HistoryCustomSection(self.input_state.custom_section_enabled),
+            "toolbar history config persistence",
+        );
     }
 
     pub(in crate::backend::wayland) fn save_click_highlight_preferences(&mut self) {
-        if !(self.input_state.presenter_mode
+        let enabled = if self.input_state.presenter_mode
             && self
                 .input_state
                 .presenter_mode_config
-                .enable_click_highlight)
+                .enable_click_highlight
         {
-            self.config.ui.click_highlight.enabled = self.input_state.click_highlight_enabled();
-        }
-        self.config.ui.click_highlight.show_on_highlight_tool =
-            self.input_state.highlight_tool_ring_enabled();
-        if let Err(err) = self.config.save() {
-            log::warn!("Failed to persist click highlight preferences: {}", err);
-        }
+            None
+        } else {
+            Some(self.input_state.click_highlight_enabled())
+        };
+        self.queue_config_mutation(
+            ConfigMutation::ClickHighlight {
+                enabled,
+                show_on_highlight_tool: self.input_state.highlight_tool_ring_enabled(),
+            },
+            "click highlight preference persistence",
+        );
+    }
+
+    pub(in crate::backend::wayland) fn shutdown_config_writer(&mut self) {
+        self.config_writer.shutdown();
     }
 
     /// Flush durable edits that are queued but not yet written. Pointer-driven
@@ -301,50 +271,27 @@ impl WaylandState {
         edit: crate::input::state::QuickColorEdit,
     ) {
         let crate::input::state::QuickColorEdit { index, color } = edit;
-        let mut outcome = QuickColorWrite::SlotMissing;
-        let save_result = crate::config::Config::update_file(|config| {
-            outcome = config.drawing.quick_colors.set_color_at(index, color);
-        });
-        match (save_result, outcome) {
-            // The document is reloaded before the edit applies, so a palette
-            // that shrank underneath the overlay (configurator, hand edit) no
-            // longer has this slot. Nothing was written: say so instead of
-            // reporting a save, and leave the config baseline alone so it keeps
-            // matching the file the runtime swatch will be reconciled against.
-            (Ok(()), QuickColorWrite::SlotMissing) => log::warn!(
-                "Quick color slot {index} is no longer in config.toml; recolor was not saved"
-            ),
-            (Ok(()), written) => {
-                self.config.drawing.quick_colors.set_color_at(index, color);
-                match written {
-                    QuickColorWrite::Written => log::debug!("Saved quick color slot {index}"),
-                    QuickColorWrite::Unchanged => {
-                        log::debug!("Quick color slot {index} already held that color");
-                    }
-                    QuickColorWrite::SlotMissing => {}
-                }
-            }
-            (Err(err), _) => log::warn!("Failed to save quick color slot {index}: {err}"),
-        }
+        self.queue_config_mutation(
+            ConfigMutation::QuickColor { index, color },
+            "quick color persistence",
+        );
     }
 
     pub(in crate::backend::wayland) fn handle_preset_action(
         &mut self,
         action: crate::input::state::PresetAction,
     ) {
-        match action {
+        let mutation = match action {
             crate::input::state::PresetAction::Save { slot, preset } => {
-                self.config.presets.set_slot(slot, Some(*preset));
-                if let Err(err) = self.config.save() {
-                    log::warn!("Failed to save preset slot {}: {}", slot, err);
+                ConfigMutation::PresetSlot {
+                    slot,
+                    preset: Some(preset),
                 }
             }
             crate::input::state::PresetAction::Clear { slot } => {
-                self.config.presets.set_slot(slot, None);
-                if let Err(err) = self.config.save() {
-                    log::warn!("Failed to clear preset slot {}: {}", slot, err);
-                }
+                ConfigMutation::PresetSlot { slot, preset: None }
             }
-        }
+        };
+        self.queue_config_mutation(mutation, "preset persistence");
     }
 }

--- a/src/config/io.rs
+++ b/src/config/io.rs
@@ -116,10 +116,9 @@ impl Config {
         Ok(backup_path)
     }
 
-    /// Reloads the active document, applies one runtime-owned mutation to
-    /// that fresh typed value, and saves it through the same revision guard.
-    /// This prevents a long-lived runtime snapshot from overwriting newer
-    /// edits made through the configurator or directly in `config.toml`.
+    /// Test-only convenience for exercising the revision-guarded document
+    /// update path without constructing a runtime persistence worker.
+    #[cfg(test)]
     pub(crate) fn update_file(update: impl FnOnce(&mut Self)) -> Result<()> {
         let config_path = Self::get_config_path()?;
         let document = ConfigDocument::load_from_path(&config_path)?;

--- a/src/input/state/core/base/state/structs.rs
+++ b/src/input/state/core/base/state/structs.rs
@@ -538,9 +538,12 @@ pub struct InputState {
     pub board_picker_layout: Option<BoardPickerLayout>,
     /// Cached layout details for the status HUD (segmented status bar)
     pub status_hud_layout: Option<crate::ui::StatusHudLayout>,
-    /// Last screen/config inputs used to build the status HUD. Retained when
-    /// the effective layout is empty so a content toggle can synchronously
-    /// refresh `status_hud_layout` before the next rendered frame.
+    /// Last screen/config inputs used to build the status HUD. Retained while
+    /// UI rendering is active so a content toggle can synchronously refresh
+    /// `status_hud_layout`, keeping policy exact — including width degradation
+    /// on narrow outputs — until the next rendered frame. Suppression clears
+    /// this so policy cannot mistake configured content for chrome that is
+    /// currently on screen.
     pub(in crate::input::state::core) status_hud_rebuild_inputs: Option<StatusHudRebuildInputs>,
     /// Set when the internal pointer-routing chain consumed a left press on
     /// the status HUD (tablet and other paths that bypass the backend's own

--- a/src/input/state/core/status_hud.rs
+++ b/src/input/state/core/status_hud.rs
@@ -31,19 +31,8 @@ impl InputState {
 
     pub fn status_hud_effectively_visible(&self) -> bool {
         self.show_status_bar
-            && self.status_hud_rebuild_inputs.as_ref().map_or_else(
-                || self.status_hud_layout.is_some(),
-                |inputs| {
-                    compute_status_hud_layout(
-                        self,
-                        inputs.position,
-                        &inputs.style,
-                        inputs.screen_width,
-                        inputs.screen_height,
-                    )
-                    .is_some()
-                },
-            )
+            && self.status_hud_rebuild_inputs.is_some()
+            && self.status_hud_layout.is_some()
     }
 
     pub fn status_bar_item_visible(&self, item: StatusBarItem) -> bool {
@@ -83,10 +72,30 @@ impl InputState {
             StatusBarItem::Help => self.show_status_help = visible,
             StatusBarItem::About => self.show_status_about = visible,
         }
-        self.rebuild_status_hud_layout_from_cached_inputs();
-        self.dirty_tracker.mark_full();
+        self.refresh_status_hud_layout();
         self.needs_redraw = true;
         true
+    }
+
+    /// Recompute the measured cache in place after a content or eligibility
+    /// change, using the inputs of the last rendered frame. Policy (floating
+    /// badge, chrome recovery) stays exact — including width degradation on
+    /// narrow outputs — between the mutation and the next frame, and hover is
+    /// re-derived so a vanished segment cannot stay lit. Damage stays with
+    /// the render effect pass, which re-measures with that frame's inputs.
+    pub(crate) fn refresh_status_hud_layout(&mut self) {
+        let Some(inputs) = self.status_hud_rebuild_inputs.clone() else {
+            self.status_hud_layout = None;
+            self.status_hud_hover = None;
+            return;
+        };
+        self.update_status_hud_layout_for_pointer(
+            inputs.position,
+            &inputs.style,
+            inputs.screen_width,
+            inputs.screen_height,
+            false,
+        );
     }
 
     pub fn status_hud_layout(&self) -> Option<&StatusHudLayout> {
@@ -142,20 +151,6 @@ impl InputState {
             // a highlight while the cursor is off-surface or over a toolbar.
             self.needs_redraw = true;
         }
-    }
-
-    fn rebuild_status_hud_layout_from_cached_inputs(&mut self) {
-        let Some(inputs) = self.status_hud_rebuild_inputs.clone() else {
-            self.status_hud_hover = None;
-            return;
-        };
-        self.update_status_hud_layout_for_pointer(
-            inputs.position,
-            &inputs.style,
-            inputs.screen_width,
-            inputs.screen_height,
-            false,
-        );
     }
 
     pub fn clear_status_hud_layout(&mut self) {

--- a/src/input/state/core/tool_controls/toolbar.rs
+++ b/src/input/state/core/tool_controls/toolbar.rs
@@ -36,6 +36,7 @@ impl InputState {
         if visible && self.toolbar_top_display_mode == TopDisplayMode::Hidden {
             self.toolbar_top_display_mode = TopDisplayMode::Full;
         }
+        self.refresh_status_hud_layout();
         self.needs_redraw = true;
         true
     }
@@ -293,6 +294,7 @@ impl InputState {
     /// the strip's menus, like minimize does.
     pub(crate) fn set_top_display_mode(&mut self, mode: TopDisplayMode) {
         self.toolbar_top_display_mode = mode;
+        self.refresh_status_hud_layout();
         match mode {
             TopDisplayMode::Full => {
                 self.show_top_strip_surface();

--- a/src/input/state/tests/status_hud.rs
+++ b/src/input/state/tests/status_hud.rs
@@ -412,6 +412,46 @@ fn disabling_every_content_item_removes_the_hud_and_restores_badge_fallback() {
 }
 
 #[test]
+fn changing_status_hud_content_leaves_damage_to_the_effect_pass() {
+    let mut input = create_test_input_state();
+    input.update_screen_dimensions(1280, 720);
+    update_hud_layout(&mut input, 1280, 720);
+    let _ = input.take_dirty_region_report();
+
+    assert!(input.set_status_bar_item_visible(StatusBarItem::About, false));
+
+    assert!(input.needs_redraw, "the HUD change still schedules a frame");
+    assert!(
+        input.take_dirty_region_report().regions.is_empty(),
+        "the render effect pass owns the old/new HUD footprint damage"
+    );
+}
+
+#[test]
+fn changing_status_hud_master_or_interactivity_leaves_damage_to_the_effect_pass() {
+    let mut input = create_test_input_state();
+    input.update_screen_dimensions(1280, 720);
+    update_hud_layout(&mut input, 1280, 720);
+    let _ = input.take_dirty_region_report();
+
+    assert!(
+        input.apply_toolbar_event(crate::ui::toolbar::ToolbarEvent::SetStatusBarInteractive(
+            false,
+        ))
+    );
+    assert!(
+        input.take_dirty_region_report().regions.is_empty(),
+        "interactivity only changes pixels inside the HUD footprint"
+    );
+
+    assert!(input.apply_toolbar_event(crate::ui::toolbar::ToolbarEvent::ToggleStatusBar(false)));
+    assert!(
+        input.take_dirty_region_report().regions.is_empty(),
+        "the effect pass owns HUD and fallback transitions"
+    );
+}
+
+#[test]
 fn status_hud_press_routing_consumes_left_press_over_interactive_hud() {
     let mut input = create_test_input_state();
     update_hud_layout(&mut input, 1280, 720);

--- a/src/input/state/tests/toolbar_display.rs
+++ b/src/input/state/tests/toolbar_display.rs
@@ -213,7 +213,10 @@ fn enabled_but_empty_status_bar_does_not_suppress_chrome_recovery_warning() {
         state.status_hud_layout().is_some(),
         "enabling content refreshes an empty cache before the next frame"
     );
-    assert!(state.status_hud_effectively_visible());
+    assert!(
+        state.status_hud_effectively_visible(),
+        "policy sees the synchronously refreshed measured cache"
+    );
     assert!(state.set_status_bar_item_visible(StatusBarItem::About, false));
 
     state.handle_action(Action::ToggleToolbar);
@@ -223,6 +226,36 @@ fn enabled_but_empty_status_bar_does_not_suppress_chrome_recovery_warning() {
     assert_eq!(
         toast.action.as_ref().map(|action| action.action),
         Some(Action::ToggleToolbar)
+    );
+}
+
+/// An About-only HUD on an 80px-wide output is shed entirely by the width
+/// budget (`shedding_the_last_optional_piece_does_not_leave_an_empty_pill`).
+/// The policy predicate must agree immediately after the content toggle, so a
+/// floating badge or all-chrome recovery warning is never suppressed for a
+/// HUD the next frame will not draw.
+#[test]
+fn width_shed_content_never_reports_an_effectively_visible_hud() {
+    let mut state = create_test_input_state();
+    for item in StatusBarItem::ALL {
+        state.set_status_bar_item_visible(item, false);
+    }
+    state.update_status_hud_layout(
+        StatusPosition::BottomLeft,
+        &StatusBarStyle::default(),
+        80,
+        60,
+    );
+    assert!(state.status_hud_layout().is_none());
+
+    assert!(state.set_status_bar_item_visible(StatusBarItem::About, true));
+    assert!(
+        state.status_hud_layout().is_none(),
+        "the narrow output sheds the About-only HUD entirely"
+    );
+    assert!(
+        !state.status_hud_effectively_visible(),
+        "policy must not report a HUD the width budget has shed"
     );
 }
 

--- a/src/toolbar_gtk/view/sections/settings_pane.rs
+++ b/src/toolbar_gtk/view/sections/settings_pane.rs
@@ -2,17 +2,16 @@
 //! button grid, and the toolbar-item customization sub-panel (group
 //! chooser plus per-item show/hide and reorder rows).
 
-use std::cell::{Cell, RefCell};
-use std::rc::Rc;
-
 use gtk4::prelude::*;
 
 use crate::toolbar_icons;
-use crate::ui::toolbar::{ToolbarEvent, ToolbarSideSection, model};
+use crate::ui::toolbar::{ToolbarEvent, ToolbarSideSection, ToolbarSnapshot, model};
 
 use super::super::super::icons::{IconPainter, IconWidget};
 use super::super::super::widgets::{send_event, set_active_class, text_button};
 use super::{SectionCtx, section_card};
+
+type SettingsModelSource = fn(&ToolbarSnapshot) -> Option<model::ToolbarSettingsModel>;
 
 pub(in crate::toolbar_gtk) fn build(ctx: &mut SectionCtx) -> Option<gtk4::Widget> {
     let settings_model = model::ToolbarSettingsModel::from_snapshot(ctx.snapshot)?;
@@ -28,27 +27,38 @@ pub(in crate::toolbar_gtk) fn build(ctx: &mut SectionCtx) -> Option<gtk4::Widget
         // even while the Settings section is flagged collapsed.
         card.body.set_visible(true);
     }
-    card.body.append(&content(ctx, &settings_model));
+    card.body.append(&content(
+        ctx,
+        &settings_model,
+        model::ToolbarSettingsModel::from_snapshot,
+    ));
     Some(card.root.upcast())
 }
 
 /// The pane's content for the top strip's Settings popover: identical
-/// controls without the collapsible-card chrome. Live updates come from
-/// content-key rebuilds in the popover host; the updaters registered here
-/// go to a scratch list the host discards.
+/// controls without the collapsible-card chrome. The popover host retains the
+/// registered updaters so ordinary checkbox echoes update in place.
 pub(in crate::toolbar_gtk) fn build_popover_content(
     ctx: &mut SectionCtx,
     settings_model: &model::ToolbarSettingsModel,
 ) -> gtk4::Box {
-    content(ctx, settings_model)
+    content(
+        ctx,
+        settings_model,
+        model::ToolbarSettingsModel::for_popover,
+    )
 }
 
-fn content(ctx: &mut SectionCtx, settings_model: &model::ToolbarSettingsModel) -> gtk4::Box {
+fn content(
+    ctx: &mut SectionCtx,
+    settings_model: &model::ToolbarSettingsModel,
+    model_source: SettingsModelSource,
+) -> gtk4::Box {
     let column = gtk4::Box::new(gtk4::Orientation::Vertical, ctx.px(6.0));
     if !ctx.snapshot.customize_items_open {
         column.append(&layout_mode_segments(ctx));
     }
-    if let Some(grid) = toggle_grid(ctx, settings_model) {
+    if let Some(grid) = toggle_grid(ctx, settings_model, model_source) {
         column.append(&grid);
     }
     for notice in settings_model.notices() {
@@ -117,13 +127,40 @@ fn layout_mode_segments(ctx: &mut SectionCtx) -> gtk4::Box {
     row
 }
 
-/// Handle keeping one settings toggle in sync: the checked state follows
-/// the snapshot and the pending event always flips the latest value.
+/// Handle keeping one settings toggle in sync: the checked state follows the
+/// snapshot while its signal emits the widget's current value.
 struct ToggleSync {
     id: model::ToolbarControlId,
     check: gtk4::CheckButton,
-    event: Rc<RefCell<ToolbarEvent>>,
-    syncing: Rc<Cell<bool>>,
+    handler: gtk4::glib::SignalHandlerId,
+}
+
+fn settings_toggle_event(template: &ToolbarEvent, checked: bool) -> ToolbarEvent {
+    match template {
+        ToolbarEvent::ToggleContextAwareUi(_) => ToolbarEvent::ToggleContextAwareUi(checked),
+        ToolbarEvent::ToggleIconMode(_) => ToolbarEvent::ToggleIconMode(checked),
+        ToolbarEvent::ToggleTextControls(_) => ToolbarEvent::ToggleTextControls(checked),
+        ToolbarEvent::ToggleStatusBar(_) => ToolbarEvent::ToggleStatusBar(checked),
+        ToolbarEvent::ToggleFloatingBadgeAlways(_) => {
+            ToolbarEvent::ToggleFloatingBadgeAlways(checked)
+        }
+        ToolbarEvent::TogglePresetToasts(_) => ToolbarEvent::TogglePresetToasts(checked),
+        ToolbarEvent::TogglePresets(_) => ToolbarEvent::TogglePresets(checked),
+        ToolbarEvent::ToggleActionsSection(_) => ToolbarEvent::ToggleActionsSection(checked),
+        ToolbarEvent::ToggleZoomActions(_) => ToolbarEvent::ToggleZoomActions(checked),
+        ToolbarEvent::ToggleActionsAdvanced(_) => ToolbarEvent::ToggleActionsAdvanced(checked),
+        ToolbarEvent::ToggleBoardsSection(_) => ToolbarEvent::ToggleBoardsSection(checked),
+        ToolbarEvent::TogglePagesSection(_) => ToolbarEvent::TogglePagesSection(checked),
+        ToolbarEvent::ToggleStepSection(_) => ToolbarEvent::ToggleStepSection(checked),
+        ToolbarEvent::SetStatusBarInteractive(_) => ToolbarEvent::SetStatusBarInteractive(checked),
+        ToolbarEvent::SetStatusBarItemVisible(item, _) => {
+            ToolbarEvent::SetStatusBarItemVisible(*item, checked)
+        }
+        // Settings toggles are currently all boolean activations. Preserve a
+        // future non-boolean model activation verbatim instead of inventing
+        // semantics in the GTK adapter.
+        event => event.clone(),
+    }
 }
 
 /// Two-column toggle grid: wide toggles span the full row, narrow ones
@@ -131,6 +168,7 @@ struct ToggleSync {
 fn toggle_grid(
     ctx: &mut SectionCtx,
     settings_model: &model::ToolbarSettingsModel,
+    model_source: SettingsModelSource,
 ) -> Option<gtk4::Grid> {
     let rows = settings_model.toggle_rows();
     if rows.is_empty() {
@@ -151,40 +189,32 @@ fn toggle_grid(
             if let Some(tooltip) = toggle.tooltip.as_string() {
                 check.set_tooltip_text(Some(&tooltip));
             }
-            let event = Rc::new(RefCell::new(toggle.activation.compatibility_event()));
-            let syncing = Rc::new(Cell::new(false));
+            let event = toggle.activation.compatibility_event();
             let sender = ctx.feedback.clone();
-            let toggle_event = event.clone();
-            let toggle_sync = syncing.clone();
-            check.connect_toggled(move |_| {
-                if !toggle_sync.get() {
-                    let event = toggle_event.borrow().clone();
-                    send_event(&sender, event);
-                }
+            let handler = check.connect_toggled(move |check| {
+                send_event(&sender, settings_toggle_event(&event, check.is_active()));
             });
             let width = if full_row { 2 } else { 1 };
             grid.attach(&check, col as i32, row_index as i32, width, 1);
             handles.push(ToggleSync {
                 id: toggle.id,
                 check,
-                event,
-                syncing,
+                handler,
             });
         }
     }
     ctx.updaters.push(Box::new(move |snapshot| {
-        let Some(fresh) = model::ToolbarSettingsModel::from_snapshot(snapshot) else {
+        let Some(fresh) = model_source(snapshot) else {
             return;
         };
         for handle in &handles {
             let Some(toggle) = fresh.toggles().iter().find(|toggle| toggle.id == handle.id) else {
                 continue;
             };
-            *handle.event.borrow_mut() = toggle.activation.compatibility_event();
             if handle.check.is_active() != toggle.checked {
-                handle.syncing.set(true);
+                handle.check.block_signal(&handle.handler);
                 handle.check.set_active(toggle.checked);
-                handle.syncing.set(false);
+                handle.check.unblock_signal(&handle.handler);
             }
         }
     }));

--- a/src/toolbar_gtk/view/top_bar.rs
+++ b/src/toolbar_gtk/view/top_bar.rs
@@ -98,10 +98,8 @@ type OverflowContentKey = (Tool, Option<Tool>, bool, bool, bool, bool, bool, boo
 
 /// Snapshot inputs the Canvas popover content renders from — the Boards /
 /// Pages / Advanced / Zoom command sections plus the Step Undo/Redo config
-/// are a pure function of these (per-button hidden overrides live in
-/// `StructureKey.items`, which rebuilds the whole bar). Enabled states and
-/// glyph faces that shift without a structure rebuild are captured so the
-/// popover stays fresh.
+/// are a pure function of these. Enabled states and glyph faces that shift
+/// without a structure rebuild are captured so the popover stays fresh.
 ///
 /// The four delay-slider *values* (`custom_undo_delay_ms`,
 /// `custom_redo_delay_ms`, `undo_all_delay_ms`, `redo_all_delay_ms`) are
@@ -115,6 +113,7 @@ type OverflowContentKey = (Tool, Option<Tool>, bool, bool, bool, bool, bool, boo
 /// harmless there.
 #[derive(PartialEq)]
 struct CanvasMenuContentKey {
+    items: crate::config::ResolvedToolbarItems,
     use_icons: bool,
     show_boards_section: bool,
     show_pages_section: bool,
@@ -140,6 +139,7 @@ struct CanvasMenuContentKey {
 impl CanvasMenuContentKey {
     fn of(snapshot: &ToolbarSnapshot) -> Self {
         Self {
+            items: snapshot.resolved_toolbar_items.clone(),
             use_icons: snapshot.use_icons,
             show_boards_section: snapshot.show_boards_section,
             show_pages_section: snapshot.show_pages_section,
@@ -164,13 +164,13 @@ impl CanvasMenuContentKey {
     }
 }
 
-/// Snapshot inputs the Session popover content renders from — the session
-/// model is a pure function of these (plus structural inputs already in
-/// `StructureKey`). `use_icons` is captured directly: the pane's action
-/// buttons render icon+label in icon mode, and `StructureKey.use_icons`
-/// (`use_icons || plan.compact`) can mask a flip while the plan is compact.
+/// Snapshot inputs the Session popover content renders from — including the
+/// resolved visibility settings for its buttons. `use_icons` is captured
+/// directly because the pane's action buttons render differently in icon and
+/// text modes.
 #[derive(PartialEq)]
 struct SessionMenuContentKey {
+    items: crate::config::ResolvedToolbarItems,
     active_session_name: Option<String>,
     active_session_path: Option<std::path::PathBuf>,
     recent_sessions: Vec<crate::ui::toolbar::SessionRecentSnapshot>,
@@ -181,6 +181,7 @@ struct SessionMenuContentKey {
 impl SessionMenuContentKey {
     fn of(snapshot: &ToolbarSnapshot) -> Self {
         Self {
+            items: snapshot.resolved_toolbar_items.clone(),
             active_session_name: snapshot.active_session_name.clone(),
             active_session_path: snapshot.active_session_path.clone(),
             recent_sessions: snapshot.recent_sessions.clone(),
@@ -190,43 +191,23 @@ impl SessionMenuContentKey {
     }
 }
 
-/// Snapshot inputs the Settings popover content renders from — the settings
-/// model reads these toggle/customization fields on top of the structural
-/// inputs already captured by `StructureKey`.
+/// Snapshot inputs that change the Settings popover's widget structure.
+/// Ordinary checkbox values deliberately stay out of this key: persistent
+/// updaters keep their checked state and next event current without replacing
+/// the popover subtree after every click.
 #[derive(PartialEq)]
 struct SettingsMenuContentKey {
-    /// Drives the "Icon buttons" checkbox state and its baked
-    /// `ToggleIconMode(!use_icons)` event (plus icon-vs-text button
-    /// rendering). Captured directly because `StructureKey.use_icons` is
-    /// `use_icons || plan.compact`, which masks a flip while the plan is
-    /// compact — without this field the stored event goes stale.
+    /// Settings action buttons render differently in icon and text mode.
     use_icons: bool,
-    context_aware_ui: bool,
-    show_text_controls: bool,
-    show_status_bar: bool,
-    status_bar_interactive: bool,
-    show_active_output_badge: bool,
-    show_status_selection_info: bool,
-    show_status_board_badge: bool,
-    show_status_page_badge: bool,
-    show_status_color: bool,
-    show_status_tool: bool,
-    show_status_size: bool,
-    show_status_context_indicators: bool,
-    show_toolbar_hint: bool,
-    show_status_help: bool,
-    show_status_about: bool,
-    show_floating_badge_always: bool,
-    show_preset_toasts: bool,
-    show_presets: bool,
-    show_actions_section: bool,
-    show_zoom_actions: bool,
-    show_actions_advanced: bool,
-    show_boards_section: bool,
-    show_pages_section: bool,
-    show_step_section: bool,
     customize_items_open: bool,
     customize_items_group: Option<crate::ui::toolbar::ToolbarItemCustomizeGroup>,
+    /// The resolved item store is structural for every Settings pane: the
+    /// main page filters its toggle grid and offers "Restore built-in
+    /// visibility" from it, and the customization rows bake visibility,
+    /// ordering, and button enabled state into their widgets. Restoring
+    /// visibility keeps the popover open, so the controls it revives can
+    /// only appear through a keyed rebuild.
+    items: crate::config::ResolvedToolbarItems,
     status_bar_contents_open: bool,
     layout_mode: ToolbarLayoutMode,
     runtime_ui_persistence: Option<crate::ui::toolbar::RuntimeUiPersistenceSnapshot>,
@@ -236,32 +217,9 @@ impl SettingsMenuContentKey {
     fn of(snapshot: &ToolbarSnapshot) -> Self {
         Self {
             use_icons: snapshot.use_icons,
-            context_aware_ui: snapshot.context_aware_ui,
-            show_text_controls: snapshot.show_text_controls,
-            show_status_bar: snapshot.show_status_bar,
-            status_bar_interactive: snapshot.status_bar_interactive,
-            show_active_output_badge: snapshot.show_active_output_badge,
-            show_status_selection_info: snapshot.show_status_selection_info,
-            show_status_board_badge: snapshot.show_status_board_badge,
-            show_status_page_badge: snapshot.show_status_page_badge,
-            show_status_color: snapshot.show_status_color,
-            show_status_tool: snapshot.show_status_tool,
-            show_status_size: snapshot.show_status_size,
-            show_status_context_indicators: snapshot.show_status_context_indicators,
-            show_toolbar_hint: snapshot.show_toolbar_hint,
-            show_status_help: snapshot.show_status_help,
-            show_status_about: snapshot.show_status_about,
-            show_floating_badge_always: snapshot.show_floating_badge_always,
-            show_preset_toasts: snapshot.show_preset_toasts,
-            show_presets: snapshot.show_presets,
-            show_actions_section: snapshot.show_actions_section,
-            show_zoom_actions: snapshot.show_zoom_actions,
-            show_actions_advanced: snapshot.show_actions_advanced,
-            show_boards_section: snapshot.show_boards_section,
-            show_pages_section: snapshot.show_pages_section,
-            show_step_section: snapshot.show_step_section,
             customize_items_open: snapshot.customize_items_open,
             customize_items_group: snapshot.customize_items_group,
+            items: snapshot.resolved_toolbar_items.clone(),
             status_bar_contents_open: snapshot.status_bar_contents_open,
             layout_mode: snapshot.layout_mode,
             runtime_ui_persistence: snapshot.runtime_ui_persistence.clone(),
@@ -287,7 +245,9 @@ struct StructureKey {
     use_icons: bool,
     layout_mode: ToolbarLayoutMode,
     scale_milli: i64,
-    items: crate::config::ResolvedToolbarItems,
+    /// Exact renderer-neutral top structure. Using the full resolved item store
+    /// here made side-only section changes tear down this bar and its popovers.
+    top_spec: model::TopToolbarSpec,
     quick_colors: crate::config::QuickColorPalette,
     binding_hints: crate::ui::toolbar::ToolbarBindingHints,
     plan: TopStripPlan,
@@ -312,7 +272,7 @@ impl StructureKey {
             use_icons: snapshot.use_icons || plan.compact,
             layout_mode: snapshot.layout_mode,
             scale_milli: (effective_scale(snapshot) * 1000.0).round() as i64,
-            items: snapshot.resolved_toolbar_items.clone(),
+            top_spec: model::TopToolbarSpec::build(snapshot, plan),
             quick_colors: snapshot.quick_colors.clone(),
             binding_hints: snapshot.binding_hints.clone(),
             plan: plan.clone(),
@@ -384,13 +344,15 @@ pub(in crate::toolbar_gtk) struct TopBar {
     capture_surface: CaptureSurfaceContent,
     structure: Option<StructureKey>,
     updaters: Rc<RefCell<Vec<Updater>>>,
-    /// Persistent value-updaters for the open Canvas popover's content. Unlike
-    /// the Session/Settings popovers (whose whole subtree rebuilds on any
-    /// modelled change), the Canvas popover hosts the continuously-dragged
-    /// delay sliders: their live values ride these updaters so a drag never
+    /// Persistent value-updaters for the open Canvas popover's content. The
+    /// continuously-dragged delay sliders ride these updaters so a drag never
     /// triggers a subtree rebuild. Repopulated whenever the popover content is
     /// (re)built; run every `apply`.
     canvas_updaters: Rc<RefCell<Vec<Updater>>>,
+    /// Persistent value-updaters for the open Settings popover. Checkbox
+    /// values and their next events change in place; only structural menu
+    /// changes replace the subtree.
+    settings_updaters: Vec<Updater>,
     shapes_popover: Option<gtk4::Popover>,
     shapes_capture_surface: Option<CaptureSurfaceContent>,
     overflow_popover: Option<gtk4::Popover>,
@@ -494,6 +456,7 @@ impl TopBar {
             structure: None,
             updaters: Rc::new(RefCell::new(Vec::new())),
             canvas_updaters: Rc::new(RefCell::new(Vec::new())),
+            settings_updaters: Vec::new(),
             shapes_popover: None,
             shapes_capture_surface: None,
             overflow_popover: None,
@@ -610,6 +573,11 @@ impl TopBar {
         for updater in self.canvas_updaters.borrow().iter() {
             updater(snapshot);
         }
+        if snapshot.settings_popover_open {
+            for updater in &self.settings_updaters {
+                updater(snapshot);
+            }
+        }
         self.window.set_visible(true);
         self.capture_surface
             .set_transparent(presentation.capture_transparent);
@@ -711,6 +679,7 @@ impl TopBar {
         // value-updaters (which capture those now-dead widgets) must go too;
         // a fresh open repopulates them.
         self.canvas_updaters.borrow_mut().clear();
+        self.settings_updaters.clear();
 
         if snapshot.top_minimized {
             self.build_minimized(snapshot, plan);

--- a/src/toolbar_gtk/view/top_bar/popovers.rs
+++ b/src/toolbar_gtk/view/top_bar/popovers.rs
@@ -297,10 +297,12 @@ impl TopBar {
             if open {
                 let content_key = SettingsMenuContentKey::of(snapshot);
                 if self.settings_content_key.borrow().as_ref() != Some(&content_key) {
+                    let (content, updaters) = self.build_settings_popover_content(snapshot, scale);
                     self.settings_capture_surface
                         .as_ref()
                         .expect("settings popover capture surface")
-                        .set_content(&self.build_settings_popover_content(snapshot, scale));
+                        .set_content(&content);
+                    self.settings_updaters = updaters;
                     *self.settings_content_key.borrow_mut() = Some(content_key);
                 }
             }
@@ -387,14 +389,14 @@ impl TopBar {
         &self,
         snapshot: &ToolbarSnapshot,
         scale: f64,
-    ) -> gtk4::Widget {
-        let mut scratch_updaters = Vec::new();
+    ) -> (gtk4::Widget, Vec<Updater>) {
+        let mut updaters = Vec::new();
         let mut ctx = super::super::sections::SectionCtx {
             snapshot,
             feedback: self.feedback.clone(),
             scale,
             use_icons: snapshot.use_icons,
-            updaters: &mut scratch_updaters,
+            updaters: &mut updaters,
         };
         let content = match model::ToolbarSettingsModel::for_popover(snapshot) {
             Some(settings) => {
@@ -402,13 +404,14 @@ impl TopBar {
             }
             None => gtk4::Box::new(gtk4::Orientation::Vertical, 0),
         };
-        menu_popover_viewport(
+        let widget = menu_popover_viewport(
             &content,
             "top.menu.settings.panel",
             MENU_CONTENT_W,
             scale,
             &self.feedback,
-        )
+        );
+        (widget, updaters)
     }
 
     pub(super) fn build_shapes_popover_content(

--- a/src/toolbar_gtk/view/top_bar/tests.rs
+++ b/src/toolbar_gtk/view/top_bar/tests.rs
@@ -5,7 +5,7 @@ use std::ffi::{CStr, CString};
 use std::time::Duration;
 
 use super::*;
-use crate::config::KeyBinding;
+use crate::config::{KeyBinding, ToolbarSectionFlag, toolbar_item_ids as ids};
 use crate::input::state::test_support::make_test_input_state;
 use crate::toolbar_gtk::widgets::{emit_secondary_press, secondary_click_gesture};
 use crate::ui::toolbar::{
@@ -38,14 +38,10 @@ fn top_structure_rebuilds_when_current_shortcuts_change() {
     assert_eq!(changed.binding_hints.badge_for_tool(Tool::Pen), Some("9"));
 }
 
-/// `StructureKey.use_icons` is `use_icons || plan.compact`, so a compact
-/// plan masks an icon-mode flip from the structural rebuild. The popover
-/// content keys must therefore track `use_icons` themselves: the Settings
-/// "Icon buttons" checkbox bakes `ToggleIconMode(!use_icons)` at build
-/// time and would otherwise re-emit the stale pre-flip value, and both
-/// popovers render icon-vs-text button bodies from it.
+/// Popover content keys track `use_icons` directly because their action
+/// buttons render differently in icon and text modes.
 #[test]
-fn popover_content_keys_track_icon_mode_even_when_the_compact_plan_masks_it() {
+fn popover_content_keys_track_icon_mode() {
     let mut state = make_test_input_state();
     state.toolbar_use_icons = false;
     let text_mode = ToolbarSnapshot::from_input_with_bindings(
@@ -56,15 +52,6 @@ fn popover_content_keys_track_icon_mode_even_when_the_compact_plan_masks_it() {
     let icon_mode = ToolbarSnapshot::from_input_with_bindings(
         &state,
         ToolbarBindingHints::from_input_state(&state),
-    );
-
-    // The masking scenario is real: under a compact plan the structure key
-    // cannot tell the two snapshots apart.
-    let mut compact_plan = TopStripPlan::unconstrained();
-    compact_plan.compact = true;
-    assert!(
-        StructureKey::of(&text_mode, &compact_plan) == StructureKey::of(&icon_mode, &compact_plan),
-        "compact plan masks the icon-mode flip from the structural rebuild"
     );
 
     assert!(
@@ -121,7 +108,7 @@ fn settings_popover_rebuilds_for_status_bar_contents_subpanel() {
 }
 
 #[test]
-fn settings_popover_rebuilds_when_status_bar_interactivity_changes() {
+fn settings_popover_keeps_content_when_status_bar_interactivity_changes() {
     let state = make_test_input_state();
     let base = ToolbarSnapshot::from_input_with_bindings(
         &state,
@@ -131,13 +118,13 @@ fn settings_popover_rebuilds_when_status_bar_interactivity_changes() {
     changed.status_bar_interactive = !base.status_bar_interactive;
 
     assert!(
-        SettingsMenuContentKey::of(&base) != SettingsMenuContentKey::of(&changed),
-        "changing status-bar interactivity must rebuild the GTK Settings popover"
+        SettingsMenuContentKey::of(&base) == SettingsMenuContentKey::of(&changed),
+        "changing status-bar interactivity must update the existing GTK controls"
     );
 }
 
 #[test]
-fn settings_popover_rebuilds_when_any_status_bar_item_visibility_changes() {
+fn settings_popover_keeps_content_when_any_status_bar_item_visibility_changes() {
     let state = make_test_input_state();
     let base = ToolbarSnapshot::from_input_with_bindings(
         &state,
@@ -173,10 +160,112 @@ fn settings_popover_rebuilds_when_any_status_bar_item_visibility_changes() {
         let mut changed = base.clone();
         mutate(&mut changed);
         assert!(
-            SettingsMenuContentKey::of(&base) != SettingsMenuContentKey::of(&changed),
-            "changing any status item visibility must rebuild the GTK Settings popover"
+            SettingsMenuContentKey::of(&base) == SettingsMenuContentKey::of(&changed),
+            "changing any status item visibility must update the existing GTK controls"
         );
     }
+}
+
+/// The main Settings page filters its toggle grid and offers "Restore
+/// built-in visibility" from the resolved item store, and that button keeps
+/// the popover open. Item-visibility changes must therefore rebuild the
+/// popover content even while the customization sub-panel is closed, or the
+/// restored controls stay missing and the Restore button stays stale.
+#[test]
+fn settings_popover_rebuilds_when_item_visibility_changes_outside_customization() {
+    let state = make_test_input_state();
+    let base = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    assert!(!base.customize_items_open);
+    let mut changed = base.clone();
+    changed
+        .resolved_toolbar_items
+        .hidden
+        .insert(ids::SIDE_SETTINGS_PRESET_TOASTS);
+    changed
+        .resolved_toolbar_items
+        .shown
+        .remove(&ids::SIDE_SETTINGS_PRESET_TOASTS);
+
+    assert!(
+        SettingsMenuContentKey::of(&base) != SettingsMenuContentKey::of(&changed),
+        "hiding or restoring a settings item must rebuild the GTK Settings popover"
+    );
+}
+
+#[test]
+fn top_structure_ignores_side_only_section_visibility_changes() {
+    let state = make_test_input_state();
+    let base = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    let base_key = StructureKey::of(&base, &plan_top_strip(&base));
+
+    for flag in [
+        ToolbarSectionFlag::Actions,
+        ToolbarSectionFlag::ActionsAdvanced,
+        ToolbarSectionFlag::ZoomActions,
+        ToolbarSectionFlag::Pages,
+        ToolbarSectionFlag::Boards,
+        ToolbarSectionFlag::StepSection,
+    ] {
+        let mut changed = base.clone();
+        match flag {
+            ToolbarSectionFlag::Actions => {
+                changed.show_actions_section = !changed.show_actions_section;
+            }
+            ToolbarSectionFlag::ActionsAdvanced => {
+                changed.show_actions_advanced = !changed.show_actions_advanced;
+            }
+            ToolbarSectionFlag::ZoomActions => {
+                changed.show_zoom_actions = !changed.show_zoom_actions;
+            }
+            ToolbarSectionFlag::Pages => {
+                changed.show_pages_section = !changed.show_pages_section;
+            }
+            ToolbarSectionFlag::Boards => {
+                changed.show_boards_section = !changed.show_boards_section;
+            }
+            ToolbarSectionFlag::StepSection => {
+                changed.show_step_section = !changed.show_step_section;
+            }
+            ToolbarSectionFlag::Presets | ToolbarSectionFlag::TextControls => continue,
+        }
+        changed.resolved_toolbar_items.hidden.insert(flag.item_id());
+        changed.resolved_toolbar_items.shown.remove(&flag.item_id());
+        let changed_key = StructureKey::of(&changed, &plan_top_strip(&changed));
+        assert!(
+            base_key == changed_key,
+            "side-only {flag:?} visibility must not rebuild the top bar"
+        );
+    }
+}
+
+#[test]
+fn top_structure_still_tracks_top_item_visibility() {
+    let state = make_test_input_state();
+    let base = ToolbarSnapshot::from_input_with_bindings(
+        &state,
+        ToolbarBindingHints::from_input_state(&state),
+    );
+    let mut changed = base.clone();
+    changed
+        .resolved_toolbar_items
+        .hidden
+        .insert(ids::TOP_TOOL_PEN);
+    changed
+        .resolved_toolbar_items
+        .shown
+        .remove(&ids::TOP_TOOL_PEN);
+
+    assert!(
+        StructureKey::of(&base, &plan_top_strip(&base))
+            != StructureKey::of(&changed, &plan_top_strip(&changed)),
+        "top-item visibility must still rebuild the top bar"
+    );
 }
 
 #[test]
@@ -2114,7 +2203,8 @@ fn actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window() {
     });
     let settings_model =
         model::ToolbarSettingsModel::for_popover(&settings_snapshot).expect("settings model");
-    let settings_content = menu_top.build_settings_popover_content(&settings_snapshot, 1.0);
+    let (settings_content, settings_updaters) =
+        menu_top.build_settings_popover_content(&settings_snapshot, 1.0);
     let settings_scroller = settings_content
         .clone()
         .downcast::<gtk4::ScrolledWindow>()
@@ -2145,6 +2235,25 @@ fn actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window() {
             .expect("GTK settings toggle event"),
         GtkToolbarFeedback::Event {
             event: toggles[0].activation.compatibility_event(),
+            rebind_requested: false,
+        }
+    );
+
+    // Backend echoes update the existing checkbox and replace its next event;
+    // the top popover must not depend on the side palette's active pane.
+    let updated_context_aware = !toggles[0].checked;
+    settings_snapshot.context_aware_ui = updated_context_aware;
+    for updater in &settings_updaters {
+        updater(&settings_snapshot);
+    }
+    assert_eq!(checks[0].is_active(), updated_context_aware);
+    checks[0].set_active(!updated_context_aware);
+    assert_eq!(
+        menu_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("updated GTK settings toggle event"),
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::ToggleContextAwareUi(!updated_context_aware),
             rebind_requested: false,
         }
     );

--- a/src/toolbar_gtk/widgets.rs
+++ b/src/toolbar_gtk/widgets.rs
@@ -280,6 +280,21 @@ fn release_window_keyboard_focus(widget: &impl IsA<gtk4::Widget>) {
     }
 }
 
+/// Whether a focus-widget change should drop the toolbar window's keyboard
+/// mode. Entries keep it: the editable hex field needs the keys it captures.
+/// Focus inside a popover keeps it too, for a different reason: the popover
+/// is an xdg_popup holding a keyboard grab on its own surface. Dropping the
+/// parent layer surface's keyboard mode there makes the compositor pull
+/// keyboard focus from the grabbing popup between a click's press and
+/// release, and that broken grab stalls the release — a Settings checkbox
+/// then takes seconds to toggle. The grab already returns keyboard focus to
+/// the compositor when the popover closes.
+fn focus_change_releases_keyboard(focus: &gtk4::Widget) -> bool {
+    let entry_focused = focus.ancestor(gtk4::Entry::static_type()).is_some();
+    let popover_focused = focus.ancestor(gtk4::Popover::static_type()).is_some();
+    !entry_focused && !popover_focused
+}
+
 /// Drop keyboard ownership when GTK focuses any non-entry control. Buttons
 /// also release from their clicked handler because they are non-focusable and
 /// may leave a previously focused entry as the logical focus widget.
@@ -288,9 +303,7 @@ pub(super) fn install_shortcut_focus_policy(window: &gtk4::Window, feedback: &Fe
         let Some(focus) = gtk4::prelude::GtkWindowExt::focus(window) else {
             return;
         };
-        let entry_focused =
-            focus.is::<gtk4::Entry>() || focus.ancestor(gtk4::Entry::static_type()).is_some();
-        if !entry_focused {
+        if focus_change_releases_keyboard(&focus) {
             release_window_keyboard_focus(window);
         }
     });
@@ -679,52 +692,4 @@ pub(super) fn rounded_rect_path(ctx: &cairo::Context, x: f64, y: f64, w: f64, h:
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn gtk_feedback_carries_rebind_state_once() {
-        let (tx, rx) = std::sync::mpsc::channel();
-        let sender = FeedbackSender::new(tx);
-        sender.set_rebind_state(ToolbarRebindModifier::CtrlShift, true);
-        sender.capture_click_modifiers(
-            gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
-        );
-        send_event(&sender, ToolbarEvent::Undo);
-        send_event(&sender, ToolbarEvent::Redo);
-
-        assert_eq!(
-            rx.recv().unwrap(),
-            GtkToolbarFeedback::Event {
-                event: ToolbarEvent::Undo,
-                rebind_requested: true,
-            }
-        );
-        assert_eq!(
-            rx.recv().unwrap(),
-            GtkToolbarFeedback::Event {
-                event: ToolbarEvent::Redo,
-                rebind_requested: false,
-            }
-        );
-    }
-
-    #[test]
-    fn backend_modifier_latch_survives_focus_reset_during_click() {
-        let (tx, rx) = std::sync::mpsc::channel();
-        let sender = FeedbackSender::new(tx);
-        sender.set_rebind_state(ToolbarRebindModifier::CtrlShift, true);
-        sender.capture_click_modifiers(gtk4::gdk::ModifierType::empty());
-        sender.set_rebind_state(ToolbarRebindModifier::CtrlShift, false);
-
-        send_event(&sender, ToolbarEvent::Undo);
-
-        assert_eq!(
-            rx.recv().unwrap(),
-            GtkToolbarFeedback::Event {
-                event: ToolbarEvent::Undo,
-                rebind_requested: true,
-            }
-        );
-    }
-}
+mod tests;

--- a/src/toolbar_gtk/widgets/tests.rs
+++ b/src/toolbar_gtk/widgets/tests.rs
@@ -1,0 +1,113 @@
+//! Shared-widget unit tests.
+
+use super::*;
+
+/// Focus moving to a control inside a popover must not drop the layer
+/// surface's keyboard mode: the popup's keyboard grab is live, and
+/// pulling compositor focus from it mid-click stalls the in-flight
+/// button release for seconds. Widget construction needs a GTK display,
+/// so the body runs in an isolated child process the same way the other
+/// GTK widget contract tests do.
+#[test]
+fn popover_internal_focus_keeps_the_keyboard_grab() {
+    const CHILD_ENV: &str = "WAYSCRIBER_GTK_FOCUS_POLICY_CHILD";
+    const TEST_NAME: &str =
+        "toolbar_gtk::widgets::tests::popover_internal_focus_keeps_the_keyboard_grab";
+
+    if std::env::var_os(CHILD_ENV).is_none() {
+        let status = std::process::Command::new(std::env::current_exe().expect("test binary"))
+            .arg(TEST_NAME)
+            .arg("--exact")
+            .arg("--test-threads=1")
+            .env(CHILD_ENV, "1")
+            .status()
+            .expect("run isolated GTK focus-policy test");
+        assert!(status.success(), "isolated GTK focus-policy test failed");
+        return;
+    }
+
+    if let Err(error) = gtk4::init() {
+        eprintln!("skipping GTK focus-policy test: {error}");
+        return;
+    }
+
+    let bar = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+    let bar_button = gtk4::Button::new();
+    let bar_entry = gtk4::Entry::new();
+    bar.append(&bar_button);
+    bar.append(&bar_entry);
+
+    let popover_body = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    let popover_check = gtk4::CheckButton::new();
+    let popover_entry = gtk4::Entry::new();
+    popover_body.append(&popover_check);
+    popover_body.append(&popover_entry);
+    let popover = gtk4::Popover::new();
+    popover.set_child(Some(&popover_body));
+    popover.set_parent(&bar);
+
+    assert!(
+        focus_change_releases_keyboard(bar_button.upcast_ref()),
+        "a plain bar control must still hand the keyboard back"
+    );
+    assert!(
+        !focus_change_releases_keyboard(bar_entry.upcast_ref()),
+        "the editable hex field keeps keyboard focus"
+    );
+    assert!(
+        !focus_change_releases_keyboard(popover_check.upcast_ref()),
+        "a popover checkbox must not break the popup's keyboard grab"
+    );
+    assert!(
+        !focus_change_releases_keyboard(popover_entry.upcast_ref()),
+        "a popover entry keeps the grab and its text input"
+    );
+
+    popover.unparent();
+}
+
+#[test]
+fn gtk_feedback_carries_rebind_state_once() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let sender = FeedbackSender::new(tx);
+    sender.set_rebind_state(ToolbarRebindModifier::CtrlShift, true);
+    sender.capture_click_modifiers(
+        gtk4::gdk::ModifierType::CONTROL_MASK | gtk4::gdk::ModifierType::SHIFT_MASK,
+    );
+    send_event(&sender, ToolbarEvent::Undo);
+    send_event(&sender, ToolbarEvent::Redo);
+
+    assert_eq!(
+        rx.recv().unwrap(),
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::Undo,
+            rebind_requested: true,
+        }
+    );
+    assert_eq!(
+        rx.recv().unwrap(),
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::Redo,
+            rebind_requested: false,
+        }
+    );
+}
+
+#[test]
+fn backend_modifier_latch_survives_focus_reset_during_click() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let sender = FeedbackSender::new(tx);
+    sender.set_rebind_state(ToolbarRebindModifier::CtrlShift, true);
+    sender.capture_click_modifiers(gtk4::gdk::ModifierType::empty());
+    sender.set_rebind_state(ToolbarRebindModifier::CtrlShift, false);
+
+    send_event(&sender, ToolbarEvent::Undo);
+
+    assert_eq!(
+        rx.recv().unwrap(),
+        GtkToolbarFeedback::Event {
+            event: ToolbarEvent::Undo,
+            rebind_requested: true,
+        }
+    );
+}

--- a/src/ui/toolbar/apply/layout.rs
+++ b/src/ui/toolbar/apply/layout.rs
@@ -227,7 +227,7 @@ impl InputState {
         self.break_focus_mode();
         if self.show_status_bar != show {
             self.show_status_bar = show;
-            self.dirty_tracker.mark_full();
+            self.refresh_status_hud_layout();
             self.needs_redraw = true;
             true
         } else {
@@ -241,7 +241,6 @@ impl InputState {
         }
         self.status_bar_interactive = interactive;
         self.status_hud_hover = None;
-        self.dirty_tracker.mark_full();
         self.needs_redraw = true;
         true
     }


### PR DESCRIPTION
## Summary

Make GTK Settings controls respond immediately by removing blocking persistence, unnecessary widget rebuilds, and keyboard-focus churn during popover clicks.

## Changes

- Persist runtime configuration through a single background writer that:
  - batches nearby typed mutations
  - reloads the latest config document before writing
  - preserves externally edited and unknown settings
  - retries failed writes and flushes pending changes during shutdown
- Keep Settings checkboxes alive and synchronize their values in place instead of rebuilding the popover after every backend echo.
- Restrict top-toolbar rebuilds to structural changes while updating value-only state through persistent widget updaters.
- Invalidate status-HUD geometry cheaply and rebuild it during the normal UI effect pass.
- Preserve the popup keyboard grab while focus is inside a popover, avoiding a layer-shell keyboard-mode transition between pointer press and release.
- Retain the existing focus-release behavior for normal toolbar controls and editable fields.

## Result

On Hyprland, the worst observed Settings checkbox press-to-toggle delay dropped from 4,290 ms to 96 ms, with no focus-out events during popover clicks.

Value-only settings such as status items, interactivity, badges, and preset toasts no longer rebuild toolbar widget trees. Toggles that genuinely change structure still rebuild the affected bar or pane.