### PR TITLE
fix(wayland): acquire keyboard focus on layer startup

### DIFF
--- a/src/backend/wayland/backend/surface.rs
+++ b/src/backend/wayland/backend/surface.rs
@@ -14,6 +14,9 @@ pub(super) fn create_overlay_surface(
 ) -> Result<()> {
     // Create surface using layer-shell when available, otherwise fall back to xdg-shell
     let wl_surface = state.compositor_state.create_surface(qh);
+    if state.layer_shell.is_some() {
+        state.begin_main_layer_focus_acquisition();
+    }
     if let Some(layer_shell) = state.layer_shell.as_ref() {
         let layer = state.main_surface_layer();
         info!("Creating layer shell surface in {:?} layer", layer);

--- a/src/backend/wayland/handlers/keyboard/mod.rs
+++ b/src/backend/wayland/handlers/keyboard/mod.rs
@@ -69,6 +69,15 @@ impl KeyboardHandler for WaylandState {
             self.set_overlay_ready(true);
             debug!("Overlay ready for keybinds");
         }
+        let is_current_main_layer_surface =
+            !self.surface.is_xdg_window() && self.surface.is_surface(surface);
+        let acquisition_was_pending = self.main_layer_focus_acquiring();
+        if self.try_complete_main_layer_focus_acquisition(is_current_main_layer_surface) {
+            debug!("Initial main-layer keyboard focus acquired");
+            self.refresh_keyboard_interactivity();
+        } else if is_current_main_layer_surface && acquisition_was_pending {
+            debug!("Ignoring superseded main-layer keyboard enter during focus acquisition");
+        }
     }
 
     fn leave(

--- a/src/backend/wayland/state/core/focus.rs
+++ b/src/backend/wayland/state/core/focus.rs
@@ -1,11 +1,57 @@
-use super::super::WaylandState;
+use smithay_client_toolkit::shell::wlr_layer::KeyboardInteractivity;
+
+use super::super::{WaylandState, data::MainLayerFocusPhase};
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::backend::wayland::state) struct MainLayerEnterFacts {
+    pub(in crate::backend::wayland::state) is_current_main_layer_surface: bool,
+    pub(in crate::backend::wayland::state) phase: MainLayerFocusPhase,
+    pub(in crate::backend::wayland::state) committed_keyboard_interactivity:
+        Option<KeyboardInteractivity>,
+    pub(in crate::backend::wayland::state) keyboard_release_requested: bool,
+}
+
+pub(in crate::backend::wayland::state) fn can_complete_main_layer_focus_acquisition(
+    facts: MainLayerEnterFacts,
+) -> bool {
+    facts.is_current_main_layer_surface
+        && facts.phase.is_acquiring()
+        && facts.committed_keyboard_interactivity == Some(KeyboardInteractivity::Exclusive)
+        && !facts.keyboard_release_requested
+}
 
 impl WaylandState {
+    pub(in crate::backend::wayland) fn begin_main_layer_focus_acquisition(&mut self) {
+        self.data.main_layer_focus_phase.begin();
+    }
+
+    pub(in crate::backend::wayland) fn main_layer_focus_acquiring(&self) -> bool {
+        self.data.main_layer_focus_phase.is_acquiring()
+    }
+
+    pub(in crate::backend::wayland) fn try_complete_main_layer_focus_acquisition(
+        &mut self,
+        is_current_main_layer_surface: bool,
+    ) -> bool {
+        let facts = MainLayerEnterFacts {
+            is_current_main_layer_surface,
+            phase: self.data.main_layer_focus_phase,
+            committed_keyboard_interactivity: self.current_keyboard_interactivity(),
+            keyboard_release_requested: self.overlay_keyboard_passthrough_requested(),
+        };
+        if !can_complete_main_layer_focus_acquisition(facts) {
+            return false;
+        }
+        self.data.main_layer_focus_phase.complete()
+    }
+
     /// Retire every keyboard-owned transient when focus is lost.
     ///
     /// Both the compositor's keyboard-leave callback and layer-output surface
     /// recreation enter through this state lifecycle boundary.
     pub(in crate::backend::wayland) fn teardown_keyboard_focus(&mut self) {
+        self.data.main_layer_focus_phase =
+            self.data.main_layer_focus_phase.after_keyboard_teardown();
         self.set_keyboard_focus(false);
         self.set_overlay_ready(false);
         self.clear_toolbar_focus();
@@ -14,5 +60,100 @@ impl WaylandState {
         self.clear_key_repeat();
         self.set_board_pan_key_held(false);
         self.stop_board_pan();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smithay_client_toolkit::shell::wlr_layer::KeyboardInteractivity;
+
+    use super::{
+        MainLayerEnterFacts, MainLayerFocusPhase, can_complete_main_layer_focus_acquisition,
+    };
+
+    #[test]
+    fn stale_main_enter_under_none_keeps_acquisition_pending() {
+        let mut phase = MainLayerFocusPhase::default();
+
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                is_current_main_layer_surface: true,
+                phase,
+                committed_keyboard_interactivity: Some(KeyboardInteractivity::None),
+                keyboard_release_requested: true,
+            }
+        ));
+        assert!(phase.is_acquiring());
+
+        assert!(can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                is_current_main_layer_surface: true,
+                phase,
+                committed_keyboard_interactivity: Some(KeyboardInteractivity::Exclusive),
+                keyboard_release_requested: false,
+            }
+        ));
+        assert!(phase.complete());
+        assert!(!phase.is_acquiring());
+    }
+
+    #[test]
+    fn main_layer_enter_requires_current_surface_acquiring_exclusive_and_no_release() {
+        let valid = MainLayerEnterFacts {
+            is_current_main_layer_surface: true,
+            phase: MainLayerFocusPhase::Acquiring,
+            committed_keyboard_interactivity: Some(KeyboardInteractivity::Exclusive),
+            keyboard_release_requested: false,
+        };
+
+        assert!(can_complete_main_layer_focus_acquisition(valid));
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                is_current_main_layer_surface: false,
+                ..valid
+            }
+        ));
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                phase: MainLayerFocusPhase::Acquired,
+                ..valid
+            }
+        ));
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                committed_keyboard_interactivity: Some(KeyboardInteractivity::OnDemand),
+                ..valid
+            }
+        ));
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                committed_keyboard_interactivity: None,
+                ..valid
+            }
+        ));
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                keyboard_release_requested: true,
+                ..valid
+            }
+        ));
+    }
+
+    #[test]
+    fn ordinary_keyboard_teardown_keeps_an_acquired_surface_out_of_acquisition() {
+        let mut phase = MainLayerFocusPhase::default();
+        assert!(phase.complete());
+
+        phase = phase.after_keyboard_teardown();
+
+        assert!(!phase.is_acquiring());
+        assert!(!can_complete_main_layer_focus_acquisition(
+            MainLayerEnterFacts {
+                is_current_main_layer_surface: true,
+                phase,
+                committed_keyboard_interactivity: Some(KeyboardInteractivity::Exclusive),
+                keyboard_release_requested: false,
+            }
+        ));
     }
 }

--- a/src/backend/wayland/state/core/mod.rs
+++ b/src/backend/wayland/state/core/mod.rs
@@ -1,5 +1,5 @@
 mod accessors;
-mod focus;
+pub(in crate::backend::wayland::state) mod focus;
 mod init;
 mod output;
 mod overlay;

--- a/src/backend/wayland/state/core/output/focus.rs
+++ b/src/backend/wayland/state/core/output/focus.rs
@@ -113,6 +113,7 @@ impl WaylandState {
         qh: &QueueHandle<Self>,
         output: &wl_output::WlOutput,
     ) {
+        self.begin_main_layer_focus_acquisition();
         let Some(layer_shell) = self.layer_shell.as_ref() else {
             return;
         };

--- a/src/backend/wayland/state/data.rs
+++ b/src/backend/wayland/state/data.rs
@@ -32,6 +32,35 @@ pub enum OverlaySuppressionKeyboardPolicy {
     Retain,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum MainLayerFocusPhase {
+    #[default]
+    Acquiring,
+    Acquired,
+}
+
+impl MainLayerFocusPhase {
+    pub(super) fn begin(&mut self) {
+        *self = Self::Acquiring;
+    }
+
+    pub(super) fn complete(&mut self) -> bool {
+        if *self == Self::Acquired {
+            return false;
+        }
+        *self = Self::Acquired;
+        true
+    }
+
+    pub(super) fn is_acquiring(self) -> bool {
+        self == Self::Acquiring
+    }
+
+    pub(super) fn after_keyboard_teardown(self) -> Self {
+        self
+    }
+}
+
 /// One-shot release latches owned by the pointing device whose press armed
 /// them. Pointer and touch can both have an outstanding release; neither may
 /// consume or clear the other's sequence. Stylus contacts use tablet-tool
@@ -128,6 +157,7 @@ use wayland_client::protocol::wl_seat;
 #[derive(Debug, Default)]
 pub struct StateData {
     pub(super) has_keyboard_focus: bool,
+    pub(super) main_layer_focus_phase: MainLayerFocusPhase,
     pub(super) has_pointer_focus: bool,
     pub(super) current_mouse_x: i32,
     pub(super) current_mouse_y: i32,
@@ -256,6 +286,7 @@ impl StateData {
     pub fn new() -> Self {
         Self {
             has_keyboard_focus: false,
+            main_layer_focus_phase: MainLayerFocusPhase::default(),
             has_pointer_focus: false,
             current_mouse_x: 0,
             current_mouse_y: 0,
@@ -348,7 +379,7 @@ impl StateData {
 
 #[cfg(test)]
 mod tests {
-    use super::OverlaySuppression;
+    use super::{MainLayerFocusPhase, OverlaySuppression};
     use crate::input::state::RegionInputSource;
 
     #[test]
@@ -359,6 +390,20 @@ mod tests {
         assert!(!suppression.take(RegionInputSource::Touch));
         assert!(suppression.take(RegionInputSource::Pointer));
         assert!(!suppression.take(RegionInputSource::Pointer));
+    }
+
+    #[test]
+    fn main_layer_focus_phase_completes_once_and_restarts_for_a_new_surface() {
+        let mut phase = MainLayerFocusPhase::default();
+
+        assert!(phase.is_acquiring());
+        assert!(phase.complete());
+        assert!(!phase.is_acquiring());
+        assert!(!phase.complete());
+
+        phase.begin();
+
+        assert!(phase.is_acquiring());
     }
 
     #[test]

--- a/src/backend/wayland/state/toolbar/visibility/mod.rs
+++ b/src/backend/wayland/state/toolbar/visibility/mod.rs
@@ -4,13 +4,26 @@ mod access;
 mod pointer;
 mod sync;
 
-fn desired_keyboard_interactivity_for(
+#[derive(Debug, Clone, Copy)]
+struct KeyboardInteractivityPolicyInput {
+    keyboard_release_requested: bool,
+    main_layer_focus_acquiring: bool,
     layer_shell_available: bool,
-    toolbar_visible: bool,
+    separate_toolbar_visible: bool,
     inline_toolbars_active: bool,
     canvas_modal_active: bool,
-) -> KeyboardInteractivity {
-    if layer_shell_available && toolbar_visible && !inline_toolbars_active && !canvas_modal_active {
+}
+
+fn keyboard_interactivity_for(input: KeyboardInteractivityPolicyInput) -> KeyboardInteractivity {
+    if input.keyboard_release_requested {
+        KeyboardInteractivity::None
+    } else if input.main_layer_focus_acquiring {
+        KeyboardInteractivity::Exclusive
+    } else if input.layer_shell_available
+        && input.separate_toolbar_visible
+        && !input.inline_toolbars_active
+        && !input.canvas_modal_active
+    {
         KeyboardInteractivity::OnDemand
     } else {
         KeyboardInteractivity::Exclusive

--- a/src/backend/wayland/state/toolbar/visibility/sync.rs
+++ b/src/backend/wayland/state/toolbar/visibility/sync.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::env_vars::{XDG_CURRENT_DESKTOP_ENV, XDG_SESSION_DESKTOP_ENV};
+use smithay_client_toolkit::shell::WaylandSurface;
 
 fn toolbar_visibility_for_frontend(
     requested: bool,
@@ -20,9 +21,6 @@ impl WaylandState {
     pub(in crate::backend::wayland) fn desired_keyboard_interactivity(
         &self,
     ) -> KeyboardInteractivity {
-        if self.overlay_keyboard_passthrough_requested() {
-            return KeyboardInteractivity::None;
-        }
         // GTK bars count as visible layer toolbars: the canvas must drop
         // from Exclusive to OnDemand while they are mapped, or compositors
         // that honor exclusivity (Hyprland) lock all input to the canvas
@@ -30,12 +28,14 @@ impl WaylandState {
         let toolbar_visible = !self.capture_picker_chrome_suppressed()
             && (self.toolbar.is_visible()
                 || (self.gtk_toolbars_active() && self.input_state.toolbar_top_visible()));
-        desired_keyboard_interactivity_for(
-            self.layer_shell.is_some(),
-            toolbar_visible,
-            self.inline_toolbars_active(),
-            self.input_state.is_color_picker_popup_open(),
-        )
+        keyboard_interactivity_for(KeyboardInteractivityPolicyInput {
+            keyboard_release_requested: self.overlay_keyboard_passthrough_requested(),
+            main_layer_focus_acquiring: self.main_layer_focus_acquiring(),
+            layer_shell_available: self.layer_shell.is_some(),
+            separate_toolbar_visible: toolbar_visible,
+            inline_toolbars_active: self.inline_toolbars_active(),
+            canvas_modal_active: self.input_state.is_color_picker_popup_open(),
+        })
     }
 
     fn log_toolbar_layer_shell_missing_once(&mut self) {
@@ -55,7 +55,7 @@ impl WaylandState {
         self.data.toolbar_layer_shell_missing_logged = true;
     }
 
-    /// Applies keyboard interactivity based on toolbar visibility.
+    /// Applies and commits keyboard interactivity when the desired mode changes.
     pub(in crate::backend::wayland) fn refresh_keyboard_interactivity(&mut self) {
         let desired = self.desired_keyboard_interactivity();
         let current = self.current_keyboard_interactivity();
@@ -63,6 +63,7 @@ impl WaylandState {
         let updated = if let Some(layer) = self.surface.layer_surface_mut() {
             if current != Some(desired) {
                 layer.set_keyboard_interactivity(desired);
+                layer.commit();
                 true
             } else {
                 false

--- a/src/backend/wayland/state/toolbar/visibility/tests.rs
+++ b/src/backend/wayland/state/toolbar/visibility/tests.rs
@@ -1,25 +1,253 @@
 use super::*;
+use crate::backend::wayland::state::{
+    core::focus::{MainLayerEnterFacts, can_complete_main_layer_focus_acquisition},
+    data::MainLayerFocusPhase,
+};
+
+fn separate_toolbar_policy_input() -> KeyboardInteractivityPolicyInput {
+    KeyboardInteractivityPolicyInput {
+        keyboard_release_requested: false,
+        main_layer_focus_acquiring: false,
+        layer_shell_available: true,
+        separate_toolbar_visible: true,
+        inline_toolbars_active: false,
+        canvas_modal_active: false,
+    }
+}
 
 #[test]
-fn desired_keyboard_interactivity_requires_layer_shell_and_layer_toolbars() {
+fn pending_main_layer_focus_acquisition_requests_exclusive_keyboard() {
+    let input = KeyboardInteractivityPolicyInput {
+        main_layer_focus_acquiring: true,
+        ..separate_toolbar_policy_input()
+    };
+
     assert_eq!(
-        desired_keyboard_interactivity_for(true, true, false, false),
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::Exclusive
+    );
+}
+
+#[test]
+fn keyboard_interactivity_policy_preserves_release_toolbar_and_fallback_precedence() {
+    let cases = [
+        (
+            "release overrides acquisition",
+            KeyboardInteractivityPolicyInput {
+                keyboard_release_requested: true,
+                main_layer_focus_acquiring: true,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::None,
+        ),
+        (
+            "release overrides steady state",
+            KeyboardInteractivityPolicyInput {
+                keyboard_release_requested: true,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::None,
+        ),
+        (
+            "separate toolbar uses on-demand after acquisition",
+            separate_toolbar_policy_input(),
+            KeyboardInteractivity::OnDemand,
+        ),
+        (
+            "hidden toolbar keeps exclusive after acquisition",
+            KeyboardInteractivityPolicyInput {
+                separate_toolbar_visible: false,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "hidden toolbar keeps exclusive during acquisition",
+            KeyboardInteractivityPolicyInput {
+                main_layer_focus_acquiring: true,
+                separate_toolbar_visible: false,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "xdg fallback keeps exclusive after acquisition",
+            KeyboardInteractivityPolicyInput {
+                layer_shell_available: false,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "xdg fallback keeps exclusive during acquisition",
+            KeyboardInteractivityPolicyInput {
+                main_layer_focus_acquiring: true,
+                layer_shell_available: false,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "inline toolbar keeps exclusive after acquisition",
+            KeyboardInteractivityPolicyInput {
+                inline_toolbars_active: true,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "inline toolbar keeps exclusive during acquisition",
+            KeyboardInteractivityPolicyInput {
+                main_layer_focus_acquiring: true,
+                inline_toolbars_active: true,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "canvas modal keeps exclusive after acquisition",
+            KeyboardInteractivityPolicyInput {
+                canvas_modal_active: true,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+        (
+            "canvas modal keeps exclusive during acquisition",
+            KeyboardInteractivityPolicyInput {
+                main_layer_focus_acquiring: true,
+                canvas_modal_active: true,
+                ..separate_toolbar_policy_input()
+            },
+            KeyboardInteractivity::Exclusive,
+        ),
+    ];
+
+    for (name, input, expected) in cases {
+        assert_eq!(keyboard_interactivity_for(input), expected, "{name}");
+    }
+}
+
+#[test]
+fn superseded_enter_policy_sequence_retries_acquisition_before_steady_state() {
+    let mut input = KeyboardInteractivityPolicyInput {
+        main_layer_focus_acquiring: true,
+        ..separate_toolbar_policy_input()
+    };
+
+    assert_eq!(
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::Exclusive
+    );
+
+    input.keyboard_release_requested = true;
+    assert_eq!(
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::None
+    );
+
+    input.keyboard_release_requested = false;
+    assert_eq!(
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::Exclusive
+    );
+
+    input.main_layer_focus_acquiring = false;
+    assert_eq!(
+        keyboard_interactivity_for(input),
         KeyboardInteractivity::OnDemand
     );
+}
+
+#[test]
+fn acquired_release_restores_separate_toolbar_on_demand_policy() {
+    let mut input = separate_toolbar_policy_input();
+
     assert_eq!(
-        desired_keyboard_interactivity_for(true, false, false, false),
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::OnDemand
+    );
+
+    input.keyboard_release_requested = true;
+    assert_eq!(
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::None
+    );
+
+    input.keyboard_release_requested = false;
+    assert_eq!(
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::OnDemand
+    );
+}
+
+#[test]
+fn retained_suppression_follows_acquisition_and_steady_state_policy() {
+    let mut input = KeyboardInteractivityPolicyInput {
+        main_layer_focus_acquiring: true,
+        ..separate_toolbar_policy_input()
+    };
+
+    assert_eq!(
+        keyboard_interactivity_for(input),
         KeyboardInteractivity::Exclusive
     );
+
+    input.main_layer_focus_acquiring = false;
     assert_eq!(
-        desired_keyboard_interactivity_for(false, true, false, false),
-        KeyboardInteractivity::Exclusive
+        keyboard_interactivity_for(input),
+        KeyboardInteractivity::OnDemand
     );
-    assert_eq!(
-        desired_keyboard_interactivity_for(true, true, true, false),
-        KeyboardInteractivity::Exclusive
-    );
-    assert_eq!(
-        desired_keyboard_interactivity_for(true, true, false, true),
-        KeyboardInteractivity::Exclusive
-    );
+}
+
+#[test]
+fn stale_enter_sequence_preserves_acquisition_until_a_valid_exclusive_enter() {
+    let mut phase = MainLayerFocusPhase::default();
+    let mut input = KeyboardInteractivityPolicyInput {
+        main_layer_focus_acquiring: phase.is_acquiring(),
+        ..separate_toolbar_policy_input()
+    };
+    let mut committed = keyboard_interactivity_for(input);
+    assert_eq!(committed, KeyboardInteractivity::Exclusive);
+
+    input.keyboard_release_requested = true;
+    committed = keyboard_interactivity_for(input);
+    assert_eq!(committed, KeyboardInteractivity::None);
+    assert!(!can_complete_main_layer_focus_acquisition(
+        MainLayerEnterFacts {
+            is_current_main_layer_surface: true,
+            phase,
+            committed_keyboard_interactivity: Some(committed),
+            keyboard_release_requested: input.keyboard_release_requested,
+        }
+    ));
+    assert!(phase.is_acquiring());
+
+    input.keyboard_release_requested = false;
+    assert!(!can_complete_main_layer_focus_acquisition(
+        MainLayerEnterFacts {
+            is_current_main_layer_surface: true,
+            phase,
+            committed_keyboard_interactivity: Some(committed),
+            keyboard_release_requested: input.keyboard_release_requested,
+        }
+    ));
+    assert!(phase.is_acquiring());
+
+    committed = keyboard_interactivity_for(input);
+    assert_eq!(committed, KeyboardInteractivity::Exclusive);
+    assert!(can_complete_main_layer_focus_acquisition(
+        MainLayerEnterFacts {
+            is_current_main_layer_surface: true,
+            phase,
+            committed_keyboard_interactivity: Some(committed),
+            keyboard_release_requested: input.keyboard_release_requested,
+        }
+    ));
+    assert!(phase.complete());
+    assert!(!phase.is_acquiring());
+
+    input.main_layer_focus_acquiring = phase.is_acquiring();
+    committed = keyboard_interactivity_for(input);
+    assert_eq!(committed, KeyboardInteractivity::OnDemand);
 }


### PR DESCRIPTION
## Summary

- request exclusive keyboard interactivity while a main layer surface is acquiring initial focus
- restore normal toolbar policy only after a valid current-surface enter while preserving release precedence
- reject stale enters using the surface identity, committed interactivity cache, and release state
- preserve acquired state across ordinary keyboard teardown and cover lifecycle and policy transitions

## Validation

- `./tools/lint-and-test.sh` under Rust 1.95
- 10 focused policy, eligibility, and lifecycle tests
- `git diff --check`

Manual compositor validation was not run because opening the overlay would affect foreground focus.