### PR TITLE
Prevent toolbar persistence loss during capture, recovery, and shutdown

### DIFF
--- a/src/backend/wayland/backend/event_loop/capture.rs
+++ b/src/backend/wayland/backend/event_loop/capture.rs
@@ -124,17 +124,9 @@ pub(super) fn handle_pending_actions(
             PendingBackendAction::ClearSavedToolState => {
                 state.handle_clear_saved_tool_state_action();
             }
-            PendingBackendAction::PersistToolbarDisplayMode(previous) => {
-                state.persist_toolbar_display_mode(previous);
-            }
-            PendingBackendAction::PersistToolbarVisibility {
-                previous_top_pinned,
-                previous_side_pinned,
-            } => {
-                state.persist_toolbar_visibility(previous_top_pinned, previous_side_pinned);
-            }
         }
     }
+    state.drain_pending_toolbar_persistence();
     if let Some(action) = state.input_state.take_pending_output_focus_action() {
         state.handle_output_focus_action(qh, action);
     }

--- a/src/backend/wayland/backend/event_loop/mod.rs
+++ b/src/backend/wayland/backend/event_loop/mod.rs
@@ -130,13 +130,15 @@ pub(super) fn run_event_loop(
         let command_palette_repeat_timeout = state.input_state.command_palette_repeat_timeout(now);
         let capture_timeout = capture::capture_timeout(state, now);
         let durable_action_timeout = durable_action_retry_timeout(state, now);
-        // Backend output actions are drained one at a time. If one remains,
-        // loop immediately even when VSync is disabled and the preceding
-        // action's redraw cleared `needs_redraw`.
-        let pending_backend_action_timeout = state
-            .input_state
-            .has_pending_backend_actions()
-            .then_some(Duration::ZERO);
+        // Backend output actions are drained one at a time, and the toolbar
+        // persistence queue drains on the same pass. If either holds
+        // drainable work, loop immediately even when VSync is disabled and
+        // the preceding action's redraw cleared `needs_redraw`. Entries
+        // deferred behind a runtime-state barrier are not drainable — the
+        // writer completion that resolves the barrier wakes the loop.
+        let pending_backend_action_timeout = (state.input_state.has_pending_backend_actions()
+            || state.toolbar_persistence_drain_ready())
+        .then_some(Duration::ZERO);
         let timeout = if should_block {
             min_timeout(autosave_timeout, focus_exit_timeout)
         } else if !vsync_enabled && state.input_state.needs_redraw {
@@ -329,6 +331,14 @@ pub(super) fn run_event_loop(
                 warn!("Failed to save session state: {}", err);
                 session_save::notify_session_failure(state, &err);
             }
+            // Every exit path funnels here, including the post-dispatch break
+            // that runs before the in-loop drain, so a toolbar toggle pressed
+            // in the same batch as the exit request is still queued. The
+            // teardown variant also settles an in-flight reset/recovery
+            // barrier first — its resolving completion was going to be waited
+            // for below anyway — so exiting mid-reset cannot cost a deferred
+            // toggle its write; the writer flush then carries it to disk.
+            state.drain_toolbar_persistence_for_teardown();
             state.shutdown_runtime_ui();
             // An edit made a moment before quitting still has to reach the file,
             // so teardown waits — briefly — for the worker's queue to drain.

--- a/src/backend/wayland/runtime_ui_state/coordinator.rs
+++ b/src/backend/wayland/runtime_ui_state/coordinator.rs
@@ -89,6 +89,16 @@ impl ToolbarRuntimeState {
         apply_live_board_state(input, self.controller.live_state(), |_| true);
     }
 
+    /// Whether a reset/recovery barrier currently rejects new mutations.
+    ///
+    /// The toolbar persistence drain checks this before taking queued
+    /// entries: `begin` would refuse them with `ControllerBusy`, and an
+    /// entry taken-then-refused is silently lost instead of retried after
+    /// the barrier resolves.
+    pub(in crate::backend::wayland) fn mutation_barrier_active(&self) -> bool {
+        self.controller.active_barrier().is_some()
+    }
+
     pub(in crate::backend::wayland) fn begin_toolbar_mutation(
         &self,
         target: ToolbarRuntimeUiPersistenceTarget,
@@ -372,6 +382,47 @@ impl ToolbarRuntimeState {
                     drain.rebuild_live = true;
                 }
             }
+        }
+    }
+
+    /// Blockingly settle an active barrier whose resolution is writer work
+    /// away, integrating completions exactly as the event loop would have.
+    /// Called at teardown BEFORE the toolbar persistence drain: exiting
+    /// mid-reset (or mid-recovery — a `RetryPending` inspection counts,
+    /// which is why the recovery outbox and active attempt gate the loop
+    /// alongside the pipeline) must not cost a queued toggle its write
+    /// when the resolving completions are ones `shutdown_blocking` was
+    /// going to wait for anyway. The predicate re-evaluates after every
+    /// completion and goes false on resting states only a controller-side
+    /// decision can advance — an unhealthy incident with no attempt
+    /// running — so those cannot hang exit; no write can land under them
+    /// anyway.
+    pub(in crate::backend::wayland) fn settle_barrier_for_teardown(&mut self) {
+        while self.controller.active_barrier().is_some()
+            && (self.controller.barrier_settling_work_in_flight()
+                || self.pending_writer_command.is_some())
+        {
+            if self.writer.is_none() {
+                return;
+            }
+            // The command owning the barrier may still be sitting in an
+            // outbox (pipeline or recovery); the writer only answers what
+            // it was sent.
+            self.dispatch_writer_command();
+            let Some(writer) = self.writer.as_ref() else {
+                return;
+            };
+            let completion = match writer.recv() {
+                Ok(completion) => completion,
+                Err(error) => {
+                    log::error!(
+                        "Runtime UI writer stopped while settling a barrier for teardown: {error}"
+                    );
+                    return;
+                }
+            };
+            self.integrate_writer_completion(completion);
+            self.poll_recovery_completion();
         }
     }
 

--- a/src/backend/wayland/runtime_ui_state/tests.rs
+++ b/src/backend/wayland/runtime_ui_state/tests.rs
@@ -2103,6 +2103,9 @@ fn a_stored_display_mode_is_restored_at_startup_over_the_config_seed() {
 /// exactly what the toggle left on screen.
 #[test]
 fn keyboard_visibility_toggle_persists_both_pins_and_startup_hides_the_toolbar() {
+    use crate::domain::Action;
+    use crate::input::state::PendingToolbarPersistence;
+
     let temp = crate::test_temp::tempdir().unwrap();
     let runtime_path = temp.path().join("runtime-ui.toml");
     let config = Config::default();
@@ -2111,16 +2114,27 @@ fn keyboard_visibility_toggle_persists_both_pins_and_startup_hides_the_toolbar()
     let mut runtime = test_runtime(&config, &runtime_path);
     let accepted_before = runtime.controller.pipeline().latest_accepted();
 
-    // The rollback carries the pre-toggle pins, exactly as the pending
-    // backend action delivers them after the toggle already applied.
+    // Driven through the real F9 arm and its queue: the toggle already
+    // applied, so the drained entry carries the pre-toggle pins, which
+    // supply the write's rollback.
+    input.handle_action(Action::ToggleToolbar);
+    assert!(!input.toolbar_top_pinned && !input.toolbar_side_pinned);
+    assert_eq!(
+        input.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: true,
+            previous_side_pinned: true,
+        }],
+        "F9 must queue exactly one visibility entry carrying the pre-toggle pins"
+    );
     let rollback = RuntimeUiMutationValues::batch([
         (
             InteractionSeedTarget::TopPinned,
-            InteractionSeedValue::Bool(input.toolbar_top_pinned),
+            InteractionSeedValue::Bool(true),
         ),
         (
             InteractionSeedTarget::SidePinned,
-            InteractionSeedValue::Bool(input.toolbar_side_pinned),
+            InteractionSeedValue::Bool(true),
         ),
     ])
     .unwrap();
@@ -2130,8 +2144,6 @@ fn keyboard_visibility_toggle_persists_both_pins_and_startup_hides_the_toolbar()
             rollback,
         )
         .expect("visibility permit");
-    input.toolbar_top_pinned = false;
-    input.toolbar_side_pinned = false;
     assert!(matches!(
         runtime.finish_toolbar_mutation(prepared, true, &input),
         ToolbarRuntimeFinish::KeepPreview
@@ -2165,6 +2177,21 @@ fn keyboard_visibility_toggle_persists_both_pins_and_startup_hides_the_toolbar()
         "both-pins-false overrides start the toolbar hidden"
     );
     restarted.shutdown_blocking();
+}
+
+/// The pre-toggle pins as the visibility toggle's write path batches them.
+fn pins_rollback_values(top: bool, side: bool) -> RuntimeUiMutationValues {
+    RuntimeUiMutationValues::batch([
+        (
+            InteractionSeedTarget::TopPinned,
+            InteractionSeedValue::Bool(top),
+        ),
+        (
+            InteractionSeedTarget::SidePinned,
+            InteractionSeedValue::Bool(side),
+        ),
+    ])
+    .expect("distinct pin targets batch")
 }
 
 /// The pre-toggle pins as the visibility toggle's rollback snapshot carries
@@ -2244,7 +2271,7 @@ fn a_rolled_back_show_toggle_re_hides_the_toolbar() {
 #[test]
 fn a_rolled_back_hide_toggle_keeps_a_cycle_hidden_strip_folded() {
     use crate::domain::Action;
-    use crate::input::state::PendingBackendAction;
+    use crate::input::state::PendingToolbarPersistence;
 
     let config = Config::default();
     let mut input = input_from_config(&config);
@@ -2253,7 +2280,7 @@ fn a_rolled_back_hide_toggle_keeps_a_cycle_hidden_strip_folded() {
     input.handle_action(Action::CycleToolbarDisplay); // micro
     input.handle_action(Action::CycleToolbarDisplay); // hidden
     assert_eq!(input.toolbar_top_display_mode, TopDisplayMode::Hidden);
-    input.take_pending_backend_action(); // drain the cycle's display-mode write
+    input.take_pending_toolbar_persistence(); // drain the cycle's display-mode write
     assert!(
         input.toolbar_visible(),
         "the Panel side palette keeps a surface visible under a cycle-hidden strip"
@@ -2263,11 +2290,11 @@ fn a_rolled_back_hide_toggle_keeps_a_cycle_hidden_strip_folded() {
     assert!(!input.toolbar_visible());
     assert!(!input.toolbar_top_pinned && !input.toolbar_side_pinned);
     assert_eq!(
-        input.take_pending_backend_action(),
-        Some(PendingBackendAction::PersistToolbarVisibility {
+        input.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
             previous_top_pinned: true,
             previous_side_pinned: true,
-        }),
+        }],
         "a pin-changing hide queues its persistence"
     );
 
@@ -2378,6 +2405,267 @@ fn visibility_toggle_rollback_through_a_failed_reset_restores_the_screen() {
     );
 }
 
+/// A toggle pressed while a reset/recovery barrier is active must defer,
+/// not vanish: `begin` refuses new mutations wholesale during the barrier,
+/// so the backend drain leaves the queue untouched until it resolves. Here
+/// the completed reset leaves live state exactly where it was (nothing was
+/// ever persisted), so the deferred entry still describes a genuine pin
+/// change and its write lands like any other — restart agrees with the
+/// screen. A reset that *does* change live state rebuilds the pins
+/// instead, and the take's no-op filter then drops the entry as moot.
+#[test]
+fn a_barrier_defers_queued_visibility_persistence_instead_of_dropping_it() {
+    use crate::domain::Action;
+    use crate::input::state::PendingToolbarPersistence;
+
+    let temp = crate::test_temp::tempdir().unwrap();
+    let runtime_path = temp.path().join("runtime-ui.toml");
+    let config = Config::default();
+    assert!(config.ui.toolbar.top_pinned && config.ui.toolbar.side_pinned);
+    let mut input = input_from_config(&config);
+    let mut runtime = controller_only_runtime(&config, &runtime_path);
+
+    assert!(matches!(
+        runtime.controller.request_supported_reset(),
+        RequestResetResult::Started { .. }
+    ));
+    let reset = runtime
+        .controller
+        .take_source_mutation()
+        .expect("reset command");
+    assert!(runtime.mutation_barrier_active());
+
+    // The press lands on screen and queues normally; only the write waits.
+    input.handle_action(Action::ToggleToolbar);
+    assert!(!input.toolbar_visible());
+    assert!(input.has_pending_toolbar_persistence());
+    assert!(
+        runtime
+            .begin_toolbar_mutation_with_rollback(
+                ToolbarRuntimeUiPersistenceTarget::ToolbarVisibility,
+                pins_rollback_values(true, true),
+            )
+            .is_none(),
+        "the barrier refuses new mutations, which is why the drain defers"
+    );
+
+    // The reset completes through the writer-completion path the event
+    // loop uses; the barrier closes.
+    runtime.integrate_writer_completion(RuntimeStateWriterCompletion::SourceMutation(
+        SourceMutationResult::Applied {
+            id: reset.id,
+            applied_through: reset.accepted_through,
+            new_source: RuntimeStateSourceRevision::missing(
+                reset.expected_source.path_identity().clone(),
+            ),
+            recovery_artifacts: Vec::new(),
+        },
+    ));
+    assert!(!runtime.mutation_barrier_active());
+    let drain = runtime.drain_writer_completions();
+    assert!(drain.rollbacks.is_empty());
+    assert!(
+        !drain.rebuild_live,
+        "resetting an empty store changes no live state, so nothing is stomped"
+    );
+
+    // The deferred drain: the entry survived the barrier with its rollback
+    // baseline and its write lands normally.
+    let accepted_after_reset = runtime.controller.pipeline().latest_accepted();
+    assert_eq!(
+        input.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: true,
+            previous_side_pinned: true,
+        }],
+        "the deferred entry must survive the barrier untouched"
+    );
+    let prepared = runtime
+        .begin_toolbar_mutation_with_rollback(
+            ToolbarRuntimeUiPersistenceTarget::ToolbarVisibility,
+            pins_rollback_values(true, true),
+        )
+        .expect("visibility permit after the barrier resolves");
+    assert!(matches!(
+        runtime.finish_toolbar_mutation(prepared, true, &input),
+        ToolbarRuntimeFinish::KeepPreview
+    ));
+    assert_eq!(
+        runtime.controller.pipeline().latest_accepted().get(),
+        accepted_after_reset.get() + 1,
+        "the deferred toggle still settles through one accepted revision"
+    );
+    assert_eq!(
+        stored_bool(&runtime, InteractionSeedTarget::TopPinned),
+        Some(false)
+    );
+    assert_eq!(
+        stored_bool(&runtime, InteractionSeedTarget::SidePinned),
+        Some(false)
+    );
+}
+
+/// The teardown race: a reset is in flight, F9 changes the screen, and the
+/// user exits before the reset completes. Teardown mirrors
+/// `drain_toolbar_persistence_for_teardown`: settle the barrier by waiting
+/// for the writer completion `shutdown_blocking` was going to consume
+/// anyway, apply its resolution, then drain — so the deferred toggle's
+/// write still reaches the file and a restart shows the exit-time screen,
+/// not the pre-toggle pins.
+#[test]
+fn an_exit_during_an_active_reset_barrier_still_lands_the_deferred_toggle() {
+    use crate::domain::Action;
+    use crate::input::state::PendingToolbarPersistence;
+
+    let temp = crate::test_temp::tempdir().unwrap();
+    let runtime_path = temp.path().join("runtime-ui.toml");
+    let config = Config::default();
+    assert!(config.ui.toolbar.top_pinned && config.ui.toolbar.side_pinned);
+    let mut input = input_from_config(&config);
+    let mut positions = config_positions(&config);
+    let mut runtime = test_runtime(&config, &runtime_path);
+
+    // The reset's command stays undispatched until settling begins, so the
+    // barrier is deterministically active while F9 lands.
+    assert!(matches!(
+        runtime.controller.request_supported_reset(),
+        RequestResetResult::Started { .. }
+    ));
+    assert!(runtime.mutation_barrier_active());
+    input.handle_action(Action::ToggleToolbar);
+    assert!(!input.toolbar_visible());
+    assert!(input.has_pending_toolbar_persistence());
+
+    // Exit begins: teardown settles the barrier first...
+    runtime.settle_barrier_for_teardown();
+    assert!(!runtime.mutation_barrier_active());
+    let drain = runtime.drain_writer_completions();
+    assert!(drain.rollbacks.is_empty());
+    if drain.rebuild_live {
+        runtime.apply_live_state(&mut input, &mut positions);
+    }
+    // ...then drains the queue; resetting an empty store changed no live
+    // state, so the entry still describes a genuine pin change.
+    assert_eq!(
+        input.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: true,
+            previous_side_pinned: true,
+        }],
+        "the deferred entry must survive the settled barrier"
+    );
+    let prepared = runtime
+        .begin_toolbar_mutation_with_rollback(
+            ToolbarRuntimeUiPersistenceTarget::ToolbarVisibility,
+            pins_rollback_values(true, true),
+        )
+        .expect("visibility permit after teardown settled the barrier");
+    assert!(matches!(
+        runtime.finish_toolbar_mutation(prepared, true, &input),
+        ToolbarRuntimeFinish::KeepPreview
+    ));
+    runtime.shutdown_blocking();
+
+    // Restart: the exit-time screen survived the mid-reset exit.
+    let mut restarted_input = input_from_config(&config);
+    let mut restarted = test_runtime(&config, &runtime_path);
+    restarted.apply_startup_state(&mut restarted_input);
+    assert!(!restarted_input.toolbar_top_pinned);
+    assert!(!restarted_input.toolbar_side_pinned);
+    assert!(
+        !restarted_input.toolbar_visible,
+        "the toggle pressed during the reset barrier must survive the exit"
+    );
+    restarted.shutdown_blocking();
+}
+
+/// The recovery twin of the teardown race above: a transient write failure
+/// leaves an unhealthy incident, the user starts a `RetryPending` recovery
+/// — whose inspection command sits in the recovery outbox while the normal
+/// pipeline reports no source mutation in flight — presses F9, and exits
+/// before the recovery completes. Settling must count recovery work as
+/// settleable: the inspection and the retried write both land, the
+/// barrier closes, and the deferred toggle persists — restart shows the
+/// exit-time screen.
+#[test]
+fn an_exit_during_retry_pending_recovery_still_lands_the_deferred_toggle() {
+    use crate::domain::Action;
+    use crate::input::state::PendingToolbarPersistence;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = crate::test_temp::tempdir().unwrap();
+    let store_dir = temp.path().join("store");
+    fs::create_dir(&store_dir).unwrap();
+    let runtime_path = store_dir.join("runtime-ui.toml");
+    let config = Config::default();
+    assert!(config.ui.toolbar.top_pinned && config.ui.toolbar.side_pinned);
+    let mut input = input_from_config(&config);
+    let mut runtime = test_runtime(&config, &runtime_path);
+
+    // A transient failure: the store directory briefly refuses writes.
+    fs::set_permissions(&store_dir, fs::Permissions::from_mode(0o555)).unwrap();
+    commit_display_mode(&mut runtime, &mut input, TopDisplayMode::Micro);
+    wait_for_runtime_mode(&mut runtime, RuntimeUiPersistenceMode::Unhealthy);
+    assert!(runtime.mutation_barrier_active());
+    fs::set_permissions(&store_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(
+        runtime.handle_persistence_lifecycle_event(&ToolbarEvent::RetryRuntimeUiPersistence),
+        "retry must start a recovery attempt"
+    );
+    assert!(runtime.mutation_barrier_active());
+    input.handle_action(Action::ToggleToolbar);
+    assert!(!input.toolbar_visible());
+    assert!(input.has_pending_toolbar_persistence());
+
+    // Exit: settling drives the inspection, the controller decision, and
+    // the retried write through the real writer.
+    runtime.settle_barrier_for_teardown();
+    assert!(!runtime.mutation_barrier_active());
+    let drain = runtime.drain_writer_completions();
+    assert!(drain.rollbacks.is_empty());
+    assert!(
+        !drain.rebuild_live,
+        "recovery under retained authority leaves live state alone"
+    );
+    assert_eq!(
+        input.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: true,
+            previous_side_pinned: true,
+        }],
+        "the deferred entry must survive the settled recovery"
+    );
+    let prepared = runtime
+        .begin_toolbar_mutation_with_rollback(
+            ToolbarRuntimeUiPersistenceTarget::ToolbarVisibility,
+            pins_rollback_values(true, true),
+        )
+        .expect("visibility permit after recovery settled");
+    assert!(matches!(
+        runtime.finish_toolbar_mutation(prepared, true, &input),
+        ToolbarRuntimeFinish::KeepPreview
+    ));
+    runtime.shutdown_blocking();
+
+    // Restart: the retried write and the deferred toggle both survived.
+    let mut restarted_input = input_from_config(&config);
+    let mut restarted = test_runtime(&config, &runtime_path);
+    restarted.apply_startup_state(&mut restarted_input);
+    assert_eq!(
+        stored_display_mode(&restarted),
+        Some(PersistedTopDisplayMode::Micro),
+        "the recovery must have landed the write that originally failed"
+    );
+    assert!(!restarted_input.toolbar_top_pinned);
+    assert!(!restarted_input.toolbar_side_pinned);
+    assert!(
+        !restarted_input.toolbar_visible,
+        "the toggle pressed during the recovery barrier must survive the exit"
+    );
+    restarted.shutdown_blocking();
+}
+
 /// A rollback can resolve long after the toggle (the forced-barrier test
 /// above proves the deferral). If presenter mode has meanwhile taken chrome
 /// ownership, applying the rollback must not surface toolbars
@@ -2394,7 +2682,7 @@ fn a_deferred_hide_rollback_lands_in_the_presenter_restore_snapshot() {
 
     input.handle_action(Action::ToggleToolbar); // hide, pins → false/false
     assert!(!input.toolbar_visible());
-    input.take_pending_backend_action(); // the write whose rollback arrives below
+    input.take_pending_toolbar_persistence(); // the write whose rollback arrives below
 
     input.presenter_mode_config.hide_toolbars = true;
     input.toggle_presenter_mode();
@@ -2439,7 +2727,7 @@ fn a_deferred_hide_rollback_lands_in_the_focus_mode_snapshot() {
 
     input.handle_action(Action::ToggleToolbar); // hide, pins → false/false
     assert!(!input.toolbar_visible());
-    input.take_pending_backend_action(); // the write whose rollback arrives below
+    input.take_pending_toolbar_persistence(); // the write whose rollback arrives below
 
     input.handle_action(Action::ToggleFocusMode);
     assert!(input.focus_mode_active());
@@ -2474,7 +2762,7 @@ fn a_deferred_hide_rollback_lands_in_the_light_mode_snapshot() {
 
     input.handle_action(Action::ToggleToolbar); // hide, pins → false/false
     assert!(!input.toolbar_visible());
-    input.take_pending_backend_action(); // the write whose rollback arrives below
+    input.take_pending_toolbar_persistence(); // the write whose rollback arrives below
 
     input.handle_action(Action::ToggleLightMode);
     assert!(input.light_mode);

--- a/src/backend/wayland/runtime_ui_state/wayland.rs
+++ b/src/backend/wayland/runtime_ui_state/wayland.rs
@@ -174,6 +174,71 @@ impl WaylandState {
         self.apply_toolbar_runtime_finish(finish);
     }
 
+    /// Drains every queued durable toolbar change into the runtime-ui
+    /// writer, oldest first. Called on every event-loop pass and once more
+    /// at teardown before the writer shuts down, so a toggle pressed in the
+    /// same input batch as an exit request still reaches the file.
+    ///
+    /// While a reset/recovery barrier is active the queue is left intact:
+    /// `begin` would refuse each entry with `ControllerBusy`, silently
+    /// losing it. Entries wait for the barrier to resolve instead — the
+    /// take's no-op filter then discards any the resolution made moot. At
+    /// exit, `drain_toolbar_persistence_for_teardown` settles a settleable
+    /// barrier first; only one that cannot settle (a persistence incident,
+    /// which no write can land under) still costs the entries their write.
+    pub(in crate::backend::wayland) fn drain_pending_toolbar_persistence(&mut self) {
+        use crate::input::state::PendingToolbarPersistence;
+
+        match self.runtime_ui.as_ref() {
+            // Degraded mode is run-only: consume the entries so the queue
+            // cannot wake the loop for writes that have nowhere to land.
+            None => {
+                self.input_state.take_pending_toolbar_persistence();
+                return;
+            }
+            Some(runtime) if runtime.mutation_barrier_active() => return,
+            Some(_) => {}
+        }
+        for entry in self.input_state.take_pending_toolbar_persistence() {
+            match entry {
+                PendingToolbarPersistence::DisplayMode { previous } => {
+                    self.persist_toolbar_display_mode(previous)
+                }
+                PendingToolbarPersistence::Visibility {
+                    previous_top_pinned,
+                    previous_side_pinned,
+                } => self.persist_toolbar_visibility(previous_top_pinned, previous_side_pinned),
+            }
+        }
+    }
+
+    /// Teardown-time drain: settle any barrier whose resolution is already
+    /// on the writer channel — exiting mid-reset must not cost a queued
+    /// toggle its write — apply that resolution to live state so the
+    /// drain's no-op filter judges against the post-barrier screen, then
+    /// drain. The caller's writer shutdown flushes the writes to disk.
+    pub(in crate::backend::wayland) fn drain_toolbar_persistence_for_teardown(&mut self) {
+        if let Some(runtime) = self.runtime_ui.as_mut() {
+            runtime.settle_barrier_for_teardown();
+        }
+        self.drain_runtime_ui_completions();
+        self.drain_pending_toolbar_persistence();
+    }
+
+    /// Whether the toolbar persistence drain could make progress this pass.
+    ///
+    /// Gates the zero-timeout wake: entries deferred behind a barrier must
+    /// not busy-spin the loop — the writer completion that resolves the
+    /// barrier wakes it instead. A missing runtime store still reports
+    /// ready so the drain can consume the entries it will never write.
+    pub(in crate::backend::wayland) fn toolbar_persistence_drain_ready(&self) -> bool {
+        self.input_state.has_pending_toolbar_persistence()
+            && self
+                .runtime_ui
+                .as_ref()
+                .is_none_or(|runtime| !runtime.mutation_barrier_active())
+    }
+
     /// Reconcile runtime overrides and active previews after an authored
     /// config reload. The product's current reload path may still restart the
     /// daemon, but keeping this boundary complete prevents a future

--- a/src/input/state/actions/action_ui.rs
+++ b/src/input/state/actions/action_ui.rs
@@ -5,7 +5,7 @@ use crate::domain::Action;
 use crate::input::state::{Toast, ToastPriority};
 use log::info;
 
-use super::super::{DrawingState, InputState, PendingBackendAction};
+use super::super::{DrawingState, InputState, PendingBackendAction, PendingToolbarPersistence};
 
 impl InputState {
     pub(in crate::input::state) fn handle_ui_action(&mut self, action: Action) -> bool {
@@ -148,12 +148,10 @@ impl InputState {
                     // hidden before the press. The unfold itself stays
                     // runtime-only, exactly like F2's hidden rung.
                     if previous_top_pinned != now_visible || previous_side_pinned != now_visible {
-                        self.set_pending_backend_action(
-                            PendingBackendAction::PersistToolbarVisibility {
-                                previous_top_pinned,
-                                previous_side_pinned,
-                            },
-                        );
+                        self.queue_toolbar_persistence(PendingToolbarPersistence::Visibility {
+                            previous_top_pinned,
+                            previous_side_pinned,
+                        });
                     }
                     self.pending_onboarding_usage.used_toolbar_toggle = true;
                     info!(
@@ -196,9 +194,9 @@ impl InputState {
                 if mode == crate::config::TopDisplayMode::Hidden {
                     self.warn_if_all_chrome_hidden();
                 }
-                self.set_pending_backend_action(PendingBackendAction::PersistToolbarDisplayMode(
-                    previous_mode,
-                ));
+                self.queue_toolbar_persistence(PendingToolbarPersistence::DisplayMode {
+                    previous: previous_mode,
+                });
                 self.dirty_tracker.mark_full();
                 self.needs_redraw = true;
                 info!("Toolbar display mode cycled to {mode:?}");

--- a/src/input/state/core/base/mod.rs
+++ b/src/input/state/core/base/mod.rs
@@ -18,9 +18,9 @@ pub(crate) use types::{
     BlockedActionFeedback, BoardPickerClickState, ClipboardFingerprint, ClipboardPasteRequest,
     DelayedHistory, HistoryMode, PasteAnchor, PendingBackendAction, PendingBoardDelete,
     PendingClipboardFallback, PendingOnboardingUsage, PendingPageDelete,
-    PendingSelectionClipboardPublish, PolygonClickState, PresetFeedbackState,
-    SelectionPublishState, TextBlockDrag, TextClickState, TextClipboardRequest, TextCutTarget,
-    TextEditEntryFeedback, TextPasteEdit, TextPasteTarget, ToastPress,
-    WayscriberClipboardSelection,
+    PendingSelectionClipboardPublish, PendingToolbarPersistence, PolygonClickState,
+    PresetFeedbackState, SelectionPublishState, TextBlockDrag, TextClickState,
+    TextClipboardRequest, TextCutTarget, TextEditEntryFeedback, TextPasteEdit, TextPasteTarget,
+    ToastPress, WayscriberClipboardSelection,
 };
 pub(crate) use types::{KeybindingEditOperation, KeybindingEditRequest};

--- a/src/input/state/core/base/state/init.rs
+++ b/src/input/state/core/base/state/init.rs
@@ -212,6 +212,7 @@ impl InputState {
             action_map,
             action_bindings: HashMap::new(),
             pending_backend_action: None,
+            pending_toolbar_persistence: Vec::new(),
             pending_keybinding_edits: Vec::new(),
             process_only_preference_notice_shown: false,
             pending_output_focus_action: None,

--- a/src/input/state/core/base/state/structs.rs
+++ b/src/input/state/core/base/state/structs.rs
@@ -18,9 +18,9 @@ use super::super::types::{
     BlockedActionFeedback, BoardPickerClickState, ClipboardPasteRequest, CompositorCapabilities,
     DelayedHistory, DrawingState, KeybindingEditRequest, OutputFocusAction, PendingBackendAction,
     PendingBoardDelete, PendingClipboardFallback, PendingOnboardingUsage, PendingPageDelete,
-    PendingSelectionClipboardPublish, PolygonClickState, PresetAction, PresetFeedbackState,
-    PressureThicknessEditMode, PressureThicknessEntryMode, QuickColorEdit, SelectionAxis,
-    SelectionPublishState, StatusChangeHighlight, TextBlockDrag, TextClickState,
+    PendingSelectionClipboardPublish, PendingToolbarPersistence, PolygonClickState, PresetAction,
+    PresetFeedbackState, PressureThicknessEditMode, PressureThicknessEntryMode, QuickColorEdit,
+    SelectionAxis, SelectionPublishState, StatusChangeHighlight, TextBlockDrag, TextClickState,
     TextClipboardRequest, TextEditEntryFeedback, TextInputMode, TextPasteTarget, UiToastState,
     ZoomAction,
 };
@@ -398,6 +398,13 @@ pub struct InputState {
     pub(in crate::input::state::core) action_bindings: HashMap<Action, Vec<KeyBinding>>,
     /// Pending backend output action (to be handled by WaylandState).
     pub(in crate::input::state::core) pending_backend_action: Option<PendingBackendAction>,
+    /// Durable toolbar chrome changes awaiting their runtime-ui.toml write,
+    /// oldest first.
+    ///
+    /// A queue, not part of the single backend-action slot: its last-action
+    /// semantics would let a capture (or a second toolbar change) silently
+    /// cost an earlier change its persistence — or vice versa.
+    pub(in crate::input::state::core) pending_toolbar_persistence: Vec<PendingToolbarPersistence>,
     /// Shortcut edits waiting for the backend, oldest first.
     ///
     /// A queue, not a slot: the palette can record several edits between two

--- a/src/input/state/core/base/types.rs
+++ b/src/input/state/core/base/types.rs
@@ -446,16 +446,30 @@ pub enum PendingBackendAction {
     CanvasExport(Action),
     BoardPdfExport(Action),
     ClearSavedToolState,
-    /// Persist the top-display preference changed by its keyboard action.
-    /// The cycle already applied, so the payload carries the pre-cycle mode
-    /// for the runtime-UI preview's rollback; toolbar-event paths persist via
+}
+
+/// Durable toolbar chrome changes awaiting their runtime-ui.toml write.
+///
+/// Deliberately not part of [`PendingBackendAction`]: that slot has
+/// last-action semantics, so sharing it would let a screenshot (or a second
+/// toolbar change) silently cost an earlier change its persistence — or vice
+/// versa. These are ordered, coalesced per kind, and drained once more at
+/// teardown, so a change made in the same input batch as an exit request
+/// still reaches the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingToolbarPersistence {
+    /// The top-display preference changed by its keyboard cycle (F2). The
+    /// cycle already applied, so the payload carries the pre-cycle mode for
+    /// the runtime-UI preview's rollback; toolbar-event paths persist via
     /// their exact event-policy target instead.
-    PersistToolbarDisplayMode(crate::config::TopDisplayMode),
-    /// Persist both pin flags driven by the keyboard visibility toggle.
-    /// The toggle already applied, so the payload carries the pre-change pins
-    /// for the runtime-UI preview's rollback; the pin buttons persist via
-    /// their exact event-policy targets instead.
-    PersistToolbarVisibility {
+    DisplayMode {
+        previous: crate::config::TopDisplayMode,
+    },
+    /// Both pin flags driven by the keyboard visibility toggle (F9). The
+    /// toggle already applied, so the payload carries the pre-change pins for
+    /// the runtime-UI preview's rollback; the pin buttons persist via their
+    /// exact event-policy targets instead.
+    Visibility {
         previous_top_pinned: bool,
         previous_side_pinned: bool,
     },

--- a/src/input/state/core/mod.rs
+++ b/src/input/state/core/mod.rs
@@ -38,8 +38,8 @@ pub(crate) use base::{
 };
 pub(crate) use base::{
     ClipboardFingerprint, ClipboardPasteRequest, PasteAnchor, PendingBackendAction,
-    PendingOnboardingUsage, PendingSelectionClipboardPublish, SelectionPublishState,
-    WayscriberClipboardSelection,
+    PendingOnboardingUsage, PendingSelectionClipboardPublish, PendingToolbarPersistence,
+    SelectionPublishState, WayscriberClipboardSelection,
 };
 pub(crate) use base::{KeybindingEditOperation, KeybindingEditRequest};
 pub use board_picker::{BoardPickerCursorHint, BoardPickerLayout};

--- a/src/input/state/core/utility/pending.rs
+++ b/src/input/state/core/utility/pending.rs
@@ -1,7 +1,7 @@
 use super::super::base::{
     ClipboardFingerprint, ClipboardPasteRequest, InputState, KeybindingEditRequest,
-    OutputFocusAction, PendingBackendAction, PendingSelectionClipboardPublish, PresetAction,
-    QuickColorEdit, SelectionPublishState, ZoomAction,
+    OutputFocusAction, PendingBackendAction, PendingSelectionClipboardPublish,
+    PendingToolbarPersistence, PresetAction, QuickColorEdit, SelectionPublishState, ZoomAction,
 };
 use crate::input::boards::PendingBoardRuntimeUiAction;
 
@@ -18,9 +18,56 @@ impl InputState {
     }
 
     /// Stores backend output work for retrieval by the backend, with
-    /// last-action semantics.
+    /// last-action semantics. Durable toolbar chrome changes do not use this
+    /// slot (see [`Self::queue_toolbar_persistence`]) because last-action
+    /// semantics would let a capture cost a toggle its persistence.
     pub(crate) fn set_pending_backend_action(&mut self, action: PendingBackendAction) {
         self.pending_backend_action = Some(action);
+    }
+
+    /// Queues a durable toolbar chrome change, oldest first.
+    ///
+    /// Coalesced per kind: the eventual write reads live state at drain time,
+    /// so a second change of the same kind needs no second entry, and the
+    /// FIRST entry's previous values remain the rollback baseline — they
+    /// describe the state before the whole burst.
+    pub(crate) fn queue_toolbar_persistence(&mut self, entry: PendingToolbarPersistence) {
+        let already_queued = self
+            .pending_toolbar_persistence
+            .iter()
+            .any(|queued| std::mem::discriminant(queued) == std::mem::discriminant(&entry));
+        if already_queued {
+            return;
+        }
+        self.pending_toolbar_persistence.push(entry);
+    }
+
+    /// Takes every due toolbar persistence entry, oldest first.
+    ///
+    /// A burst that lands exactly where it started (F9 pressed twice, a
+    /// display cycle walked full circle) is dropped here: nothing durable
+    /// changed, the write would be byte-identical to its own rollback, and
+    /// the only observable effect of writing it would be a bad rollback.
+    pub(crate) fn take_pending_toolbar_persistence(&mut self) -> Vec<PendingToolbarPersistence> {
+        let mut entries = std::mem::take(&mut self.pending_toolbar_persistence);
+        entries.retain(|entry| match *entry {
+            PendingToolbarPersistence::DisplayMode { previous } => {
+                previous != self.toolbar_top_display_mode
+            }
+            PendingToolbarPersistence::Visibility {
+                previous_top_pinned,
+                previous_side_pinned,
+            } => {
+                previous_top_pinned != self.toolbar_top_pinned
+                    || previous_side_pinned != self.toolbar_side_pinned
+            }
+        });
+        entries
+    }
+
+    /// Whether durable toolbar work is waiting to be drained.
+    pub(crate) fn has_pending_toolbar_persistence(&self) -> bool {
+        !self.pending_toolbar_persistence.is_empty()
     }
 
     /// Takes every shortcut edit recorded since the last drain, oldest first.

--- a/src/input/state/mod.rs
+++ b/src/input/state/mod.rs
@@ -49,9 +49,9 @@ pub(crate) use core::{
 pub(crate) use core::{
     ClipboardFingerprint, ClipboardPasteRequest, HelpOverlayPressSource, HexPasteTarget,
     KeybindingEditOperation, KeybindingEditRequest, PasteAnchor, PendingBackendAction,
-    PendingOnboardingUsage, PendingSelectionClipboardPublish, SelectionPublishState,
-    TextClipboardRequest, TextCutTarget, TextPasteEdit, TextPasteTarget, ToastPress,
-    WayscriberClipboardSelection,
+    PendingOnboardingUsage, PendingSelectionClipboardPublish, PendingToolbarPersistence,
+    SelectionPublishState, TextClipboardRequest, TextCutTarget, TextPasteEdit, TextPasteTarget,
+    ToastPress, WayscriberClipboardSelection,
 };
 pub use highlight::ClickHighlightSettings;
 #[allow(unused_imports)]

--- a/src/input/state/tests/focus_mode.rs
+++ b/src/input/state/tests/focus_mode.rs
@@ -336,15 +336,18 @@ fn focus_mode_hides_a_fallback_badge_when_the_enabled_status_bar_is_empty() {
 #[test]
 fn focus_mode_never_enqueues_persistence() {
     // Focus mode's hide/restore is transient by contract, and so is every
-    // explicit ToggleFloatingBadge/ToggleZoomChip: neither reaches the disk.
+    // explicit ToggleFloatingBadge/ToggleZoomChip: neither reaches the disk
+    // through either pending channel.
     let mut state = create_test_input_state();
     let _ = state.take_pending_backend_action();
 
     state.handle_action(Action::ToggleFocusMode); // hide all
     assert!(state.take_pending_backend_action().is_none());
+    assert!(!state.has_pending_toolbar_persistence());
 
     state.handle_action(Action::ToggleFocusMode); // restore all
     assert!(state.take_pending_backend_action().is_none());
+    assert!(!state.has_pending_toolbar_persistence());
 }
 
 /// The explicit toggles own the live flags; focus mode's later suppression is

--- a/src/input/state/tests/toolbar_display.rs
+++ b/src/input/state/tests/toolbar_display.rs
@@ -3,7 +3,7 @@ use crate::config::{
     Action, RadialMenuMouseBinding, StatusBarItem, StatusBarStyle, StatusPosition, TopDisplayMode,
 };
 use crate::input::state::core::{ContextMenuKind, MenuCommand};
-use crate::input::state::{InputState, PendingBackendAction};
+use crate::input::state::{InputState, PendingBackendAction, PendingToolbarPersistence};
 use std::collections::HashMap;
 
 fn unbind_chrome_visibility_actions(state: &mut InputState) {
@@ -49,10 +49,10 @@ fn cycle_action_walks_full_micro_hidden_full_with_toasts() {
         Some("Toolbar: micro")
     );
     assert_eq!(
-        state.take_pending_backend_action(),
-        Some(PendingBackendAction::PersistToolbarDisplayMode(
-            TopDisplayMode::Full
-        )),
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::DisplayMode {
+            previous: TopDisplayMode::Full,
+        }],
         "keyboard cycle persists like the toolbar-event paths"
     );
 
@@ -147,11 +147,11 @@ fn toggle_toolbar_drives_both_pins_and_queues_their_persistence() {
     assert!(!state.toolbar_top_pinned);
     assert!(!state.toolbar_side_pinned);
     assert_eq!(
-        state.take_pending_backend_action(),
-        Some(PendingBackendAction::PersistToolbarVisibility {
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
             previous_top_pinned: true,
             previous_side_pinned: true,
-        }),
+        }],
         "the keyboard toggle persists like the toolbar-event paths"
     );
 
@@ -161,11 +161,11 @@ fn toggle_toolbar_drives_both_pins_and_queues_their_persistence() {
     assert!(state.toolbar_top_pinned);
     assert!(state.toolbar_side_pinned);
     assert_eq!(
-        state.take_pending_backend_action(),
-        Some(PendingBackendAction::PersistToolbarVisibility {
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
             previous_top_pinned: false,
             previous_side_pinned: false,
-        })
+        }]
     );
 }
 
@@ -181,11 +181,11 @@ fn toggle_toolbar_resolves_asymmetric_pins_to_what_is_on_screen() {
     state.handle_action(Action::ToggleToolbar); // off
     assert!(!state.toolbar_top_pinned && !state.toolbar_side_pinned);
     assert_eq!(
-        state.take_pending_backend_action(),
-        Some(PendingBackendAction::PersistToolbarVisibility {
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
             previous_top_pinned: true,
             previous_side_pinned: false,
-        })
+        }]
     );
 
     state.handle_action(Action::ToggleToolbar); // on
@@ -210,16 +210,16 @@ fn cycle_hidden_show_with_unchanged_pins_queues_no_persistence() {
     state.handle_action(Action::CycleToolbarDisplay); // hidden
     assert!(!state.toolbar_visible());
     assert!(state.toolbar_top_pinned && state.toolbar_side_pinned);
-    state.take_pending_backend_action(); // drain the cycle's display-mode write
+    state.take_pending_toolbar_persistence(); // drain the cycle's display-mode write
 
     state.handle_action(Action::ToggleToolbar); // show: unfolds Hidden → Full
     assert!(state.toolbar_visible());
     assert_eq!(state.top_display_state(), TopDisplayMode::Full);
     assert!(state.toolbar_top_pinned && state.toolbar_side_pinned);
-    assert_eq!(
-        state.take_pending_backend_action(),
-        None,
-        "a toggle that moves no pin has nothing to persist"
+    assert!(
+        !state.has_pending_toolbar_persistence(),
+        "a toggle that moves no pin queues nothing (the raw queue, not the \
+         drain-time filter, is the contract here)"
     );
 }
 
@@ -237,10 +237,10 @@ fn hide_with_already_unpinned_surfaces_queues_no_persistence() {
     state.handle_action(Action::ToggleToolbar); // hide
     assert!(!state.toolbar_visible());
     assert!(!state.toolbar_top_pinned && !state.toolbar_side_pinned);
-    assert_eq!(
-        state.take_pending_backend_action(),
-        None,
-        "a toggle that moves no pin has nothing to persist"
+    assert!(
+        !state.has_pending_toolbar_persistence(),
+        "a toggle that moves no pin queues nothing (the raw queue, not the \
+         drain-time filter, is the contract here)"
     );
 }
 
@@ -253,10 +253,10 @@ fn presenter_swallowed_toggle_leaves_pins_and_persistence_untouched() {
 
     state.handle_action(Action::ToggleToolbar);
     assert!(state.toolbar_top_pinned && state.toolbar_side_pinned);
-    assert_eq!(
-        state.take_pending_backend_action(),
-        None,
-        "a swallowed toggle must not persist anything"
+    assert!(
+        !state.has_pending_toolbar_persistence(),
+        "a swallowed toggle must queue nothing (the raw queue, not the \
+         drain-time filter, is the contract here)"
     );
 }
 
@@ -279,12 +279,130 @@ fn focus_and_presenter_transitions_never_queue_pin_persistence() {
             state.toolbar_top_pinned && state.toolbar_side_pinned,
             "{action:?} must not touch the pin overrides"
         );
-        assert_eq!(
-            state.take_pending_backend_action(),
-            None,
-            "{action:?} must not queue visibility persistence"
+        assert!(
+            !state.has_pending_toolbar_persistence(),
+            "{action:?} must not queue visibility persistence (the raw \
+             queue, not the drain-time filter, is the contract here)"
         );
     }
+}
+
+/// F9 and F2 in one input batch, drained together: the queue keeps both,
+/// oldest first. The old single backend-action slot would have kept only the
+/// F2 write, silently costing the F9 press its persistence.
+///
+/// The strip sits on Micro first so the in-batch F2 moves the raw persisted
+/// mode: pressed over the F9-hidden strip, the cycle's Hidden rung unfolds to
+/// Full, and from a Full start that write would be a no-op the drain filter
+/// (correctly) drops.
+#[test]
+fn a_toggle_and_a_cycle_in_one_batch_both_keep_their_persistence() {
+    let mut state = create_test_input_state();
+    assert!(state.toolbar_top_pinned && state.toolbar_side_pinned);
+    state.handle_action(Action::CycleToolbarDisplay); // micro
+    state.take_pending_toolbar_persistence(); // drain the setup cycle's write
+
+    state.handle_action(Action::ToggleToolbar); // F9 hide
+    state.handle_action(Action::CycleToolbarDisplay); // F2: unfolds to full
+
+    assert_eq!(
+        state.take_pending_toolbar_persistence(),
+        vec![
+            PendingToolbarPersistence::Visibility {
+                previous_top_pinned: true,
+                previous_side_pinned: true,
+            },
+            PendingToolbarPersistence::DisplayMode {
+                previous: TopDisplayMode::Micro,
+            },
+        ],
+        "both changes must survive the batch, oldest first"
+    );
+}
+
+/// A capture and a visibility toggle in the same batch, in either order:
+/// the capture rides the single backend-action slot, the toggle rides the
+/// persistence queue, and neither may cost the other its delivery.
+#[test]
+fn visibility_persistence_survives_a_capture_request() {
+    let mut state = create_test_input_state();
+
+    state.handle_action(Action::ToggleToolbar); // F9 hide
+    state.handle_action(Action::CaptureFileFull);
+    assert_eq!(
+        state.take_pending_backend_action(),
+        Some(PendingBackendAction::Screenshot(Action::CaptureFileFull)),
+        "the capture must survive the toggle"
+    );
+    assert_eq!(
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: true,
+            previous_side_pinned: true,
+        }],
+        "the toggle must survive the capture"
+    );
+
+    // The reverse order: capture first, then the toggle (a show this time).
+    state.handle_action(Action::CaptureFileFull);
+    state.handle_action(Action::ToggleToolbar); // F9 show
+    assert_eq!(
+        state.take_pending_backend_action(),
+        Some(PendingBackendAction::Screenshot(Action::CaptureFileFull)),
+        "the capture must survive the toggle"
+    );
+    assert_eq!(
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: false,
+            previous_side_pinned: false,
+        }],
+        "the toggle must survive the capture"
+    );
+}
+
+/// F9 twice before a drain: one coalesced raw entry keeps the FIRST press's
+/// pre-change pins (the burst's rollback baseline), and because the pins end
+/// exactly where they started, the drain-time no-op filter drops it — the
+/// write would be byte-identical to its own rollback.
+#[test]
+fn a_toggle_burst_coalesces_to_the_original_rollback_baseline() {
+    let mut state = create_test_input_state();
+    assert!(state.toolbar_top_pinned && state.toolbar_side_pinned);
+
+    state.handle_action(Action::ToggleToolbar); // hide
+    state.handle_action(Action::ToggleToolbar); // show: pins back where they started
+    assert!(state.toolbar_top_pinned && state.toolbar_side_pinned);
+
+    assert!(
+        state.has_pending_toolbar_persistence(),
+        "the burst coalesces to one raw entry, it is not dropped at queue time"
+    );
+    assert_eq!(
+        state.take_pending_toolbar_persistence(),
+        vec![],
+        "a burst that lands where it started has nothing durable to write"
+    );
+}
+
+/// The backend drains this queue once more at teardown; nothing on the input
+/// side may drop a queued entry when the same batch also requests an exit.
+#[test]
+fn an_exit_request_does_not_clear_queued_toolbar_persistence() {
+    let mut state = create_test_input_state();
+
+    state.handle_action(Action::ToggleToolbar); // F9 hide
+    state.handle_action(Action::Exit);
+    assert!(state.should_exit, "the exit request must have landed");
+
+    assert_eq!(
+        state.take_pending_toolbar_persistence(),
+        vec![PendingToolbarPersistence::Visibility {
+            previous_top_pinned: true,
+            previous_side_pinned: true,
+        }],
+        "the toggle must still be waiting for the teardown drain"
+    );
 }
 
 #[test]

--- a/src/runtime_ui_state/controller.rs
+++ b/src/runtime_ui_state/controller.rs
@@ -389,6 +389,18 @@ impl RuntimeUiStateController {
         self.active_barrier.as_ref()
     }
 
+    /// Whether writer work is queued or in flight that can advance the
+    /// active barrier: a pipeline source mutation, or an active recovery
+    /// attempt (whose current command is queued in the recovery outbox or
+    /// already with the writer). False for resting states that only a
+    /// controller-side decision can advance — an unhealthy incident with
+    /// no attempt running waits on the user, not the writer.
+    pub(crate) fn barrier_settling_work_in_flight(&self) -> bool {
+        self.pipeline.has_source_mutation_in_flight()
+            || !self.recovery_outbox.is_empty()
+            || self.active_recovery.is_some()
+    }
+
     pub(crate) fn take_preview_resolutions(&mut self) -> Vec<AbandonedPreviewResolution> {
         std::mem::take(&mut self.preview_resolution_outbox)
     }

--- a/src/toolbar_gtk/view/top_bar/tests.rs
+++ b/src/toolbar_gtk/view/top_bar/tests.rs
@@ -1541,6 +1541,25 @@ fn actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window() {
         return;
     }
 
+    // The size budgets below are in spec pixels, so the widgets must be
+    // measured with the shipped metrics. Production installs this stylesheet
+    // in `Windows::new`; without it — and without a neutral font DPI — GTK
+    // sizes everything from the tester's desktop theme, and a text-scaling
+    // factor alone inflates the rows past the budgets' headroom.
+    let css_provider = gtk4::CssProvider::new();
+    css_provider.load_from_string(&crate::toolbar_gtk::css::stylesheet(1.0));
+    if let Some(display) = gtk4::gdk::Display::default() {
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &css_provider,
+            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+    }
+    if let Some(settings) = gtk4::Settings::default() {
+        settings.set_gtk_font_name(Some("Sans 11"));
+        settings.set_gtk_xft_dpi(96 * 1024);
+    }
+
     let state = make_test_input_state();
     let regular = ToolbarSnapshot::from_input_with_bindings(
         &state,
@@ -2205,6 +2224,9 @@ fn actual_gtk_widgets_match_the_shared_contract_without_presenting_a_window() {
         model::ToolbarSettingsModel::for_popover(&settings_snapshot).expect("settings model");
     let (settings_content, settings_updaters) =
         menu_top.build_settings_popover_content(&settings_snapshot, 1.0);
+    // Production parents popover content under the classed bar; measured
+    // standalone, the scoped stylesheet would never reach it.
+    settings_content.add_css_class("wayscriber-toolbar");
     let settings_scroller = settings_content
         .clone()
         .downcast::<gtk4::ScrolledWindow>()


### PR DESCRIPTION
## Summary

Follow-up to #320.

This fixes ordering and teardown races in the durable F9 toolbar-visibility and F2 display-mode paths. It also makes the GTK popover contract test deterministic, ensuring Cargo reaches the downstream test targets that the previous failure had masked.

Previously, toolbar persistence shared a single backend action slot with captures, exports, and clear- saved operations. Multiple actions in one input batch could overwrite each other, and exiting while a reset or recovery barrier was active could discard a deferred toolbar change.

## What changed

### Ordered toolbar persistence

- Moved durable F9 and F2 changes into a dedicated ordered queue.
- Coalesced repeated changes by persistence kind while retaining the original rollback baseline.
- Filtered no-op bursts when draining, so returning to the starting state writes nothing.
- Drained toolbar persistence on every event-loop pass without introducing a zero-timeout busy loop.
- Prevented captures, exports, and other backend actions from replacing pending toolbar writes.

### Barrier-safe shutdown

Teardown now follows the same ordering as the live event loop:

1. Settle any writer work that can advance the active reset or recovery barrier.
2. Apply the resulting commit or rollback to live state.
3. Drain deferred toolbar persistence against that resolved state.
4. Shut down and flush the runtime-state writer.

This covers:

- Exit during an active reset.
- Exit during a recovery inspection or retry.
- Recovery work waiting in the dedicated recovery outbox.
- Deferred writes whose no-op decision depends on the post-barrier state.

Barriers that require a user-side decision remain non-settleable, so shutdown cannot hang waiting for work that the writer cannot advance.