### PR TITLE
Improve rendering hot paths and simplify runtime validation

### DIFF
--- a/src/backend/wayland/backend/event_loop/capture.rs
+++ b/src/backend/wayland/backend/event_loop/capture.rs
@@ -356,7 +356,7 @@ fn resolve_board_capture_outcome(
                 mime_type: image.format.mime_type,
                 width: image.width,
                 height: image.height,
-                bytes: image.bytes,
+                bytes: image.bytes.into(),
             };
             state
                 .input_state

--- a/src/backend/wayland/backend/state_init/session.rs
+++ b/src/backend/wayland/backend/state_init/session.rs
@@ -43,7 +43,7 @@ pub(super) fn build_session_options(
                 let default_base = paths::data_dir()
                     .unwrap_or_else(|| config_dir.to_path_buf())
                     .join("wayscriber");
-                let display = display_env.clone().unwrap_or_else(|| "default".to_string());
+                let display = display_env.unwrap_or_else(|| "default".to_string());
                 session_options = Some(session::SessionOptions::new(default_base, display));
             }
             if let Some(options) = session_options.as_mut() {

--- a/src/backend/wayland/clipboard/image.rs
+++ b/src/backend/wayland/clipboard/image.rs
@@ -57,7 +57,7 @@ pub(super) fn decode_clipboard_image(mime_type: &str, bytes: Vec<u8>) -> Clipboa
         mime_type: canonical_image_mime_type(format).to_string(),
         width: dimensions.0,
         height: dimensions.1,
-        bytes,
+        bytes: bytes.into(),
     })
 }
 

--- a/src/backend/wayland/clipboard/transfer/tests.rs
+++ b/src/backend/wayland/clipboard/transfer/tests.rs
@@ -98,7 +98,7 @@ fn clipboard_terminal_outcomes_keep_their_existing_event_loop_policy() {
                 mime_type: "image/png".to_string(),
                 width: 1,
                 height: 1,
-                bytes: vec![0, 0, 0, 255],
+                bytes: vec![0, 0, 0, 255].into(),
             }),
         },
         Some(42),

--- a/src/backend/wayland/handlers/pointer/cursor.rs
+++ b/src/backend/wayland/handlers/pointer/cursor.rs
@@ -373,9 +373,10 @@ impl WaylandState {
         let Some(pointer) = self.current_pointer() else {
             return;
         };
-        let serial = pointer
-            .data::<PointerData>()
-            .and_then(|data| data.latest_button_serial().or(data.latest_enter_serial()));
+        let serial = pointer.data::<PointerData>().and_then(|data| {
+            data.latest_button_serial()
+                .or_else(|| data.latest_enter_serial())
+        });
         let Some(serial) = serial else {
             return;
         };

--- a/src/backend/wayland/state/clipboard/session_paste/tests.rs
+++ b/src/backend/wayland/state/clipboard/session_paste/tests.rs
@@ -209,7 +209,7 @@ fn test_image(bytes: usize) -> EmbeddedImage {
         mime_type: "image/png".to_string(),
         width: 16,
         height: 16,
-        bytes: vec![7; bytes],
+        bytes: vec![7; bytes].into(),
     }
 }
 

--- a/src/backend/wayland/state/core/output/focus.rs
+++ b/src/backend/wayland/state/core/output/focus.rs
@@ -44,9 +44,7 @@ impl WaylandState {
         }
 
         let surface_current_output = self.surface.current_output();
-        let current_output = surface_current_output
-            .clone()
-            .or_else(|| self.preferred_fullscreen_output());
+        let current_output = surface_current_output.or_else(|| self.preferred_fullscreen_output());
         let current_index = current_output
             .as_ref()
             .and_then(|current| outputs.iter().position(|output| output == current))

--- a/src/backend/wayland/state/core/output/transition.rs
+++ b/src/backend/wayland/state/core/output/transition.rs
@@ -6,10 +6,9 @@ impl WaylandState {
         physical_output_identity: Option<String>,
         reason: &str,
     ) {
-        let Some(current_options) = self.session_options().cloned() else {
+        let Some(mut staged_options) = self.session_options().cloned() else {
             return;
         };
-        let mut staged_options = current_options.clone();
         let changed = staged_options.set_output_identity(physical_output_identity.as_deref());
         let same_epoch_pending = self
             .session

--- a/src/backend/wayland/state/region_capture/window_snap.rs
+++ b/src/backend/wayland/state/region_capture/window_snap.rs
@@ -1,7 +1,7 @@
 use crate::backend::wayland::state::WaylandState;
 use crate::backend::wayland::state::screen_image::{ScreenSourceToken, screen_rect_for_image_rect};
 use crate::capture::window_geometry::{WindowQueryContext, WindowTarget};
-use crate::input::state::{RegionInputSource, RegionPurposeTag};
+use crate::input::state::{RegionInputSource, RegionPurposeTag, RegionSelection};
 use crate::screen_pixels::{ImagePixelRect, ImagePoint};
 use crate::util::Rect;
 
@@ -38,15 +38,19 @@ impl WindowSnapTarget {
         self.image_rect
     }
 
+    #[cfg(test)]
     pub(in crate::backend::wayland) const fn screen_rect(&self) -> Rect {
         self.screen_rect
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 enum WindowSnapAvailability {
     Pending(WindowSnapQueryStage),
-    Ready(Vec<WindowSnapTarget>),
+    Ready {
+        targets: Vec<WindowSnapTarget>,
+        display_selections: Vec<RegionSelection>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -121,7 +125,7 @@ impl WindowSnapSession {
     }
 
     pub(super) fn is_ready(&self) -> bool {
-        matches!(self.availability, WindowSnapAvailability::Ready(_))
+        matches!(self.availability, WindowSnapAvailability::Ready { .. })
     }
 
     pub(super) const fn mode_active(&self) -> bool {
@@ -131,7 +135,16 @@ impl WindowSnapSession {
     pub(super) fn targets(&self) -> &[WindowSnapTarget] {
         match &self.availability {
             WindowSnapAvailability::Pending(_) => &[],
-            WindowSnapAvailability::Ready(targets) => targets,
+            WindowSnapAvailability::Ready { targets, .. } => targets,
+        }
+    }
+
+    pub(super) fn display_selections(&self) -> &[RegionSelection] {
+        match &self.availability {
+            WindowSnapAvailability::Pending(_) => &[],
+            WindowSnapAvailability::Ready {
+                display_selections, ..
+            } => display_selections,
         }
     }
 
@@ -251,8 +264,25 @@ pub(super) fn apply_window_query_completion(
     let current = session
         .as_mut()
         .expect("a correlated pending window-snap session still exists");
-    current.availability = WindowSnapAvailability::Ready(mapped);
+    let display_selections = mapped
+        .iter()
+        .map(|target| region_selection_for_rect(target.screen_rect))
+        .collect();
+    current.availability = WindowSnapAvailability::Ready {
+        targets: mapped,
+        display_selections,
+    };
     WindowQueryApply::Ready
+}
+
+fn region_selection_for_rect(rect: Rect) -> RegionSelection {
+    RegionSelection {
+        start: (f64::from(rect.x), f64::from(rect.y)),
+        end: (
+            f64::from(rect.x) + f64::from(rect.width),
+            f64::from(rect.y) + f64::from(rect.height),
+        ),
+    }
 }
 
 fn map_window_target(source: ScreenSourceToken, target: WindowTarget) -> Option<WindowSnapTarget> {
@@ -300,11 +330,13 @@ impl WaylandState {
             .is_some_and(WindowSnapSession::mode_active)
     }
 
-    pub(in crate::backend::wayland) fn region_window_snap_targets(&self) -> &[WindowSnapTarget] {
+    pub(in crate::backend::wayland) fn region_window_snap_display_selections(
+        &self,
+    ) -> &[RegionSelection] {
         self.data
             .window_snap
             .as_ref()
-            .map(WindowSnapSession::targets)
+            .map(WindowSnapSession::display_selections)
             .unwrap_or_default()
     }
 

--- a/src/backend/wayland/state/region_capture/window_snap/tests.rs
+++ b/src/backend/wayland/state/region_capture/window_snap/tests.rs
@@ -111,6 +111,13 @@ fn output_logical_window_maps_to_authoritative_pixels_then_zoomed_screen() {
     let mapped = &session.targets()[0];
     assert_eq!(mapped.image_rect().size(), (450, 300));
     assert_eq!(mapped.screen_rect(), Rect::new(150, 75, 450, 300).unwrap());
+    assert_eq!(
+        session.display_selections(),
+        &[RegionSelection {
+            start: (150.0, 75.0),
+            end: (600.0, 375.0),
+        }]
+    );
 }
 
 #[test]

--- a/src/backend/wayland/state/render/ui.rs
+++ b/src/backend/wayland/state/render/ui.rs
@@ -447,24 +447,10 @@ impl WaylandState {
                 (image_point.x, image_point.y),
             )
         });
-        let window_targets: Vec<_> = self
-            .region_window_snap_targets()
-            .iter()
-            .map(|target| {
-                let rect = target.screen_rect();
-                crate::input::state::RegionSelection {
-                    start: (f64::from(rect.x), f64::from(rect.y)),
-                    end: (
-                        f64::from(rect.x + rect.width),
-                        f64::from(rect.y + rect.height),
-                    ),
-                }
-            })
-            .collect();
         let window = crate::ui::RegionCaptureWindowVisual {
             available: self.region_window_snap_available(),
             active: self.region_window_snap_active(),
-            targets: &window_targets,
+            targets: self.region_window_snap_display_selections(),
             highlighted_target: self.region_window_snap_highlighted_index(),
         };
 

--- a/src/backend/wayland/state/render/ui.rs
+++ b/src/backend/wayland/state/render/ui.rs
@@ -458,7 +458,7 @@ impl WaylandState {
             ctx,
             width,
             height,
-            crate::ui::RegionCapturePickerVisual {
+            &crate::ui::RegionCapturePickerVisual {
                 selection,
                 pointer,
                 measurement: measurement.as_deref(),

--- a/src/backend/wayland/state/toolbar/events/session.rs
+++ b/src/backend/wayland/state/toolbar/events/session.rs
@@ -11,7 +11,6 @@ pub(super) fn populate_session_snapshot(
 ) {
     let active_path = options.map(|options| options.session_file_path());
     snapshot.active_session_name = active_path.as_deref().map(session_display_name);
-    snapshot.active_session_path = active_path.clone();
     // Recents are only read (from the catalog on disk) while the top strip's
     // Session popover is up.
     snapshot.recent_sessions = if snapshot.session_popover_open {
@@ -19,6 +18,7 @@ pub(super) fn populate_session_snapshot(
     } else {
         Vec::new()
     };
+    snapshot.active_session_path = active_path;
 }
 
 fn session_display_name(path: &Path) -> String {

--- a/src/backend/wayland/state/toolbar/visibility/pointer.rs
+++ b/src/backend/wayland/state/toolbar/visibility/pointer.rs
@@ -65,7 +65,10 @@ impl WaylandState {
         // Hide the cursor while dragging with pointer lock to avoid visual jitter.
         if pointer
             .data::<PointerData>()
-            .and_then(|data| data.latest_button_serial().or(data.latest_enter_serial()))
+            .and_then(|data| {
+                data.latest_button_serial()
+                    .or_else(|| data.latest_enter_serial())
+            })
             .is_some()
         {
             self.hide_pointer_cursor();

--- a/src/backend/wayland/toolbar/main/render.rs
+++ b/src/backend/wayland/toolbar/main/render.rs
@@ -16,7 +16,9 @@ impl ToolbarSurfaceManager {
             return;
         }
         self.top.set_ui_scale(snapshot.toolbar_scale);
-        let top_hover = hover.or(self.top_hover).or(self.top.focused_hover());
+        let top_hover = hover
+            .or(self.top_hover)
+            .or_else(|| self.top.focused_hover());
         let top_hover_start = self.top_hover_start;
         if let Err(err) = self.top.render(
             shm,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -257,12 +257,23 @@ impl Cli {
     }
 
     fn validate(&self) -> Result<(), String> {
+        self.validate_runtime_capabilities_command()?;
+        self.validate_session_flag_pairs()?;
+        self.validate_overlay_commands()?;
+        self.validate_session_commands()?;
+        self.validate_catalog_commands()
+    }
+
+    fn validate_runtime_capabilities_command(&self) -> Result<(), String> {
         if self.runtime_capabilities
             && (self.selects_a_launch_command() || self.about || self.check_update)
         {
             return Err("--runtime-capabilities conflicts with launch flags".to_string());
         }
+        Ok(())
+    }
 
+    fn validate_session_flag_pairs(&self) -> Result<(), String> {
         if self.exit_after_capture && self.no_exit_after_capture {
             return Err(conflict("--exit-after-capture", "--no-exit-after-capture"));
         }
@@ -294,7 +305,10 @@ impl Cli {
         if self.rename_session.is_some() && self.selects_overlay_option() {
             return Err("--rename-session conflicts with overlay/daemon options".to_string());
         }
+        Ok(())
+    }
 
+    fn validate_overlay_commands(&self) -> Result<(), String> {
         if self.freeze_on_show && !self.daemon {
             return Err("--freeze-on-show requires --daemon".to_string());
         }
@@ -308,16 +322,7 @@ impl Cli {
             return Err("--freeze-on-show conflicts with overlay/session commands".to_string());
         }
 
-        let overlay_action_count = [
-            self.daemon_action.is_some(),
-            self.light_toggle,
-            self.light_draw_toggle,
-            self.light_draw_on,
-            self.light_draw_off,
-        ]
-        .into_iter()
-        .filter(|selected| *selected)
-        .count();
+        let overlay_action_count = self.overlay_action_count();
 
         if self.session_file.is_some() {
             if overlay_action_count > 0 {
@@ -388,7 +393,23 @@ impl Cli {
         {
             return Err("daemon overlay actions cannot be combined with launch flags".to_string());
         }
+        Ok(())
+    }
 
+    fn overlay_action_count(&self) -> usize {
+        [
+            self.daemon_action.is_some(),
+            self.light_toggle,
+            self.light_draw_toggle,
+            self.light_draw_on,
+            self.light_draw_off,
+        ]
+        .into_iter()
+        .filter(|selected| *selected)
+        .count()
+    }
+
+    fn validate_session_commands(&self) -> Result<(), String> {
         if self.clear_session && (self.daemon || self.active) {
             return Err("--clear-session conflicts with --daemon/--active".to_string());
         }
@@ -429,6 +450,10 @@ impl Cli {
                     .to_string(),
             );
         }
+        Ok(())
+    }
+
+    fn validate_catalog_commands(&self) -> Result<(), String> {
         if self.about && (self.selects_a_launch_command() || self.check_update) {
             return Err("--about conflicts with the selected command".to_string());
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -521,7 +521,7 @@ fn value_after(args: &[String], index: usize, name: &str) -> Result<String, Stri
 fn attached_short_value(arg: &str, value_start: usize, name: &str) -> Result<String, String> {
     let value = arg[value_start..]
         .strip_prefix('=')
-        .unwrap_or(&arg[value_start..]);
+        .unwrap_or_else(|| &arg[value_start..]);
     if value.is_empty() {
         return Err(format!("{name} requires a value"));
     }

--- a/src/config/tests/validate.rs
+++ b/src/config/tests/validate.rs
@@ -515,6 +515,7 @@ fn validate_clamps_preset_fields() {
         show_status_bar: None,
         drag_tools: None,
     });
+    config.presets.slot_5 = config.presets.slot_1.clone();
 
     config.validate_and_clamp();
 
@@ -536,6 +537,10 @@ fn validate_clamps_preset_fields() {
     assert_eq!(preset.arrow_length, Some(50.0));
     assert_eq!(preset.arrow_angle, Some(15.0));
     assert_eq!(preset.polygon_sides, Some(3));
+    assert_eq!(
+        config.presets.slot_5, config.presets.slot_1,
+        "the same validation must reach the last supported slot"
+    );
 }
 
 #[test]

--- a/src/config/validate/presets.rs
+++ b/src/config/validate/presets.rs
@@ -4,133 +4,143 @@ use crate::input::state::{MAX_STROKE_THICKNESS, MIN_STROKE_THICKNESS};
 
 use super::super::types::{PRESET_SLOTS_MAX, PRESET_SLOTS_MIN, ToolPresetConfig};
 
+#[derive(Clone, Copy)]
+struct PresetFloatRange {
+    label: &'static str,
+    min: f64,
+    max: f64,
+    precision: usize,
+}
+
+const MARKER_OPACITY: PresetFloatRange = PresetFloatRange {
+    label: "marker_opacity",
+    min: 0.05,
+    max: 0.9,
+    precision: 2,
+};
+const FONT_SIZE: PresetFloatRange = PresetFloatRange {
+    label: "font_size",
+    min: 8.0,
+    max: 72.0,
+    precision: 1,
+};
+const ARROW_LENGTH: PresetFloatRange = PresetFloatRange {
+    label: "arrow_length",
+    min: 5.0,
+    max: 50.0,
+    precision: 1,
+};
+const ARROW_ANGLE: PresetFloatRange = PresetFloatRange {
+    label: "arrow_angle",
+    min: 15.0,
+    max: 60.0,
+    precision: 1,
+};
+
 impl Config {
     pub(super) fn validate_presets(&mut self) {
-        if !(PRESET_SLOTS_MIN..=PRESET_SLOTS_MAX).contains(&self.presets.slot_count) {
-            log::warn!(
-                "Invalid preset slot_count {}, clamping to {}-{} range",
-                self.presets.slot_count,
-                PRESET_SLOTS_MIN,
-                PRESET_SLOTS_MAX
-            );
-            self.presets.slot_count = self
-                .presets
-                .slot_count
-                .clamp(PRESET_SLOTS_MIN, PRESET_SLOTS_MAX);
-        }
-
-        let clamp_preset = |slot: usize, preset: &mut ToolPresetConfig| {
-            let clamp_size = |value: &mut f64, label: &str| {
-                if !(MIN_STROKE_THICKNESS..=MAX_STROKE_THICKNESS).contains(&*value) {
-                    log::warn!(
-                        "Invalid preset {} {:.1} in slot {}, clamping to {:.1}-{:.1} range",
-                        label,
-                        *value,
-                        slot,
-                        MIN_STROKE_THICKNESS,
-                        MAX_STROKE_THICKNESS
-                    );
-                    *value = value.clamp(MIN_STROKE_THICKNESS, MAX_STROKE_THICKNESS);
-                }
-            };
-
-            if !(MIN_STROKE_THICKNESS..=MAX_STROKE_THICKNESS).contains(&preset.size) {
-                log::warn!(
-                    "Invalid preset size {:.1} in slot {}, clamping to {:.1}-{:.1} range",
-                    preset.size,
-                    slot,
-                    MIN_STROKE_THICKNESS,
-                    MAX_STROKE_THICKNESS
-                );
-                preset.size = preset
-                    .size
-                    .clamp(MIN_STROKE_THICKNESS, MAX_STROKE_THICKNESS);
+        validate_slot_count(&mut self.presets.slot_count);
+        for (slot, preset) in [
+            (1, self.presets.slot_1.as_mut()),
+            (2, self.presets.slot_2.as_mut()),
+            (3, self.presets.slot_3.as_mut()),
+            (4, self.presets.slot_4.as_mut()),
+            (5, self.presets.slot_5.as_mut()),
+        ] {
+            if let Some(preset) = preset {
+                validate_preset(slot, preset);
             }
-
-            if let Some(tool_settings) = preset.tool_settings.as_mut() {
-                clamp_size(&mut tool_settings.pen.size, "pen size");
-                clamp_size(&mut tool_settings.line.size, "line size");
-                clamp_size(&mut tool_settings.rect.size, "rect size");
-                clamp_size(&mut tool_settings.ellipse.size, "ellipse size");
-                clamp_size(&mut tool_settings.arrow.size, "arrow size");
-                clamp_size(&mut tool_settings.blur.size, "blur size");
-                clamp_size(&mut tool_settings.marker.size, "marker size");
-                clamp_size(&mut tool_settings.step_marker.size, "step marker size");
-                clamp_size(&mut tool_settings.eraser_size, "eraser size");
-            }
-
-            if let Some(opacity) = preset.marker_opacity.as_mut()
-                && !(0.05..=0.9).contains(opacity)
-            {
-                log::warn!(
-                    "Invalid marker_opacity {:.2} in preset slot {}, clamping to 0.05-0.90 range",
-                    *opacity,
-                    slot
-                );
-                *opacity = opacity.clamp(0.05, 0.9);
-            }
-
-            if let Some(size) = preset.font_size.as_mut()
-                && !(8.0..=72.0).contains(size)
-            {
-                log::warn!(
-                    "Invalid font_size {:.1} in preset slot {}, clamping to 8.0-72.0 range",
-                    *size,
-                    slot
-                );
-                *size = size.clamp(8.0, 72.0);
-            }
-
-            if let Some(length) = preset.arrow_length.as_mut()
-                && !(5.0..=50.0).contains(length)
-            {
-                log::warn!(
-                    "Invalid arrow_length {:.1} in preset slot {}, clamping to 5.0-50.0 range",
-                    *length,
-                    slot
-                );
-                *length = length.clamp(5.0, 50.0);
-            }
-
-            if let Some(angle) = preset.arrow_angle.as_mut()
-                && !(15.0..=60.0).contains(angle)
-            {
-                log::warn!(
-                    "Invalid arrow_angle {:.1} in preset slot {}, clamping to 15.0-60.0 range",
-                    *angle,
-                    slot
-                );
-                *angle = angle.clamp(15.0, 60.0);
-            }
-
-            if let Some(sides) = preset.polygon_sides.as_mut()
-                && !(REGULAR_POLYGON_MIN_SIDES..=REGULAR_POLYGON_MAX_SIDES).contains(sides)
-            {
-                log::warn!(
-                    "Invalid polygon_sides {} in preset slot {}, clamping to {}-{} range",
-                    *sides,
-                    slot,
-                    REGULAR_POLYGON_MIN_SIDES,
-                    REGULAR_POLYGON_MAX_SIDES
-                );
-                *sides = clamp_regular_sides(*sides);
-            }
-        };
-
-        if let Some(preset) = self.presets.slot_1.as_mut() {
-            clamp_preset(1, preset);
-        }
-        if let Some(preset) = self.presets.slot_2.as_mut() {
-            clamp_preset(2, preset);
-        }
-        if let Some(preset) = self.presets.slot_3.as_mut() {
-            clamp_preset(3, preset);
-        }
-        if let Some(preset) = self.presets.slot_4.as_mut() {
-            clamp_preset(4, preset);
-        }
-        if let Some(preset) = self.presets.slot_5.as_mut() {
-            clamp_preset(5, preset);
         }
     }
+}
+
+fn validate_slot_count(slot_count: &mut usize) {
+    if (PRESET_SLOTS_MIN..=PRESET_SLOTS_MAX).contains(slot_count) {
+        return;
+    }
+    log::warn!(
+        "Invalid preset slot_count {}, clamping to {}-{} range",
+        *slot_count,
+        PRESET_SLOTS_MIN,
+        PRESET_SLOTS_MAX
+    );
+    *slot_count = (*slot_count).clamp(PRESET_SLOTS_MIN, PRESET_SLOTS_MAX);
+}
+
+fn validate_preset(slot: usize, preset: &mut ToolPresetConfig) {
+    clamp_stroke_size(slot, "size", &mut preset.size);
+    if let Some(tool_settings) = preset.tool_settings.as_mut() {
+        for (label, size) in [
+            ("pen size", &mut tool_settings.pen.size),
+            ("line size", &mut tool_settings.line.size),
+            ("rect size", &mut tool_settings.rect.size),
+            ("ellipse size", &mut tool_settings.ellipse.size),
+            ("arrow size", &mut tool_settings.arrow.size),
+            ("blur size", &mut tool_settings.blur.size),
+            ("marker size", &mut tool_settings.marker.size),
+            ("step marker size", &mut tool_settings.step_marker.size),
+            ("eraser size", &mut tool_settings.eraser_size),
+        ] {
+            clamp_stroke_size(slot, label, size);
+        }
+    }
+
+    clamp_optional_float(slot, &mut preset.marker_opacity, MARKER_OPACITY);
+    clamp_optional_float(slot, &mut preset.font_size, FONT_SIZE);
+    clamp_optional_float(slot, &mut preset.arrow_length, ARROW_LENGTH);
+    clamp_optional_float(slot, &mut preset.arrow_angle, ARROW_ANGLE);
+    clamp_polygon_sides(slot, &mut preset.polygon_sides);
+}
+
+fn clamp_stroke_size(slot: usize, label: &str, value: &mut f64) {
+    if (MIN_STROKE_THICKNESS..=MAX_STROKE_THICKNESS).contains(value) {
+        return;
+    }
+    log::warn!(
+        "Invalid preset {} {:.1} in slot {}, clamping to {:.1}-{:.1} range",
+        label,
+        *value,
+        slot,
+        MIN_STROKE_THICKNESS,
+        MAX_STROKE_THICKNESS
+    );
+    *value = value.clamp(MIN_STROKE_THICKNESS, MAX_STROKE_THICKNESS);
+}
+
+fn clamp_optional_float(slot: usize, value: &mut Option<f64>, range: PresetFloatRange) {
+    let Some(value) = value.as_mut() else {
+        return;
+    };
+    if (range.min..=range.max).contains(value) {
+        return;
+    }
+    log::warn!(
+        "Invalid {} {:.*} in preset slot {}, clamping to {:.*}-{:.*} range",
+        range.label,
+        range.precision,
+        *value,
+        slot,
+        range.precision,
+        range.min,
+        range.precision,
+        range.max
+    );
+    *value = value.clamp(range.min, range.max);
+}
+
+fn clamp_polygon_sides(slot: usize, sides: &mut Option<u8>) {
+    let Some(sides) = sides.as_mut() else {
+        return;
+    };
+    if (REGULAR_POLYGON_MIN_SIDES..=REGULAR_POLYGON_MAX_SIDES).contains(sides) {
+        return;
+    }
+    log::warn!(
+        "Invalid polygon_sides {} in preset slot {}, clamping to {}-{} range",
+        *sides,
+        slot,
+        REGULAR_POLYGON_MIN_SIDES,
+        REGULAR_POLYGON_MAX_SIDES
+    );
+    *sides = clamp_regular_sides(*sides);
 }

--- a/src/daemon/overlay/mod.rs
+++ b/src/daemon/overlay/mod.rs
@@ -42,7 +42,9 @@ impl Daemon {
                 .pending_toggle_request
                 .as_ref()
                 .and_then(|request| request.session_resume_override());
-            set_runtime_session_override(request_override.or(self.session_resume_override()));
+            set_runtime_session_override(
+                request_override.or_else(|| self.session_resume_override()),
+            );
             let requested_mode = self
                 .pending_toggle_request
                 .as_ref()

--- a/src/draw/frame/tests/history/basics.rs
+++ b/src/draw/frame/tests/history/basics.rs
@@ -159,7 +159,7 @@ fn modify_image_bounds_undo_redo_changes_geometry_without_replacing_payload() {
             mime_type: "image/png".to_string(),
             width: 10,
             height: 8,
-            bytes: vec![1, 2, 3, 4],
+            bytes: vec![1, 2, 3, 4].into(),
         },
     });
     if let Shape::Image { x, y, w, h, .. } = &mut frame.shape_mut(id).unwrap().shape {
@@ -194,7 +194,7 @@ fn modify_image_bounds_undo_redo_changes_geometry_without_replacing_payload() {
     match &frame.shape(id).unwrap().shape {
         Shape::Image { x, y, w, h, data } => {
             assert_eq!((*x, *y, *w, *h), (0, 0, 10, 8));
-            assert_eq!(data.bytes, vec![1, 2, 3, 4]);
+            assert_eq!(data.bytes.as_ref(), [1, 2, 3, 4]);
         }
         _ => panic!("expected image"),
     }
@@ -203,7 +203,7 @@ fn modify_image_bounds_undo_redo_changes_geometry_without_replacing_payload() {
     match &frame.shape(id).unwrap().shape {
         Shape::Image { x, y, w, h, data } => {
             assert_eq!((*x, *y, *w, *h), (20, 30, 40, 32));
-            assert_eq!(data.bytes, vec![1, 2, 3, 4]);
+            assert_eq!(data.bytes.as_ref(), [1, 2, 3, 4]);
         }
         _ => panic!("expected image"),
     }

--- a/src/draw/frame/tests/serialization.rs
+++ b/src/draw/frame/tests/serialization.rs
@@ -136,7 +136,7 @@ fn image_bounds_history_serializes_without_duplicate_image_payloads() {
             mime_type: "image/png".to_string(),
             width: 16,
             height: 16,
-            bytes,
+            bytes: bytes.into(),
         },
     });
     let index = frame.find_index(id).unwrap();

--- a/src/draw/render/image.rs
+++ b/src/draw/render/image.rs
@@ -2,17 +2,35 @@ use crate::draw::shape::EmbeddedImage;
 use crate::image_decode::{decode_rgba, format_from_mime_or_bytes};
 use cairo::{Format, ImageSurface};
 use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque, hash_map::DefaultHasher};
+use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+use std::sync::Arc;
 
 const IMAGE_CACHE_ENTRIES: usize = 32;
+
+#[derive(Clone, Debug)]
+struct ImageBytesIdentity(Arc<[u8]>);
+
+impl PartialEq for ImageBytesIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for ImageBytesIdentity {}
+
+impl Hash for ImageBytesIdentity {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ptr().hash(state);
+        self.0.len().hash(state);
+    }
+}
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct ImageCacheKey {
     mime_type: String,
-    len: usize,
-    hash: u64,
+    bytes: ImageBytesIdentity,
     width: u32,
     height: u32,
 }
@@ -92,8 +110,7 @@ pub fn render_image_shape(
 fn cached_surface(data: &EmbeddedImage) -> Option<Rc<ImageSurface>> {
     let key = ImageCacheKey {
         mime_type: data.mime_type.clone(),
-        len: data.bytes.len(),
-        hash: content_hash(&data.bytes),
+        bytes: ImageBytesIdentity(Arc::clone(&data.bytes)),
         width: data.width,
         height: data.height,
     };
@@ -148,12 +165,6 @@ fn decode_surface(data: &EmbeddedImage) -> Option<ImageSurface> {
     .ok()
 }
 
-fn content_hash(bytes: &[u8]) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    bytes.hash(&mut hasher);
-    hasher.finish()
-}
-
 fn render_missing_image_placeholder(ctx: &cairo::Context, x: i32, y: i32, w: i32, h: i32) {
     let width = w.saturating_abs().max(1) as f64;
     let height = h.saturating_abs().max(1) as f64;
@@ -173,4 +184,21 @@ fn render_missing_image_placeholder(ctx: &cairo::Context, x: i32, y: i32, w: i32
     ctx.line_to(draw_x, draw_y + height);
     let _ = ctx.stroke();
     let _ = ctx.restore();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ImageBytesIdentity;
+    use std::sync::Arc;
+
+    #[test]
+    fn cache_identity_follows_shared_payload_allocation() {
+        let bytes: Arc<[u8]> = vec![1, 2, 3].into();
+        let shared = ImageBytesIdentity(Arc::clone(&bytes));
+        let same_allocation = ImageBytesIdentity(Arc::clone(&bytes));
+        let equal_bytes_in_another_allocation = ImageBytesIdentity(vec![1, 2, 3].into());
+
+        assert_eq!(shared, same_allocation);
+        assert_ne!(shared, equal_bytes_in_another_allocation);
+    }
 }

--- a/src/draw/render/pressure_strokes.rs
+++ b/src/draw/render/pressure_strokes.rs
@@ -5,7 +5,7 @@ const PRESSURE_STROKE_MAX_SUBDIVISIONS: usize = 128;
 const PRESSURE_STROKE_MIN_WIDTH: f64 = 0.1;
 const PRESSURE_STROKE_EPSILON: f64 = 0.000_001;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 struct PressureStrokeSample {
     x: f64,
     y: f64,
@@ -67,11 +67,35 @@ fn pressure_stroke_samples(
     thicknesses: &[f32],
 ) -> Vec<PressureStrokeSample> {
     let len = points.len().min(thicknesses.len());
-    let mut samples = Vec::with_capacity(len);
+    pressure_stroke_samples_from_iter(
+        points
+            .iter()
+            .zip(thicknesses)
+            .map(|(&(x, y), &width)| (x, y, width)),
+        len,
+    )
+}
 
-    for i in 0..len {
-        let (x, y) = points[i];
-        let width = (thicknesses[i] as f64).max(PRESSURE_STROKE_MIN_WIDTH);
+fn packed_pressure_stroke_samples(
+    points: &[(i32, i32, f32)],
+    thickness_delta: f32,
+) -> Vec<PressureStrokeSample> {
+    pressure_stroke_samples_from_iter(
+        points
+            .iter()
+            .map(|&(x, y, width)| (x, y, width + thickness_delta)),
+        points.len(),
+    )
+}
+
+fn pressure_stroke_samples_from_iter(
+    points: impl Iterator<Item = (i32, i32, f32)>,
+    capacity: usize,
+) -> Vec<PressureStrokeSample> {
+    let mut samples = Vec::with_capacity(capacity);
+
+    for (x, y, width) in points {
+        let width = f64::from(width).max(PRESSURE_STROKE_MIN_WIDTH);
         let current = PressureStrokeSample {
             x: x as f64,
             y: y as f64,
@@ -226,6 +250,26 @@ pub fn render_freehand_pressure_borrowed(
     }
 
     let samples = pressure_stroke_samples(points, thicknesses);
+    render_pressure_samples(ctx, &samples, color);
+}
+
+/// Render packed `(x, y, thickness)` pressure samples without first splitting
+/// the stored stroke into parallel coordinate and thickness buffers.
+pub(crate) fn render_packed_freehand_pressure_borrowed(
+    ctx: &cairo::Context,
+    points: &[(i32, i32, f32)],
+    thickness_delta: f32,
+    color: Color,
+) {
+    if points.is_empty() {
+        return;
+    }
+
+    let samples = packed_pressure_stroke_samples(points, thickness_delta);
+    render_pressure_samples(ctx, &samples, color);
+}
+
+fn render_pressure_samples(ctx: &cairo::Context, samples: &[PressureStrokeSample], color: Color) {
     if samples.is_empty() {
         return;
     }
@@ -234,7 +278,7 @@ pub fn render_freehand_pressure_borrowed(
     ctx.push_group_with_content(cairo::Content::Alpha);
     ctx.set_operator(cairo::Operator::Over);
     ctx.set_source_rgba(1.0, 1.0, 1.0, 1.0);
-    fill_pressure_geometry(ctx, &samples);
+    fill_pressure_geometry(ctx, samples);
 
     if let Ok(mask) = ctx.pop_group() {
         ctx.set_source_rgba(color.r, color.g, color.b, color.a);
@@ -281,6 +325,30 @@ mod tests {
             .unwrap()
             .chunks_exact(4)
             .any(|pixel| pixel[3] > 0)
+    }
+
+    #[test]
+    fn packed_samples_match_parallel_pressure_buffers() {
+        let packed = [(10, 20, 4.0), (30, 40, 8.0), (50, 25, 2.0)];
+        let points = [(10, 20), (30, 40), (50, 25)];
+        let thicknesses = [4.0, 8.0, 2.0];
+
+        assert_eq!(
+            packed_pressure_stroke_samples(&packed, 0.0),
+            pressure_stroke_samples(&points, &thicknesses)
+        );
+    }
+
+    #[test]
+    fn packed_samples_apply_selection_thickness_delta() {
+        let packed = [(10, 20, 4.0), (30, 40, 8.0)];
+        let points = [(10, 20), (30, 40)];
+        let thicknesses = [8.0, 12.0];
+
+        assert_eq!(
+            packed_pressure_stroke_samples(&packed, 4.0),
+            pressure_stroke_samples(&points, &thicknesses)
+        );
     }
 
     #[test]

--- a/src/draw/render/selection.rs
+++ b/src/draw/render/selection.rs
@@ -40,16 +40,8 @@ pub fn render_selection_halo(ctx: &cairo::Context, drawn: &DrawnShape) {
             render_freehand_borrowed(ctx, points, glow, thick + outline_width);
         }
         Shape::FreehandPressure { points, .. } => {
-            // For pressure lines, we render the same variable-width line but with extra thickness
-            // Split points into coords and thickness
-            let coords: Vec<(i32, i32)> = points.iter().map(|&(x, y, _)| (x, y)).collect();
-            let thickness: Vec<f32> = points
-                .iter()
-                .map(|&(_, _, t)| t + outline_width as f32)
-                .collect();
-
-            use super::pressure_strokes::render_freehand_pressure_borrowed;
-            render_freehand_pressure_borrowed(ctx, &coords, &thickness, glow);
+            use super::pressure_strokes::render_packed_freehand_pressure_borrowed;
+            render_packed_freehand_pressure_borrowed(ctx, points, outline_width as f32, glow);
         }
         Shape::Line {
             x1,

--- a/src/draw/render/shapes.rs
+++ b/src/draw/render/shapes.rs
@@ -1,7 +1,7 @@
 use super::blur::{render_black_out_rect, render_blur_placeholder};
 use super::highlight::render_click_highlight;
 use super::image::render_image_shape;
-use super::pressure_strokes::render_freehand_pressure_borrowed;
+use super::pressure_strokes::render_packed_freehand_pressure_borrowed;
 use super::primitives::{render_arrow, render_ellipse, render_line, render_polygon, render_rect};
 use super::strokes::{render_freehand_borrowed, render_marker_stroke_borrowed};
 use super::text::{render_sticky_note, render_text_over_with_halo};
@@ -57,9 +57,7 @@ pub fn render_shape_over_with_halo(
             render_freehand_borrowed(ctx, points, *color, *thick);
         }
         Shape::FreehandPressure { points, color } => {
-            let coords: Vec<(i32, i32)> = points.iter().map(|&(x, y, _)| (x, y)).collect();
-            let thickness: Vec<f32> = points.iter().map(|&(_, _, t)| t).collect();
-            render_freehand_pressure_borrowed(ctx, &coords, &thickness, *color);
+            render_packed_freehand_pressure_borrowed(ctx, points, 0.0, *color);
         }
         Shape::Line {
             x1,

--- a/src/draw/render/shapes.rs
+++ b/src/draw/render/shapes.rs
@@ -6,11 +6,36 @@ use super::primitives::{render_arrow, render_ellipse, render_line, render_polygo
 use super::strokes::{render_freehand_borrowed, render_marker_stroke_borrowed};
 use super::text::{render_sticky_note, render_text_over_with_halo};
 use crate::draw::Color;
-use crate::draw::shape::Shape;
 use crate::draw::shape::{
-    ARROW_LABEL_BACKGROUND, arrow_label_ends, arrow_label_layout, measure_text_with_context,
-    step_marker_outline_thickness, step_marker_radius,
+    ARROW_LABEL_BACKGROUND, ArrowLabel, ArrowStyle, Shape, StepMarkerLabel, arrow_label_ends,
+    arrow_label_layout, measure_text_with_context, step_marker_outline_thickness,
+    step_marker_radius,
 };
+
+#[derive(Clone, Copy)]
+struct ShapeTextOptions {
+    known_background_luminance: Option<f64>,
+    halo_enabled: bool,
+}
+
+struct ArrowRenderSpec<'a> {
+    start: (i32, i32),
+    end: (i32, i32),
+    color: Color,
+    thickness: f64,
+    arrow_length: f64,
+    arrow_angle: f64,
+    head_at_end: bool,
+    style: ArrowStyle,
+    bend: f64,
+    label: Option<&'a ArrowLabel>,
+}
+
+struct StepMarkerRenderSpec<'a> {
+    center: (i32, i32),
+    color: Color,
+    label: &'a StepMarkerLabel,
+}
 
 /// Renders a single shape to a Cairo context.
 ///
@@ -48,6 +73,10 @@ pub fn render_shape_over_with_halo(
     known_background_luminance: Option<f64>,
     text_halo_enabled: bool,
 ) {
+    let text_options = ShapeTextOptions {
+        known_background_luminance,
+        halo_enabled: text_halo_enabled,
+    };
     match shape {
         Shape::Freehand {
             points,
@@ -114,53 +143,22 @@ pub fn render_shape_over_with_halo(
             bend,
             label,
         } => {
-            // Only the label needs these: `render_arrow` reads `head_at_end`
-            // itself. `Double` deliberately ignores the flag here, matching the
-            // outline it draws either way.
-            let (tip_x, tip_y, tail_x, tail_y) =
-                arrow_label_ends(*x1, *y1, *x2, *y2, *head_at_end, *style);
-            render_arrow(
+            render_arrow_shape(
                 ctx,
-                *x1,
-                *y1,
-                *x2,
-                *y2,
-                *color,
-                *thick,
-                *arrow_length,
-                *arrow_angle,
-                *head_at_end,
-                *style,
-                *bend,
+                ArrowRenderSpec {
+                    start: (*x1, *y1),
+                    end: (*x2, *y2),
+                    color: *color,
+                    thickness: *thick,
+                    arrow_length: *arrow_length,
+                    arrow_angle: *arrow_angle,
+                    head_at_end: *head_at_end,
+                    style: *style,
+                    bend: *bend,
+                    label: label.as_ref(),
+                },
+                text_options,
             );
-            if let Some(label) = label {
-                let label_text = label.value.to_string();
-                if let Some(layout) = arrow_label_layout(
-                    tip_x,
-                    tip_y,
-                    tail_x,
-                    tail_y,
-                    *thick,
-                    style.effective_bend(*bend),
-                    &label_text,
-                    label.size,
-                    &label.font_descriptor,
-                ) {
-                    render_text_over_with_halo(
-                        ctx,
-                        layout.x,
-                        layout.y,
-                        &label_text,
-                        *color,
-                        label.size,
-                        &label.font_descriptor,
-                        ARROW_LABEL_BACKGROUND,
-                        None,
-                        known_background_luminance,
-                        text_halo_enabled,
-                    );
-                }
-            }
         }
         Shape::BlurRect {
             x,
@@ -207,78 +205,15 @@ pub fn render_shape_over_with_halo(
             );
         }
         Shape::StepMarker { x, y, color, label } => {
-            let label_text = label.value.to_string();
-            let radius = step_marker_radius(label.value, label.size, &label.font_descriptor);
-            let outline_thickness = step_marker_outline_thickness(label.size);
-            let alpha = color.a.clamp(0.0, 1.0);
-            let fill_color = Color {
-                a: (alpha * 0.9).clamp(0.0, 1.0),
-                ..*color
-            };
-            let brightness = super::color_luminance(*color);
-            let (outline_color, text_color) = if brightness > 0.6 {
-                (
-                    Color {
-                        r: 0.05,
-                        g: 0.05,
-                        b: 0.05,
-                        a: 0.85 * alpha,
-                    },
-                    Color {
-                        r: 0.12,
-                        g: 0.12,
-                        b: 0.12,
-                        a: alpha,
-                    },
-                )
-            } else {
-                (
-                    Color {
-                        r: 0.98,
-                        g: 0.98,
-                        b: 0.98,
-                        a: 0.9 * alpha,
-                    },
-                    Color {
-                        r: 0.98,
-                        g: 0.98,
-                        b: 0.98,
-                        a: alpha,
-                    },
-                )
-            };
-            render_click_highlight(
+            render_step_marker_shape(
                 ctx,
-                *x as f64,
-                *y as f64,
-                radius,
-                outline_thickness,
-                fill_color,
-                outline_color,
-                1.0,
+                StepMarkerRenderSpec {
+                    center: (*x, *y),
+                    color: *color,
+                    label,
+                },
+                text_options,
             );
-            let font_desc = label.font_descriptor.to_pango_string(label.size);
-            if let Some(metrics) =
-                measure_text_with_context(ctx, &label_text, &font_desc, label.size, None)
-            {
-                let center_offset_x = metrics.ink_x + metrics.ink_width / 2.0;
-                let center_offset_y = metrics.ink_y + metrics.ink_height / 2.0;
-                let baseline_x = (*x as f64 - center_offset_x).round() as i32;
-                let baseline_y = (*y as f64 - center_offset_y + metrics.baseline).round() as i32;
-                render_text_over_with_halo(
-                    ctx,
-                    baseline_x,
-                    baseline_y,
-                    &label_text,
-                    text_color,
-                    label.size,
-                    &label.font_descriptor,
-                    false,
-                    None,
-                    known_background_luminance,
-                    text_halo_enabled,
-                );
-            }
         }
         Shape::StickyNote {
             x,
@@ -314,6 +249,152 @@ pub fn render_shape_over_with_halo(
             render_image_shape(ctx, *x, *y, *w, *h, data);
         }
     }
+}
+
+fn render_arrow_shape(ctx: &cairo::Context, arrow: ArrowRenderSpec<'_>, text: ShapeTextOptions) {
+    // Only the label needs these: `render_arrow` reads `head_at_end` itself.
+    // `Double` deliberately ignores the flag here, matching the outline it
+    // draws either way.
+    let (tip_x, tip_y, tail_x, tail_y) = arrow_label_ends(
+        arrow.start.0,
+        arrow.start.1,
+        arrow.end.0,
+        arrow.end.1,
+        arrow.head_at_end,
+        arrow.style,
+    );
+    render_arrow(
+        ctx,
+        arrow.start.0,
+        arrow.start.1,
+        arrow.end.0,
+        arrow.end.1,
+        arrow.color,
+        arrow.thickness,
+        arrow.arrow_length,
+        arrow.arrow_angle,
+        arrow.head_at_end,
+        arrow.style,
+        arrow.bend,
+    );
+    let Some(label) = arrow.label else {
+        return;
+    };
+    let label_text = label.value.to_string();
+    let Some(layout) = arrow_label_layout(
+        tip_x,
+        tip_y,
+        tail_x,
+        tail_y,
+        arrow.thickness,
+        arrow.style.effective_bend(arrow.bend),
+        &label_text,
+        label.size,
+        &label.font_descriptor,
+    ) else {
+        return;
+    };
+    render_text_over_with_halo(
+        ctx,
+        layout.x,
+        layout.y,
+        &label_text,
+        arrow.color,
+        label.size,
+        &label.font_descriptor,
+        ARROW_LABEL_BACKGROUND,
+        None,
+        text.known_background_luminance,
+        text.halo_enabled,
+    );
+}
+
+fn render_step_marker_shape(
+    ctx: &cairo::Context,
+    marker: StepMarkerRenderSpec<'_>,
+    text: ShapeTextOptions,
+) {
+    let label_text = marker.label.value.to_string();
+    let radius = step_marker_radius(
+        marker.label.value,
+        marker.label.size,
+        &marker.label.font_descriptor,
+    );
+    let outline_thickness = step_marker_outline_thickness(marker.label.size);
+    let alpha = marker.color.a.clamp(0.0, 1.0);
+    let fill_color = Color {
+        a: (alpha * 0.9).clamp(0.0, 1.0),
+        ..marker.color
+    };
+    let brightness = super::color_luminance(marker.color);
+    let (outline_color, text_color) = if brightness > 0.6 {
+        (
+            Color {
+                r: 0.05,
+                g: 0.05,
+                b: 0.05,
+                a: 0.85 * alpha,
+            },
+            Color {
+                r: 0.12,
+                g: 0.12,
+                b: 0.12,
+                a: alpha,
+            },
+        )
+    } else {
+        (
+            Color {
+                r: 0.98,
+                g: 0.98,
+                b: 0.98,
+                a: 0.9 * alpha,
+            },
+            Color {
+                r: 0.98,
+                g: 0.98,
+                b: 0.98,
+                a: alpha,
+            },
+        )
+    };
+    render_click_highlight(
+        ctx,
+        f64::from(marker.center.0),
+        f64::from(marker.center.1),
+        radius,
+        outline_thickness,
+        fill_color,
+        outline_color,
+        1.0,
+    );
+    let font_desc = marker
+        .label
+        .font_descriptor
+        .to_pango_string(marker.label.size);
+    let Some(metrics) =
+        measure_text_with_context(ctx, &label_text, &font_desc, marker.label.size, None)
+    else {
+        return;
+    };
+    let center_offset_x = metrics.ink_x + metrics.ink_width / 2.0;
+    let center_offset_y = metrics.ink_y + metrics.ink_height / 2.0;
+    let baseline_x = (f64::from(marker.center.0) - center_offset_x).round() as i32;
+    let baseline_y =
+        (f64::from(marker.center.1) - center_offset_y + metrics.baseline).round() as i32;
+    render_text_over_with_halo(
+        ctx,
+        baseline_x,
+        baseline_y,
+        &label_text,
+        text_color,
+        marker.label.size,
+        &marker.label.font_descriptor,
+        false,
+        None,
+        text.known_background_luminance,
+        text.halo_enabled,
+    );
 }
 
 #[cfg(test)]

--- a/src/draw/shape/tests.rs
+++ b/src/draw/shape/tests.rs
@@ -453,7 +453,7 @@ fn image_bounding_box_and_kind_name_use_display_bounds() {
             mime_type: "image/png".to_string(),
             width: 2,
             height: 1,
-            bytes: vec![1, 2, 3],
+            bytes: vec![1, 2, 3].into(),
         },
     };
 
@@ -482,7 +482,7 @@ fn pressure_and_image_bounds_handle_extreme_coordinates() {
             mime_type: "image/png".to_string(),
             width: 1,
             height: 1,
-            bytes: vec![1],
+            bytes: vec![1].into(),
         },
     };
     let image_bounds = image
@@ -593,7 +593,7 @@ fn image_serialization_uses_base64_bytes() {
             mime_type: "image/jpeg".to_string(),
             width: 3,
             height: 4,
-            bytes: vec![1, 2, 3, 4],
+            bytes: vec![1, 2, 3, 4].into(),
         },
     };
 
@@ -604,8 +604,22 @@ fn image_serialization_uses_base64_bytes() {
     match restored {
         Shape::Image { data, .. } => {
             assert_eq!(data.mime_type, "image/jpeg");
-            assert_eq!(data.bytes, vec![1, 2, 3, 4]);
+            assert_eq!(data.bytes.as_ref(), [1, 2, 3, 4]);
         }
         other => panic!("expected image shape, got {:?}", other),
     }
+}
+
+#[test]
+fn embedded_image_clones_share_the_encoded_payload() {
+    let image = EmbeddedImage {
+        mime_type: "image/png".to_string(),
+        width: 1,
+        height: 1,
+        bytes: vec![1, 2, 3, 4].into(),
+    };
+
+    let cloned = image.clone();
+
+    assert!(std::sync::Arc::ptr_eq(&image.bytes, &cloned.bytes));
 }

--- a/src/draw/shape/types.rs
+++ b/src/draw/shape/types.rs
@@ -10,6 +10,7 @@ use crate::draw::color::Color;
 use crate::draw::font::FontDescriptor;
 use crate::util::Rect;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::sync::Arc;
 
 /// Encoded image payload stored directly on an image shape.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -18,7 +19,7 @@ pub struct EmbeddedImage {
     pub width: u32,
     pub height: u32,
     #[serde(with = "base64_bytes")]
-    pub bytes: Vec<u8>,
+    pub bytes: Arc<[u8]>,
 }
 
 /// Brush options for eraser strokes.
@@ -561,18 +562,20 @@ fn normalized_rect(x: i32, y: i32, w: i32, h: i32) -> Option<Rect> {
 mod base64_bytes {
     use super::*;
 
-    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(bytes: &Arc<[u8]>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         crate::base64::encode_standard(bytes).serialize(serializer)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Arc<[u8]>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let encoded = String::deserialize(deserializer)?;
-        crate::base64::decode_standard(&encoded).map_err(serde::de::Error::custom)
+        crate::base64::decode_standard(&encoded)
+            .map(Arc::from)
+            .map_err(serde::de::Error::custom)
     }
 }

--- a/src/input/hit_test/tests.rs
+++ b/src/input/hit_test/tests.rs
@@ -426,7 +426,7 @@ fn image_hit_test_uses_display_rectangle() {
                 mime_type: "image/png".to_string(),
                 width: 4,
                 height: 3,
-                bytes: vec![1, 2, 3],
+                bytes: vec![1, 2, 3].into(),
             },
         },
         0,

--- a/src/input/state/core/board_picker/layout/cursor.rs
+++ b/src/input/state/core/board_picker/layout/cursor.rs
@@ -113,7 +113,7 @@ impl InputState {
         Some(BoardPickerCursorHint::Default)
     }
 
-    pub(crate) fn mark_board_picker_region(&mut self, layout: BoardPickerLayout) {
+    pub(crate) fn mark_board_picker_region(&mut self, layout: &BoardPickerLayout) {
         let x = layout.origin_x.floor() as i32;
         let y = layout.origin_y.floor() as i32;
         let width = layout.width.ceil() as i32 + 2;

--- a/src/input/state/core/board_picker/layout/helpers.rs
+++ b/src/input/state/core/board_picker/layout/helpers.rs
@@ -18,7 +18,7 @@ pub(super) struct PagePanelInfo {
 impl InputState {
     pub(super) fn board_picker_page_panel_info(
         &self,
-        layout: BoardPickerLayout,
+        layout: &BoardPickerLayout,
         board_index: usize,
     ) -> Option<PagePanelInfo> {
         if !layout.page_panel_enabled {
@@ -53,13 +53,13 @@ impl InputState {
         })
     }
 
-    pub(super) const fn board_picker_page_row_stride(layout: BoardPickerLayout) -> f64 {
+    pub(super) const fn board_picker_page_row_stride(layout: &BoardPickerLayout) -> f64 {
         layout.page_thumb_height + PAGE_NAME_HEIGHT + PAGE_NAME_PADDING + layout.page_thumb_gap
     }
 
     pub(super) fn board_picker_slot_to_page_index(
         &self,
-        layout: BoardPickerLayout,
+        layout: &BoardPickerLayout,
         board_index: usize,
         slot: usize,
     ) -> Option<usize> {
@@ -73,7 +73,7 @@ impl InputState {
 
     pub(super) fn board_picker_page_index_to_slot(
         &self,
-        layout: BoardPickerLayout,
+        layout: &BoardPickerLayout,
         board_index: usize,
         page_index: usize,
     ) -> Option<usize> {
@@ -87,7 +87,7 @@ impl InputState {
 
     pub(super) fn board_picker_page_thumb_origin(
         &self,
-        layout: BoardPickerLayout,
+        layout: &BoardPickerLayout,
         board_index: usize,
         page_index: usize,
     ) -> Option<(PagePanelInfo, usize, usize, f64, f64)> {
@@ -98,7 +98,7 @@ impl InputState {
 
     pub(super) fn board_picker_page_thumb_origin_for_slot(
         &self,
-        layout: BoardPickerLayout,
+        layout: &BoardPickerLayout,
         info: PagePanelInfo,
         slot: usize,
     ) -> Option<(PagePanelInfo, usize, usize, f64, f64)> {

--- a/src/input/state/core/board_picker/layout/hit_test.rs
+++ b/src/input/state/core/board_picker/layout/hit_test.rs
@@ -15,8 +15,8 @@ struct FloatRect {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct BoardPickerPagePanelHitContext {
-    layout: super::super::BoardPickerLayout,
+struct BoardPickerPagePanelHitContext<'a> {
+    layout: &'a super::super::BoardPickerLayout,
     board_index: usize,
     info: PagePanelInfo,
 }
@@ -30,7 +30,7 @@ impl FloatRect {
 impl InputState {
     fn with_visible_page_context<T>(
         &self,
-        f: impl FnOnce(&BoardPickerPagePanelHitContext) -> Option<T>,
+        f: impl FnOnce(&BoardPickerPagePanelHitContext<'_>) -> Option<T>,
     ) -> Option<T> {
         let context = self.board_picker_page_panel_context()?;
         if context.info.visible_pages == 0 {
@@ -52,8 +52,8 @@ impl InputState {
         layout.padding_y + layout.header_height + row as f64 * layout.row_height
     }
 
-    fn board_picker_page_panel_context(&self) -> Option<BoardPickerPagePanelHitContext> {
-        let layout = self.board_picker_layout?;
+    fn board_picker_page_panel_context(&self) -> Option<BoardPickerPagePanelHitContext<'_>> {
+        let layout = self.board_picker_layout.as_ref()?;
         let board_index = layout.page_board_index?;
         let info = self.board_picker_page_panel_info(layout, board_index)?;
         Some(BoardPickerPagePanelHitContext {
@@ -67,7 +67,7 @@ impl InputState {
         &self,
         x: f64,
         y: f64,
-        context: &BoardPickerPagePanelHitContext,
+        context: &BoardPickerPagePanelHitContext<'_>,
         mut rect_for_thumb: impl FnMut(f64, f64) -> FloatRect,
     ) -> Option<usize> {
         for slot in 0..context.info.visible_slots {
@@ -88,7 +88,7 @@ impl InputState {
     }
 
     pub(crate) fn board_picker_index_at(&self, x: i32, y: i32) -> Option<usize> {
-        let layout = self.board_picker_layout?;
+        let layout = self.board_picker_layout.as_ref()?;
         let local_x = x as f64 - layout.origin_x;
         let local_y = y as f64 - layout.origin_y;
         let row_top = layout.padding_y + layout.header_height;
@@ -108,7 +108,7 @@ impl InputState {
     }
 
     pub(crate) fn board_picker_contains_point(&self, x: i32, y: i32) -> bool {
-        if let Some(layout) = self.board_picker_layout {
+        if let Some(layout) = self.board_picker_layout.as_ref() {
             let rect = FloatRect {
                 x: layout.origin_x,
                 y: layout.origin_y,
@@ -126,9 +126,9 @@ impl InputState {
         if self.board_picker_is_new_row(row) {
             return None;
         }
-        let layout = self.board_picker_layout?;
-        let (local_x, local_y) = Self::board_picker_layout_point(&layout, x, y);
-        let row_top = Self::board_picker_row_top(&layout, row);
+        let layout = self.board_picker_layout.as_ref()?;
+        let (local_x, local_y) = Self::board_picker_layout_point(layout, x, y);
+        let row_top = Self::board_picker_row_top(layout, row);
         let swatch_y = row_top + (layout.row_height - layout.swatch_size) * 0.5;
         let swatch_x = layout.padding_x;
         let rect = FloatRect {
@@ -145,7 +145,7 @@ impl InputState {
     }
 
     pub(crate) fn board_picker_palette_color_at(&self, x: i32, y: i32) -> Option<Color> {
-        let layout = self.board_picker_layout?;
+        let layout = self.board_picker_layout.as_ref()?;
         if layout.palette_rows == 0 || layout.palette_cols == 0 {
             return None;
         }
@@ -244,7 +244,10 @@ impl InputState {
         thumb_rect.contains(x as f64, y as f64)
     }
 
-    fn board_picker_end_of_pages_visible(&self, context: &BoardPickerPagePanelHitContext) -> bool {
+    fn board_picker_end_of_pages_visible(
+        &self,
+        context: &BoardPickerPagePanelHitContext<'_>,
+    ) -> bool {
         context.info.first_visible_page + context.info.visible_pages >= context.info.page_count
             && context.info.visible_pages < context.info.slot_count
     }
@@ -363,13 +366,13 @@ impl InputState {
         if self.board_picker_is_new_row(row) {
             return None;
         }
-        let layout = self.board_picker_layout?;
+        let layout = self.board_picker_layout.as_ref()?;
         if layout.handle_width <= 0.0 || self.board_picker_is_quick() {
             return None;
         }
 
-        let (local_x, local_y) = Self::board_picker_layout_point(&layout, x, y);
-        let row_top = Self::board_picker_row_top(&layout, row);
+        let (local_x, local_y) = Self::board_picker_layout_point(layout, x, y);
+        let row_top = Self::board_picker_row_top(layout, row);
         let list_right = layout.list_width;
         let handle_x = list_right - layout.padding_x - layout.handle_width;
         let rect = FloatRect {
@@ -390,13 +393,13 @@ impl InputState {
         if self.board_picker_is_new_row(row) {
             return None;
         }
-        let layout = self.board_picker_layout?;
+        let layout = self.board_picker_layout.as_ref()?;
         if layout.open_icon_size <= 0.0 || self.board_picker_is_quick() {
             return None;
         }
 
-        let (local_x, local_y) = Self::board_picker_layout_point(&layout, x, y);
-        let row_top = Self::board_picker_row_top(&layout, row);
+        let (local_x, local_y) = Self::board_picker_layout_point(layout, x, y);
+        let row_top = Self::board_picker_row_top(layout, row);
         let list_right = layout.list_width;
         let handle_x = list_right - layout.padding_x - layout.handle_width;
         let open_x = handle_x - layout.open_icon_gap - layout.open_icon_size;
@@ -418,10 +421,10 @@ impl InputState {
         if self.board_picker_is_new_row(row) {
             return None;
         }
-        let layout = self.board_picker_layout?;
+        let layout = self.board_picker_layout.as_ref()?;
 
-        let (local_x, local_y) = Self::board_picker_layout_point(&layout, x, y);
-        let row_top = Self::board_picker_row_top(&layout, row);
+        let (local_x, local_y) = Self::board_picker_layout_point(layout, x, y);
+        let row_top = Self::board_picker_row_top(layout, row);
         let pin_size = layout.swatch_size * super::super::PIN_OFFSET_FACTOR;
         let pin_x = layout.padding_x + layout.swatch_size + layout.swatch_padding - pin_size * 0.25;
         let pin_y = row_top + (layout.row_height - pin_size) * 0.5 - pin_size * 0.25;

--- a/src/input/state/core/board_picker/state/lifecycle.rs
+++ b/src/input/state/core/board_picker/state/lifecycle.rs
@@ -62,7 +62,7 @@ impl InputState {
 
     pub(crate) fn close_board_picker(&mut self) {
         if let Some(layout) = self.board_picker_layout {
-            self.mark_board_picker_region(layout);
+            self.mark_board_picker_region(&layout);
         }
         // Board picker dims the entire screen; ensure full redraw when closing.
         self.dirty_tracker.mark_full();

--- a/src/input/state/core/captured_image.rs
+++ b/src/input/state/core/captured_image.rs
@@ -109,7 +109,7 @@ mod tests {
             mime_type: "image/png".to_string(),
             width: 10,
             height: 8,
-            bytes: vec![0; bytes],
+            bytes: vec![0; bytes].into(),
         }
     }
 

--- a/src/input/state/core/session_preflight_exact.rs
+++ b/src/input/state/core/session_preflight_exact.rs
@@ -189,7 +189,7 @@ fn duplicate_active_board_in_snapshot(input: &InputState, snapshot: &mut Session
     };
     cloned.pages.active = source_board.pages.active_index();
     let insert_at = (source_index + 1).min(snapshot.boards.len());
-    snapshot.active_board_id = cloned.id.clone();
+    snapshot.active_board_id.clone_from(&cloned.id);
     snapshot.boards.insert(insert_at, cloned);
     true
 }

--- a/src/input/state/tests/boards.rs
+++ b/src/input/state/tests/boards.rs
@@ -393,7 +393,7 @@ fn add_active_image_shape(state: &mut InputState, bytes: usize) -> ShapeId {
             mime_type: "image/png".to_string(),
             width: 240,
             height: 180,
-            bytes: pseudo_random_bytes(bytes),
+            bytes: pseudo_random_bytes(bytes).into(),
         },
     })
 }

--- a/src/input/state/tests/pages.rs
+++ b/src/input/state/tests/pages.rs
@@ -484,7 +484,7 @@ fn add_active_image_shape(state: &mut InputState, bytes: usize) -> ShapeId {
             mime_type: "image/png".to_string(),
             width: 240,
             height: 180,
-            bytes: pseudo_random_bytes(bytes),
+            bytes: pseudo_random_bytes(bytes).into(),
         },
     })
 }

--- a/src/input/state/tests/session_preflight.rs
+++ b/src/input/state/tests/session_preflight.rs
@@ -69,7 +69,7 @@ fn add_active_image_shape(state: &mut InputState) -> ShapeId {
             mime_type: "image/png".to_string(),
             width: 240,
             height: 180,
-            bytes: Vec::new(),
+            bytes: Vec::new().into(),
         },
     })
 }

--- a/src/session/tests/limits.rs
+++ b/src/session/tests/limits.rs
@@ -195,7 +195,7 @@ fn image_frame(bytes: usize) -> crate::draw::Frame {
             mime_type: "image/png".to_string(),
             width: 640,
             height: 360,
-            bytes: pseudo_random_bytes(bytes),
+            bytes: pseudo_random_bytes(bytes).into(),
         },
     });
     frame
@@ -625,7 +625,7 @@ fn save_snapshot_keeps_depth_one_when_visible_payload_is_near_limit() {
                 mime_type: "image/png".to_string(),
                 width: 640,
                 height: 360,
-                bytes: vec![0x35; 96 * 1024],
+                bytes: vec![0x35; 96 * 1024].into(),
             },
         });
         let id = frame.add_shape(large_freehand(40, 0));
@@ -752,7 +752,7 @@ fn add_image_and_annotations(frame: &mut crate::draw::Frame, page_index: usize, 
             mime_type: "image/png".to_string(),
             width: 640,
             height: 360,
-            bytes: vec![0x5a; bytes],
+            bytes: vec![0x5a; bytes].into(),
         },
     });
     let (image_index, image_shape) = frame

--- a/src/ui/board_picker.rs
+++ b/src/ui/board_picker.rs
@@ -37,7 +37,7 @@ pub(crate) fn render_board_picker_with_halo(
     }
 
     let layout = match input_state.board_picker_layout() {
-        Some(layout) => *layout,
+        Some(layout) => layout,
         None => return,
     };
 

--- a/src/ui/board_picker/page_panel.rs
+++ b/src/ui/board_picker/page_panel.rs
@@ -29,7 +29,7 @@ use thumbnail::{
 pub(super) fn render_page_panel(
     ctx: &cairo::Context,
     input_state: &InputState,
-    layout: BoardPickerLayout,
+    layout: &BoardPickerLayout,
     screen_width: u32,
     screen_height: u32,
     text_halo_enabled: bool,
@@ -259,7 +259,7 @@ pub(super) fn render_page_panel(
 
 fn render_sticky_add_button(
     ctx: &cairo::Context,
-    layout: BoardPickerLayout,
+    layout: &BoardPickerLayout,
     pointer_x: i32,
     pointer_y: i32,
 ) {

--- a/src/ui/board_picker/palette.rs
+++ b/src/ui/board_picker/palette.rs
@@ -10,7 +10,7 @@ const PALETTE_SWATCH_GAP: f64 = 6.0;
 pub(super) fn render_board_palette(
     ctx: &cairo::Context,
     input_state: &InputState,
-    layout: crate::input::state::BoardPickerLayout,
+    layout: &crate::input::state::BoardPickerLayout,
 ) {
     if layout.palette_rows == 0 || layout.palette_cols == 0 {
         return;

--- a/src/ui/board_picker/rows.rs
+++ b/src/ui/board_picker/rows.rs
@@ -18,7 +18,7 @@ const SWATCH_TRANSPARENT_OUTLINE: Rgba = (0.62, 0.68, 0.76, 0.85);
 pub(super) fn render_board_rows(
     ctx: &cairo::Context,
     input_state: &InputState,
-    layout: BoardPickerLayout,
+    layout: &BoardPickerLayout,
     board_count: usize,
     max_count: usize,
 ) {
@@ -28,7 +28,7 @@ pub(super) fn render_board_rows(
 struct BoardRowsRenderer<'a> {
     ctx: &'a cairo::Context,
     input: &'a InputState,
-    layout: BoardPickerLayout,
+    layout: &'a BoardPickerLayout,
     board_count: usize,
     max_count: usize,
     rows_top: f64,
@@ -49,7 +49,7 @@ impl<'a> BoardRowsRenderer<'a> {
     fn new(
         ctx: &'a cairo::Context,
         input: &'a InputState,
-        layout: BoardPickerLayout,
+        layout: &'a BoardPickerLayout,
         board_count: usize,
         max_count: usize,
     ) -> Self {

--- a/src/ui/region_action_bar.rs
+++ b/src/ui/region_action_bar.rs
@@ -316,11 +316,11 @@ impl RegionActionBar {
 
     /// The painted frame, without its drop shadow. The picker uses it to keep
     /// the Review size badge out from under the bar.
-    pub(crate) const fn bounds(self) -> RegionActionRect {
+    pub(crate) const fn bounds(&self) -> RegionActionRect {
         self.bounds
     }
 
-    pub(crate) fn hit(self, point: (f64, f64)) -> Option<RegionAction> {
+    pub(crate) fn hit(&self, point: (f64, f64)) -> Option<RegionAction> {
         self.items
             .iter()
             .chain(self.edit.iter())
@@ -335,7 +335,7 @@ impl RegionActionBar {
     }
 
     pub(crate) fn enabled_hit(
-        self,
+        &self,
         point: (f64, f64),
         availability: RegionActionAvailability,
     ) -> Option<RegionAction> {
@@ -343,11 +343,11 @@ impl RegionActionBar {
             .filter(|&action| availability.allows(action))
     }
 
-    pub(crate) fn contains(self, point: (f64, f64)) -> bool {
+    pub(crate) fn contains(&self, point: (f64, f64)) -> bool {
         self.bounds.contains(point)
     }
 
-    fn status_bounds(self) -> Option<RegionActionRect> {
+    fn status_bounds(&self) -> Option<RegionActionRect> {
         let toggle = self.toggle.bounds;
         if toggle.width <= 0.0 {
             return None;
@@ -363,13 +363,13 @@ impl RegionActionBar {
 
 pub(crate) fn render_region_action_bar(
     ctx: &cairo::Context,
-    bar: RegionActionBar,
+    bar: &RegionActionBar,
     visual: RegionActionBarVisual,
 ) {
     let _ = ctx.save();
     draw_bar_frame(ctx, bar.bounds);
 
-    for item in bar.items {
+    for &item in &bar.items {
         draw_action(
             ctx,
             item,
@@ -384,7 +384,7 @@ pub(crate) fn render_region_action_bar(
         bar.edit[0].bounds.y,
         bar.toggle.bounds.width,
     );
-    for item in bar.edit {
+    for &item in &bar.edit {
         draw_action(
             ctx,
             item,
@@ -699,7 +699,7 @@ fn draw_checkbox(ctx: &cairo::Context, x: f64, y: f64, size: f64, checked: bool)
     let _ = ctx.stroke();
 }
 
-fn draw_status(ctx: &cairo::Context, bar: RegionActionBar, status: Option<RegionCutStatus>) {
+fn draw_status(ctx: &cairo::Context, bar: &RegionActionBar, status: Option<RegionCutStatus>) {
     let Some(status) = status else {
         return;
     };
@@ -975,7 +975,7 @@ mod tests {
         let ctx = cairo::Context::new(&surface).unwrap();
         render_region_action_bar(
             &ctx,
-            bar,
+            &bar,
             RegionActionBarVisual::simple(Some(RegionAction::Both), true),
         );
         drop(ctx);
@@ -1001,7 +1001,7 @@ mod tests {
         let row_alpha = |checked: bool| {
             let mut surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 800, 600).unwrap();
             let ctx = cairo::Context::new(&surface).unwrap();
-            render_region_action_bar(&ctx, bar, RegionActionBarVisual::simple(None, checked));
+            render_region_action_bar(&ctx, &bar, RegionActionBarVisual::simple(None, checked));
             drop(ctx);
             surface.flush();
             let stride = surface.stride() as usize;
@@ -1025,7 +1025,7 @@ mod tests {
         let ctx = cairo::Context::new(&surface).unwrap();
         render_region_action_bar(
             &ctx,
-            bar,
+            &bar,
             RegionActionBarVisual {
                 hovered: None,
                 include_drawings: false,
@@ -1061,7 +1061,7 @@ mod tests {
         let ctx = cairo::Context::new(&surface).unwrap();
         render_region_action_bar(
             &ctx,
-            bar,
+            &bar,
             RegionActionBarVisual {
                 hovered: None,
                 include_drawings: false,

--- a/src/ui/region_capture_picker.rs
+++ b/src/ui/region_capture_picker.rs
@@ -253,7 +253,7 @@ pub(crate) fn render_region_capture_picker(
     ctx: &cairo::Context,
     screen_width: u32,
     screen_height: u32,
-    visual: RegionCapturePickerVisual<'_>,
+    visual: &RegionCapturePickerVisual<'_>,
     mut sample_loupe: impl FnMut(f64, f64) -> Option<crate::draw::Color>,
 ) {
     let width = f64::from(screen_width);
@@ -291,7 +291,7 @@ pub(crate) fn render_region_capture_picker(
         // frame drops its arms wherever grips are offered.
         draw_selection_frame(ctx, x, y, w, h, visual.resize_handles.is_none());
     }
-    if let Some(handles) = visual.resize_handles {
+    if let Some(handles) = visual.resize_handles.as_ref() {
         render_region_resize_handles(ctx, handles, visual.hovered_handle);
     }
     if let Some(drag) = visual.cut.drag {
@@ -311,7 +311,7 @@ pub(crate) fn render_region_capture_picker(
             READOUT_FONT_SIZE,
             visual.pointer,
             anchor,
-            visual.action_bar.map(RegionActionBar::bounds),
+            visual.action_bar.as_ref().map(RegionActionBar::bounds),
             (screen_width, screen_height),
             cairo::FontWeight::Bold,
         );
@@ -326,7 +326,7 @@ pub(crate) fn render_region_capture_picker(
     if let Some(loupe) = visual.loupe {
         render_region_capture_loupe(ctx, (screen_width, screen_height), loupe, &mut sample_loupe);
     }
-    if let Some(action_bar) = visual.action_bar {
+    if let Some(action_bar) = visual.action_bar.as_ref() {
         render_region_action_bar(
             ctx,
             action_bar,
@@ -794,7 +794,7 @@ mod tests {
             &ctx,
             40,
             40,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: Some(RegionSelection {
                     start: (10.0, 10.0),
                     end: (30.0, 30.0),
@@ -842,7 +842,7 @@ mod tests {
             &ctx,
             40,
             40,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: None,
                 pointer: (28.0, 28.0),
                 measurement: None,
@@ -883,7 +883,7 @@ mod tests {
             &ctx,
             40,
             40,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: None,
                 pointer: (20.0, 20.0),
                 measurement: None,
@@ -931,7 +931,7 @@ mod tests {
             &ctx,
             40,
             20,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: None,
                 pointer: (20.0, 18.0),
                 measurement: None,
@@ -978,7 +978,7 @@ mod tests {
             &ctx,
             40,
             40,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: None,
                 pointer: (20.0, 20.0),
                 measurement: Some("20, 20"),
@@ -1043,7 +1043,7 @@ mod tests {
             &ctx,
             40,
             40,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: Some(RegionSelection {
                     start: (10.0, 10.0),
                     end: (30.0, 30.0),
@@ -1087,7 +1087,7 @@ mod tests {
             &ctx,
             800,
             600,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: Some(selection),
                 pointer: (200.0, 150.0),
                 measurement: Some("200 × 100"),
@@ -1198,7 +1198,7 @@ mod tests {
                 &ctx,
                 800,
                 600,
-                RegionCapturePickerVisual {
+                &RegionCapturePickerVisual {
                     selection: Some(selection),
                     pointer: (760.0, 575.0),
                     measurement,
@@ -1294,7 +1294,7 @@ mod tests {
                 &ctx,
                 300,
                 260,
-                RegionCapturePickerVisual {
+                &RegionCapturePickerVisual {
                     selection: Some(selection),
                     // Park the pointer in a corner: targeting still paints a
                     // crosshair, and its two lines must not cross the pixels
@@ -1406,7 +1406,7 @@ mod tests {
             &ctx,
             60,
             40,
-            RegionCapturePickerVisual {
+            &RegionCapturePickerVisual {
                 selection: Some(display),
                 pointer: (4.0, 4.0),
                 measurement: None,

--- a/src/ui/region_resize_handles.rs
+++ b/src/ui/region_resize_handles.rs
@@ -145,11 +145,11 @@ impl RegionResizeHandles {
 
 pub(crate) fn render_region_resize_handles(
     ctx: &cairo::Context,
-    handles: RegionResizeHandles,
+    handles: &RegionResizeHandles,
     hovered: Option<SelectionHandle>,
 ) {
     let _ = ctx.save();
-    for chip in handles.chips.into_iter().flatten() {
+    for chip in handles.chips.iter().flatten() {
         let (x, y, width, height) = chip.rect();
         if width <= 0.0 || height <= 0.0 {
             continue;
@@ -329,7 +329,7 @@ mod tests {
             let handles = RegionResizeHandles::place(selection(20.0, 20.0, side, side));
             let mut surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 60, 60).unwrap();
             let ctx = cairo::Context::new(&surface).unwrap();
-            render_region_resize_handles(&ctx, handles, Some(SelectionHandle::TopLeft));
+            render_region_resize_handles(&ctx, &handles, Some(SelectionHandle::TopLeft));
             assert_eq!(
                 ctx.status(),
                 Ok(()),
@@ -371,7 +371,7 @@ mod tests {
         let handles = RegionResizeHandles::place(selection(20.0, 20.0, 160.0, 160.0));
         let mut surface = cairo::ImageSurface::create(cairo::Format::ARgb32, 200, 200).unwrap();
         let ctx = cairo::Context::new(&surface).unwrap();
-        render_region_resize_handles(&ctx, handles, Some(SelectionHandle::TopLeft));
+        render_region_resize_handles(&ctx, &handles, Some(SelectionHandle::TopLeft));
         drop(ctx);
         surface.flush();
         let stride = surface.stride() as usize;


### PR DESCRIPTION
## Summary

This PR delivers ten focused performance and maintainability improvements:

- Share embedded image payloads and use identity-based render caching
- Render packed pressure samples without intermediate allocations
- Cache window-snap display geometry
- Borrow large board-picker layouts in hot paths
- Borrow large region-capture visual structures
- Split complex arrow and step-marker rendering into focused helpers
- Separate CLI validation by concern
- Centralize preset validation and cover every supported slot
- Defer fallback lookups until they are needed
- Reuse allocations during session and output transitions

The improvement plan was reviewed twice. Broad lint churn, arbitrary file splitting, and lower-impact telemetry cleanup were excluded in favor of measured hot-path work and cohesive refactoring.

Each improvement is contained in a separate commit.

## Validation

- Full `./tools/lint-and-test.sh` passed
- Formatting and strict Clippy passed
- All-feature and no-default-feature configurations passed
- Core, configurator, integration, UI, and documentation tests passed
- Packaging, source-coverage, and repository audits passed
- `git diff --check` passed
