### PR TITLE
refactor(wayland): group protocol globals

### DIFF
--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -77,7 +77,7 @@ Daemon mode therefore provides a persistent background service that reacts to us
    - Communicate with `capture::CaptureManager` for screenshot actions.
    - Exit when `InputState.should_exit` is set (Escape, tray close, etc.).
 
-`WaylandState` coordinates the runtime owners handlers need. `PointerRuntime` owns pointer, cursor, pointer-lock, and single-contact touch protocol lifecycles, while the root retains cross-owner input and toolbar routing.
+`WaylandState` coordinates the runtime owners handlers need. `ProtocolGlobals` owns bound globals and toolkit handler state; `PointerRuntime` owns pointer, cursor, pointer-lock, and single-contact touch protocol lifecycles. The root retains cross-owner input and toolbar routing.
 
 Freeze capture waits for the overlay-suppression frame, then selects `wlr-screencopy`, `ext-image-copy-capture`, or the screenshot portal in that order. The two direct protocols capture the active output into shared memory; the portal captures the desktop and the client crops the selected output when needed. Direct capture and portal crop both require compositor-reported output pixels; a missing current mode fails instead of guessing from the overlay buffer.
 

--- a/src/backend/wayland/backend/setup.rs
+++ b/src/backend/wayland/backend/setup.rs
@@ -25,7 +25,7 @@ use crate::env_vars::{XDG_CURRENT_DESKTOP_ENV, XDG_SESSION_DESKTOP_ENV};
 
 use super::super::{
     frozen::ExtImageCopyManagers,
-    state::{WaylandGlobals, WaylandState},
+    state::{ProtocolGlobals, ProtocolGlobalsSeed, WaylandState},
 };
 
 // Freeze/zoom capture currently consumes wl_shm buffer events and ignores linux-dmabuf.
@@ -39,7 +39,7 @@ pub(super) struct WaylandSetup {
     pub(super) globals: wayland_client::globals::GlobalList,
     pub(super) event_queue: EventQueue<WaylandState>,
     pub(super) qh: wayland_client::QueueHandle<WaylandState>,
-    pub(super) state_globals: WaylandGlobals,
+    pub(super) state_globals: ProtocolGlobals,
     pub(super) screencopy_manager: Option<ZwlrScreencopyManagerV1>,
     pub(super) ext_image_copy_managers: Option<ExtImageCopyManagers>,
     pub(super) text_input_manager: Option<ZwpTextInputManagerV3>,
@@ -211,18 +211,18 @@ pub(super) fn setup_wayland() -> Result<WaylandSetup> {
 
     let layer_shell_available = layer_shell.is_some();
 
-    let state_globals = WaylandGlobals {
-        registry_state,
-        compositor_state,
+    let state_globals = ProtocolGlobals::from_seed(ProtocolGlobalsSeed {
+        registry: registry_state,
+        compositor: compositor_state,
         layer_shell,
         xdg_shell,
         activation,
         shm,
-        pointer_constraints_state,
-        relative_pointer_state,
-        output_state,
-        seat_state,
-    };
+        pointer_constraints: pointer_constraints_state,
+        relative_pointer: relative_pointer_state,
+        output: output_state,
+        seat: seat_state,
+    });
 
     Ok(WaylandSetup {
         conn,

--- a/src/backend/wayland/backend/state_init/mod.rs
+++ b/src/backend/wayland/backend/state_init/mod.rs
@@ -112,13 +112,13 @@ pub(super) fn init_state(backend: &WaylandBackend, setup: WaylandSetup) -> Resul
         freeze_capture: frozen_supported,
         pointer_constraints: setup
             .state_globals
-            .pointer_constraints_state
+            .pointer_constraints()
             .bound_global()
             .is_ok(),
         desktop_environment: desktop_environment_from_env(),
         shell_mode: if setup.layer_shell_available {
             ShellMode::LayerShell
-        } else if setup.state_globals.xdg_shell.is_some() {
+        } else if setup.state_globals.xdg_shell().is_some() {
             ShellMode::XdgFallback
         } else {
             ShellMode::Unknown

--- a/src/backend/wayland/backend/surface.rs
+++ b/src/backend/wayland/backend/surface.rs
@@ -13,11 +13,11 @@ pub(super) fn create_overlay_surface(
     qh: &wayland_client::QueueHandle<WaylandState>,
 ) -> Result<()> {
     // Create surface using layer-shell when available, otherwise fall back to xdg-shell
-    let wl_surface = state.compositor_state.create_surface(qh);
-    if state.layer_shell.is_some() {
+    let wl_surface = state.protocol.compositor().create_surface(qh);
+    if state.protocol.layer_shell().is_some() {
         state.begin_main_layer_focus_acquisition();
     }
-    if let Some(layer_shell) = state.layer_shell.as_ref() {
+    if let Some(layer_shell) = state.protocol.layer_shell() {
         let layer = state.main_surface_layer();
         info!("Creating layer shell surface in {:?} layer", layer);
         let layer_surface = layer_shell.create_layer_surface(
@@ -41,7 +41,7 @@ pub(super) fn create_overlay_surface(
         state.surface.set_layer_surface(layer_surface);
         state.set_current_keyboard_interactivity(Some(desired_keyboard_mode));
         info!("Layer shell surface created");
-    } else if let Some(xdg_shell) = state.xdg_shell.as_ref() {
+    } else if let Some(xdg_shell) = state.protocol.xdg_shell() {
         info!("Layer shell missing; creating xdg-shell window");
         let window = xdg_shell.create_window(wl_surface, WindowDecorations::None, qh);
         window.set_title("wayscriber overlay");

--- a/src/backend/wayland/handlers/compositor.rs
+++ b/src/backend/wayland/handlers/compositor.rs
@@ -126,7 +126,7 @@ impl CompositorHandler for WaylandState {
         }
         self.refresh_active_output_label();
 
-        if let Some(info) = self.output_state.info(output) {
+        if let Some(info) = self.protocol.output().info(output) {
             let scale = info.scale_factor.max(1);
             self.surface.set_scale(scale);
             // Mark full damage when entering output - scale may have changed, pool may be new

--- a/src/backend/wayland/handlers/output.rs
+++ b/src/backend/wayland/handlers/output.rs
@@ -7,7 +7,7 @@ use super::super::state::WaylandState;
 
 impl OutputHandler for WaylandState {
     fn output_state(&mut self) -> &mut OutputState {
-        &mut self.output_state
+        self.protocol.output_mut()
     }
 
     fn new_output(

--- a/src/backend/wayland/handlers/registry.rs
+++ b/src/backend/wayland/handlers/registry.rs
@@ -10,7 +10,7 @@ use super::super::state::WaylandState;
 
 impl ProvidesRegistryState for WaylandState {
     fn registry(&mut self) -> &mut RegistryState {
-        &mut self.registry_state
+        self.protocol.registry_mut()
     }
 
     registry_handlers![OutputState, SeatState];

--- a/src/backend/wayland/handlers/seat.rs
+++ b/src/backend/wayland/handlers/seat.rs
@@ -8,7 +8,7 @@ use crate::input::RegionInputSource;
 
 impl SeatHandler for WaylandState {
     fn seat_state(&mut self) -> &mut SeatState {
-        &mut self.seat_state
+        self.protocol.seat_mut()
     }
 
     fn new_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: wl_seat::WlSeat) {
@@ -26,7 +26,12 @@ impl SeatHandler for WaylandState {
             Capability::Keyboard => {
                 info!("Keyboard capability available");
                 self.set_current_seat(Some(seat.clone()));
-                if self.seat_state.get_keyboard(qh, &seat, None).is_ok() {
+                if self
+                    .protocol
+                    .seat_mut()
+                    .get_keyboard(qh, &seat, None)
+                    .is_ok()
+                {
                     debug!("Keyboard initialized");
                 }
                 // IME: create the single supported text-input object alongside the
@@ -38,11 +43,13 @@ impl SeatHandler for WaylandState {
             }
             Capability::Pointer => {
                 info!("Pointer capability available");
-                match self.seat_state.get_pointer_with_theme(
+                let shm = self.protocol.shm().wl_shm().clone();
+                let cursor_surface = self.protocol.compositor().create_surface(qh);
+                match self.protocol.seat_mut().get_pointer_with_theme(
                     qh,
                     &seat,
-                    self.shm.wl_shm(),
-                    self.compositor_state.create_surface(qh),
+                    &shm,
+                    cursor_surface,
                     ThemeSpec::default(),
                 ) {
                     Ok(pointer) => {
@@ -51,7 +58,7 @@ impl SeatHandler for WaylandState {
                     }
                     Err(err) => {
                         warn!("Pointer initialized without theme: {}", err);
-                        if self.seat_state.get_pointer(qh, &seat).is_ok() {
+                        if self.protocol.seat_mut().get_pointer(qh, &seat).is_ok() {
                             debug!("Pointer initialized without theme fallback");
                         }
                     }
@@ -59,7 +66,7 @@ impl SeatHandler for WaylandState {
             }
             Capability::Touch => {
                 info!("Touch capability available");
-                match self.seat_state.get_touch(qh, &seat) {
+                match self.protocol.seat_mut().get_touch(qh, &seat) {
                     Ok(touch) => {
                         debug!("Touch initialized");
                         self.pointer.attach_touch(touch);
@@ -123,10 +130,11 @@ impl WaylandState {
         self.input_state.take_text_input_cursor_rect_dirty();
         self.input_state.take_text_input_external_change_dirty();
 
-        let fallback = self.seat_state.seats().find(|seat| {
+        let fallback = self.protocol.seat().seats().find(|seat| {
             seat != removed_seat
                 && self
-                    .seat_state
+                    .protocol
+                    .seat()
                     .info(seat)
                     .is_some_and(|info| info.has_keyboard)
         });

--- a/src/backend/wayland/handlers/shm.rs
+++ b/src/backend/wayland/handlers/shm.rs
@@ -5,6 +5,6 @@ use super::super::state::WaylandState;
 
 impl ShmHandler for WaylandState {
     fn shm_state(&mut self) -> &mut Shm {
-        &mut self.shm
+        self.protocol.shm_mut()
     }
 }

--- a/src/backend/wayland/handlers/xdg.rs
+++ b/src/backend/wayland/handlers/xdg.rs
@@ -34,10 +34,11 @@ impl WindowHandler for WaylandState {
         _serial: u32,
     ) {
         let fallback_dimensions = self
-            .output_state
+            .protocol
+            .output()
             .outputs()
             .next()
-            .and_then(|output| self.output_state.info(&output))
+            .and_then(|output| self.protocol.output().info(&output))
             .and_then(|info| {
                 if let Some((w, h)) = info.logical_size {
                     Some((w.max(1) as u32, h.max(1) as u32))
@@ -87,7 +88,7 @@ impl WindowHandler for WaylandState {
         }
 
         if self.surface.current_output().is_none()
-            && let Some(output) = self.output_state.outputs().next()
+            && let Some(output) = self.protocol.output().outputs().next()
         {
             self.surface.set_current_output(output);
             self.set_has_seen_surface_enter(false);

--- a/src/backend/wayland/state.rs
+++ b/src/backend/wayland/state.rs
@@ -3,20 +3,9 @@
 use anyhow::{Context, Result};
 use log::{debug, info, warn};
 use smithay_client_toolkit::{
-    activation::{ActivationHandler, ActivationState, RequestData},
-    compositor::CompositorState,
+    activation::{ActivationHandler, RequestData},
     globals::ProvidesBoundGlobal,
-    output::OutputState,
-    registry::RegistryState,
-    seat::{
-        SeatState, pointer_constraints::PointerConstraintsState,
-        relative_pointer::RelativePointerState,
-    },
-    shell::{
-        wlr_layer::{KeyboardInteractivity, LayerShell},
-        xdg::XdgShell,
-    },
-    shm::Shm,
+    shell::wlr_layer::KeyboardInteractivity,
 };
 use std::{
     collections::VecDeque,
@@ -106,6 +95,8 @@ mod pdf_export;
 mod perf;
 mod pointer_runtime;
 pub(in crate::backend::wayland) use pointer_runtime::TouchTarget;
+mod protocol_globals;
+pub(in crate::backend::wayland) use protocol_globals::{ProtocolGlobals, ProtocolGlobalsSeed};
 mod region_capture;
 pub(in crate::backend::wayland) use region_capture::RegionCaptureIntent;
 #[cfg(test)]
@@ -140,21 +131,8 @@ pub(super) use helpers::{
     toolbar_drag_preview_enabled, toolbar_drag_throttle_interval, toolbar_pointer_lock_enabled,
 };
 
-pub(in crate::backend::wayland) struct WaylandGlobals {
-    pub registry_state: RegistryState,
-    pub compositor_state: CompositorState,
-    pub layer_shell: Option<LayerShell>,
-    pub xdg_shell: Option<XdgShell>,
-    pub activation: Option<ActivationState>,
-    pub shm: Shm,
-    pub pointer_constraints_state: PointerConstraintsState,
-    pub relative_pointer_state: RelativePointerState,
-    pub output_state: OutputState,
-    pub seat_state: SeatState,
-}
-
 pub(in crate::backend::wayland) struct WaylandStateInit {
-    pub globals: WaylandGlobals,
+    pub globals: ProtocolGlobals,
     pub config: Config,
     pub input_state: InputState,
     pub onboarding: crate::onboarding::OnboardingStore,
@@ -183,19 +161,8 @@ pub(in crate::backend::wayland) struct WaylandStateInit {
 
 /// Internal Wayland state shared across modules.
 pub(super) struct WaylandState {
-    // Wayland protocol objects
-    pub(super) registry_state: RegistryState,
-    pub(super) compositor_state: CompositorState,
-    pub(super) layer_shell: Option<LayerShell>,
-    pub(super) xdg_shell: Option<XdgShell>,
-    pub(super) activation: Option<ActivationState>,
-    pub(super) shm: Shm,
-    // Both drive pointer lock for toolbar drags; see
-    // state/toolbar/visibility/pointer.rs.
-    pub(super) pointer_constraints_state: PointerConstraintsState,
-    pub(super) relative_pointer_state: RelativePointerState,
-    pub(super) output_state: OutputState,
-    pub(super) seat_state: SeatState,
+    // Bound Wayland globals and toolkit handler state.
+    pub(super) protocol: ProtocolGlobals,
 
     // Surface and buffer management
     pub(super) surface: SurfaceState,

--- a/src/backend/wayland/state/AGENTS.md
+++ b/src/backend/wayland/state/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## Architecture
 - This subtree supports live overlay runtime state: buffers, damage, boards, capture routing, clipboard paste, color picker, onboarding, PDF export, render helpers, toolbar plumbing, zoom, and core accessors.
-- Protocol and interaction sub-states extracted from `WaylandState` live beside it: `pointer_runtime.rs` (pointer, cursor, pointer-lock, and touch lifecycles), `text_input.rs` (text-input-v3 lifecycle and commit serials), `tablet_runtime.rs` (tablet-input-v2 objects and stylus contact), `key_repeat.rs` (manual key-repeat timing), and `helper_launch.rs` (About/configurator launches requested by input).
+- Protocol and interaction sub-states extracted from `WaylandState` live beside it: `protocol_globals.rs` (bound globals and toolkit handler state), `pointer_runtime.rs` (pointer, cursor, pointer-lock, and touch lifecycles), `text_input.rs` (text-input-v3 lifecycle and commit serials), `tablet_runtime.rs` (tablet-input-v2 objects and stylus contact), `key_repeat.rs` (manual key-repeat timing), and `helper_launch.rs` (About/configurator launches requested by input).
 - `render/` owns overlay render phases; `toolbar/` owns runtime toolbar state helpers; `clipboard/` owns session paste helpers.
 
 ## Invariants

--- a/src/backend/wayland/state/activation.rs
+++ b/src/backend/wayland/state/activation.rs
@@ -15,7 +15,7 @@ impl WaylandState {
         let Some(token) = self.take_startup_activation_token() else {
             return false;
         };
-        let Some(activation) = self.activation.as_ref() else {
+        let Some(activation) = self.protocol.activation() else {
             return false;
         };
         let Some(wl_surface) = self.surface.wl_surface().cloned() else {
@@ -32,7 +32,7 @@ impl WaylandState {
             return;
         }
 
-        let Some(activation) = self.activation.as_ref() else {
+        let Some(activation) = self.protocol.activation() else {
             return;
         };
 
@@ -70,7 +70,7 @@ impl WaylandState {
             return;
         };
 
-        let Some(activation) = self.activation.as_ref() else {
+        let Some(activation) = self.protocol.activation() else {
             return;
         };
 

--- a/src/backend/wayland/state/capture.rs
+++ b/src/backend/wayland/state/capture.rs
@@ -92,10 +92,12 @@ impl WaylandState {
         failed_backend: FrozenCaptureBackend,
         qh: &QueueHandle<Self>,
     ) {
-        if let Err(error) =
-            self.frozen
-                .begin_fallback_capture(failed_backend, &self.shm, qh, &self.tokio_handle)
-        {
+        if let Err(error) = self.frozen.begin_fallback_capture(
+            failed_backend,
+            self.protocol.shm(),
+            qh,
+            &self.tokio_handle,
+        ) {
             log::warn!("No frozen capture fallback succeeded after {failed_backend:?}: {error:#}");
             self.frozen
                 .finish_failed_fallback_capture(&mut self.input_state);

--- a/src/backend/wayland/state/capture/backdrop.rs
+++ b/src/backend/wayland/state/capture/backdrop.rs
@@ -67,14 +67,14 @@ impl WaylandState {
         if exclude.is_some_and(|destroyed| destroyed == &output) {
             return None;
         }
-        let active_info = self.output_state.info(&output)?;
+        let active_info = self.protocol.output().info(&output)?;
         let active = desktop_backdrop_output_geometry_from_info(&active_info)?;
         let mut outputs = Vec::new();
-        for candidate in self.output_state.outputs() {
+        for candidate in self.protocol.output().outputs() {
             if exclude.is_some_and(|destroyed| destroyed == &candidate) {
                 continue;
             }
-            let info = self.output_state.info(&candidate)?;
+            let info = self.protocol.output().info(&candidate)?;
             outputs.push(desktop_backdrop_output_geometry_from_info(&info)?);
         }
 
@@ -91,7 +91,7 @@ impl WaylandState {
 
     fn known_output_count_excluding(&self, exclude: Option<&wl_output::WlOutput>) -> Option<u32> {
         let mut count = 0u32;
-        for candidate in self.output_state.outputs() {
+        for candidate in self.protocol.output().outputs() {
             if exclude.is_some_and(|destroyed| destroyed == &candidate) {
                 continue;
             }
@@ -142,7 +142,7 @@ impl WaylandState {
             self.zoom.set_active_output(None, None);
             return;
         }
-        let Some(info) = self.output_state.info(&output) else {
+        let Some(info) = self.protocol.output().info(&output) else {
             self.set_freeze_zoom_geometry_excluding(None, exclude);
             self.frozen.set_active_output(None, None);
             self.zoom.set_active_output(None, None);

--- a/src/backend/wayland/state/capture/barrier.rs
+++ b/src/backend/wayland/state/capture/barrier.rs
@@ -346,10 +346,12 @@ impl WaylandState {
                     self.cancel_overlay_capture_preflight(reason, None);
                     return;
                 };
-                if let Err(err) =
-                    self.frozen
-                        .begin_preflight_capture(backend, &self.shm, qh, &self.tokio_handle)
-                {
+                if let Err(err) = self.frozen.begin_preflight_capture(
+                    backend,
+                    self.protocol.shm(),
+                    qh,
+                    &self.tokio_handle,
+                ) {
                     log::warn!("Frozen preflight capture failed: {err}");
                     if self.frozen.has_acquisition_attempt() {
                         self.frozen
@@ -372,7 +374,7 @@ impl WaylandState {
                 };
                 if let Err(err) = self.zoom.begin_preflight_capture(
                     use_fallback,
-                    &self.shm,
+                    self.protocol.shm(),
                     qh,
                     &self.tokio_handle,
                 ) {

--- a/src/backend/wayland/state/capture/pdf.rs
+++ b/src/backend/wayland/state/capture/pdf.rs
@@ -115,7 +115,7 @@ impl WaylandState {
         let active_output_id = self
             .surface
             .current_output()
-            .and_then(|output| self.output_state.info(&output).map(|info| info.id));
+            .and_then(|output| self.protocol.output().info(&output).map(|info| info.id));
         if !pending
             .layout_context
             .matches(active_output_id, self.frozen.output_layout_generation())
@@ -231,7 +231,7 @@ impl WaylandState {
         operation: ImageOperationKind,
     ) -> Option<(DesktopBackdropCaptureRequest, CaptureLayoutContext)> {
         let output = self.surface.current_output()?;
-        let output_id = self.output_state.info(&output)?.id;
+        let output_id = self.protocol.output().info(&output)?.id;
         let geometry = self.desktop_backdrop_geometry()?;
         let layout_context =
             CaptureLayoutContext::new(output_id, self.frozen.output_layout_generation());

--- a/src/backend/wayland/state/core/init.rs
+++ b/src/backend/wayland/state/core/init.rs
@@ -31,19 +31,6 @@ impl WaylandState {
             #[cfg(feature = "tablet-input")]
             tablet_manager,
         } = init;
-        let WaylandGlobals {
-            registry_state,
-            compositor_state,
-            layer_shell,
-            xdg_shell,
-            activation,
-            shm,
-            pointer_constraints_state,
-            relative_pointer_state,
-            output_state,
-            seat_state,
-        } = globals;
-
         #[cfg(feature = "tablet-input")]
         let tablet_settings = {
             TabletSettings {
@@ -66,8 +53,9 @@ impl WaylandState {
         data.xdg_fullscreen = xdg_fullscreen;
         data.main_surface_uses_overlay_layer = main_surface_uses_overlay_layer;
         let force_inline_toolbars = force_inline_toolbars_requested(&config);
-        data.inline_toolbars =
-            layer_shell.is_none() || force_inline_toolbars || main_surface_uses_overlay_layer;
+        data.inline_toolbars = globals.layer_shell().is_none()
+            || force_inline_toolbars
+            || main_surface_uses_overlay_layer;
         if force_inline_toolbars {
             info!(
                 "Forcing inline toolbars (config/ui.toolbar.force_inline or {FORCE_INLINE_TOOLBARS_ENV})"
@@ -123,16 +111,7 @@ impl WaylandState {
         let ocr = crate::ocr::OcrController::new(runtime_wake.clone());
 
         Self {
-            registry_state,
-            compositor_state,
-            layer_shell,
-            xdg_shell,
-            activation,
-            shm,
-            pointer_constraints_state,
-            relative_pointer_state,
-            output_state,
-            seat_state,
+            protocol: globals,
             surface: SurfaceState::new(),
             toolbar: ToolbarSurfaceManager::new(),
             data,

--- a/src/backend/wayland/state/core/output/focus.rs
+++ b/src/backend/wayland/state/core/output/focus.rs
@@ -91,7 +91,7 @@ impl WaylandState {
             return;
         }
 
-        if self.layer_shell.is_none() {
+        if self.protocol.layer_shell().is_none() {
             warn!("Output switch requested, but no supported shell is active");
             self.input_state.trigger_blocked_feedback();
             return;
@@ -114,11 +114,11 @@ impl WaylandState {
         output: &wl_output::WlOutput,
     ) {
         self.begin_main_layer_focus_acquisition();
-        let Some(layer_shell) = self.layer_shell.as_ref() else {
+        let Some(layer_shell) = self.protocol.layer_shell() else {
             return;
         };
 
-        let wl_surface = self.compositor_state.create_surface(qh);
+        let wl_surface = self.protocol.compositor().create_surface(qh);
         wl_surface.set_buffer_scale(self.surface.scale().max(1));
         let layer = self.main_surface_layer();
         let layer_surface = layer_shell.create_layer_surface(

--- a/src/backend/wayland/state/core/output/identity.rs
+++ b/src/backend/wayland/state/core/output/identity.rs
@@ -5,7 +5,7 @@ impl WaylandState {
         &self,
     ) -> Option<wl_output::WlOutput> {
         if let Some(preferred) = self.preferred_output_identity()
-            && let Some(output) = self.output_state.outputs().find(|output| {
+            && let Some(output) = self.protocol.output().outputs().find(|output| {
                 self.output_identity_for(output)
                     .map(|id| id.eq_ignore_ascii_case(preferred))
                     .unwrap_or(false)
@@ -16,14 +16,14 @@ impl WaylandState {
 
         self.surface
             .current_output()
-            .or_else(|| self.output_state.outputs().next())
+            .or_else(|| self.protocol.output().outputs().next())
     }
 
     pub(in crate::backend::wayland) fn output_identity_for(
         &self,
         output: &wl_output::WlOutput,
     ) -> Option<String> {
-        let info = self.output_state.info(output)?;
+        let info = self.protocol.output().info(output)?;
 
         let mut components: Vec<String> = Vec::new();
 
@@ -48,10 +48,12 @@ impl WaylandState {
 
     pub(super) fn sorted_known_outputs(&self) -> Vec<wl_output::WlOutput> {
         let mut outputs: Vec<(u32, wl_output::WlOutput)> = self
-            .output_state
+            .protocol
+            .output()
             .outputs()
             .filter_map(|output| {
-                self.output_state
+                self.protocol
+                    .output()
                     .info(&output)
                     .map(|info| (info.id, output))
             })
@@ -62,7 +64,7 @@ impl WaylandState {
     }
 
     pub(super) fn output_badge_label_for(&self, output: &wl_output::WlOutput) -> Option<String> {
-        let info = self.output_state.info(output)?;
+        let info = self.protocol.output().info(output)?;
 
         if let Some(name) = info.name.as_deref().filter(|name| !name.is_empty()) {
             return Some(crate::util::truncate_with_ellipsis(

--- a/src/backend/wayland/state/core/overlay.rs
+++ b/src/backend/wayland/state/core/overlay.rs
@@ -51,10 +51,10 @@ impl WaylandState {
         }
         self.data.overlay_clickthrough = clickthrough;
         if let Some(wl_surface) = self.surface.wl_surface().cloned() {
-            set_surface_clickthrough(&self.compositor_state, &wl_surface, clickthrough);
+            set_surface_clickthrough(self.protocol.compositor(), &wl_surface, clickthrough);
         }
         self.toolbar
-            .set_suppressed(&self.compositor_state, clickthrough);
+            .set_suppressed(self.protocol.compositor(), clickthrough);
     }
 
     pub(in crate::backend::wayland) fn sync_overlay_interactivity(&mut self) {

--- a/src/backend/wayland/state/gtk_toolbar.rs
+++ b/src/backend/wayland/state/gtk_toolbar.rs
@@ -78,7 +78,7 @@ impl WaylandState {
         let request = requested_backend(&self.config);
         let preconditions = GtkPreconditions {
             feature_compiled: cfg!(feature = "toolbar-gtk"),
-            layer_shell: self.layer_shell.is_some(),
+            layer_shell: self.protocol.layer_shell().is_some(),
             force_inline: super::force_inline_toolbars_requested(&self.config),
             main_surface_uses_overlay_layer: self.data.main_surface_uses_overlay_layer,
         };
@@ -239,7 +239,7 @@ impl WaylandState {
             output_name: self
                 .surface
                 .current_output()
-                .and_then(|output| self.output_state.info(&output))
+                .and_then(|output| self.protocol.output().info(&output))
                 .and_then(|info| info.name),
             rebind_modifier: self.config.ui.toolbar.rebind_modifier,
             rebind_modifier_active: self.config.ui.toolbar.rebind_modifier.matches(

--- a/src/backend/wayland/state/protocol_globals.rs
+++ b/src/backend/wayland/state/protocol_globals.rs
@@ -1,0 +1,108 @@
+use smithay_client_toolkit::{
+    activation::ActivationState,
+    compositor::CompositorState,
+    output::OutputState,
+    registry::RegistryState,
+    seat::{
+        SeatState, pointer_constraints::PointerConstraintsState,
+        relative_pointer::RelativePointerState,
+    },
+    shell::{wlr_layer::LayerShell, xdg::XdgShell},
+    shm::Shm,
+};
+
+pub(in crate::backend::wayland) struct ProtocolGlobalsSeed {
+    pub registry: RegistryState,
+    pub compositor: CompositorState,
+    pub layer_shell: Option<LayerShell>,
+    pub xdg_shell: Option<XdgShell>,
+    pub activation: Option<ActivationState>,
+    pub shm: Shm,
+    pub pointer_constraints: PointerConstraintsState,
+    pub relative_pointer: RelativePointerState,
+    pub output: OutputState,
+    pub seat: SeatState,
+}
+
+/// Bound Wayland globals and the toolkit state that dispatches their events.
+pub(in crate::backend::wayland) struct ProtocolGlobals {
+    registry: RegistryState,
+    compositor: CompositorState,
+    layer_shell: Option<LayerShell>,
+    xdg_shell: Option<XdgShell>,
+    activation: Option<ActivationState>,
+    shm: Shm,
+    pointer_constraints: PointerConstraintsState,
+    relative_pointer: RelativePointerState,
+    output: OutputState,
+    seat: SeatState,
+}
+
+impl ProtocolGlobals {
+    pub(in crate::backend::wayland) fn from_seed(seed: ProtocolGlobalsSeed) -> Self {
+        Self {
+            registry: seed.registry,
+            compositor: seed.compositor,
+            layer_shell: seed.layer_shell,
+            xdg_shell: seed.xdg_shell,
+            activation: seed.activation,
+            shm: seed.shm,
+            pointer_constraints: seed.pointer_constraints,
+            relative_pointer: seed.relative_pointer,
+            output: seed.output,
+            seat: seed.seat,
+        }
+    }
+
+    pub(in crate::backend::wayland) fn registry_mut(&mut self) -> &mut RegistryState {
+        &mut self.registry
+    }
+
+    pub(in crate::backend::wayland) fn compositor(&self) -> &CompositorState {
+        &self.compositor
+    }
+
+    pub(in crate::backend::wayland) fn layer_shell(&self) -> Option<&LayerShell> {
+        self.layer_shell.as_ref()
+    }
+
+    pub(in crate::backend::wayland) fn xdg_shell(&self) -> Option<&XdgShell> {
+        self.xdg_shell.as_ref()
+    }
+
+    pub(in crate::backend::wayland) fn activation(&self) -> Option<&ActivationState> {
+        self.activation.as_ref()
+    }
+
+    pub(in crate::backend::wayland) fn shm(&self) -> &Shm {
+        &self.shm
+    }
+
+    pub(in crate::backend::wayland) fn shm_mut(&mut self) -> &mut Shm {
+        &mut self.shm
+    }
+
+    pub(in crate::backend::wayland) fn pointer_constraints(&self) -> &PointerConstraintsState {
+        &self.pointer_constraints
+    }
+
+    pub(in crate::backend::wayland) fn relative_pointer(&self) -> &RelativePointerState {
+        &self.relative_pointer
+    }
+
+    pub(in crate::backend::wayland) fn output(&self) -> &OutputState {
+        &self.output
+    }
+
+    pub(in crate::backend::wayland) fn output_mut(&mut self) -> &mut OutputState {
+        &mut self.output
+    }
+
+    pub(in crate::backend::wayland) fn seat(&self) -> &SeatState {
+        &self.seat
+    }
+
+    pub(in crate::backend::wayland) fn seat_mut(&mut self) -> &mut SeatState {
+        &mut self.seat
+    }
+}

--- a/src/backend/wayland/state/region_capture/window_snap/query.rs
+++ b/src/backend/wayland/state/region_capture/window_snap/query.rs
@@ -161,7 +161,7 @@ impl WaylandState {
 
     fn region_window_query_context(&self, source: ScreenSourceToken) -> Option<WindowQueryContext> {
         let output = self.surface.current_output()?;
-        let info = self.output_state.info(&output)?;
+        let info = self.protocol.output().info(&output)?;
         if info.id != source.output_id {
             return None;
         }

--- a/src/backend/wayland/state/render/mod.rs
+++ b/src/backend/wayland/state/render/mod.rs
@@ -107,7 +107,7 @@ impl WaylandState {
         // effect's on-screen footprint.
         let acquired = record_stage!(buffer_acquire, {
             self.surface.acquire_buffer(
-                &self.shm,
+                self.protocol.shm(),
                 buffer_count,
                 phys_width as i32,
                 phys_height as i32,

--- a/src/backend/wayland/state/toolbar/drag/clamp.rs
+++ b/src/backend/wayland/state/toolbar/drag/clamp.rs
@@ -115,7 +115,7 @@ impl WaylandState {
             drag_log(|| "skip apply_toolbar_offsets: drag preview active without pointer lock");
             return false;
         }
-        if self.layer_shell.is_none() {
+        if self.protocol.layer_shell().is_none() {
             return false;
         }
         let top_base_x = self.inline_top_base_x();

--- a/src/backend/wayland/state/toolbar/drag/handoff.rs
+++ b/src/backend/wayland/state/toolbar/drag/handoff.rs
@@ -141,7 +141,8 @@ impl WaylandState {
         self.set_toolbar_drag_preview_active(false);
         let snapshot = self.toolbar_snapshot();
         let _ = self.apply_toolbar_offsets(&snapshot);
-        self.toolbar.set_suppressed(&self.compositor_state, false);
+        self.toolbar
+            .set_suppressed(self.protocol.compositor(), false);
         self.request_toolbar_drag_flush();
         self.clear_inline_toolbar_hits();
         self.clear_inline_toolbar_hover();

--- a/src/backend/wayland/state/toolbar/drag/move_drag.rs
+++ b/src/backend/wayland/state/toolbar/drag/move_drag.rs
@@ -12,13 +12,14 @@ impl WaylandState {
                 return false;
             }
             if toolbar_drag_preview_enabled()
-                && self.layer_shell.is_some()
+                && self.protocol.layer_shell().is_some()
                 && !self.inline_toolbars_active()
                 && !self.toolbar_drag_preview_active()
             {
                 drag_log(|| "enable inline drag preview (layer-shell toolbars hidden)");
                 self.set_toolbar_drag_preview_active(true);
-                self.toolbar.set_suppressed(&self.compositor_state, true);
+                self.toolbar
+                    .set_suppressed(self.protocol.compositor(), true);
                 self.input_state.dirty_tracker.mark_full();
                 self.input_state.needs_redraw = true;
             }
@@ -37,7 +38,7 @@ impl WaylandState {
                     coord.1,
                     coord_is_screen,
                     self.inline_toolbars_active(),
-                    self.layer_shell.is_some()
+                    self.protocol.layer_shell().is_some()
                 )
             });
             // Store initial coord with explicit coordinate space (screen vs toolbar-local).
@@ -172,7 +173,7 @@ impl WaylandState {
                 self.input_state.dirty_tracker.mark_full();
                 self.input_state.needs_redraw = true;
             }
-            if self.layer_shell.is_none() || inline_render_active {
+            if self.protocol.layer_shell().is_none() || inline_render_active {
                 self.clear_inline_toolbar_hits();
             }
             return;
@@ -267,7 +268,7 @@ impl WaylandState {
             self.input_state.dirty_tracker.mark_full();
             self.input_state.needs_redraw = true;
         }
-        if self.layer_shell.is_none() || inline_render_active {
+        if self.protocol.layer_shell().is_none() || inline_render_active {
             self.clear_inline_toolbar_hits();
         }
     }
@@ -393,7 +394,7 @@ impl WaylandState {
             self.input_state.dirty_tracker.mark_full();
             self.input_state.needs_redraw = true;
         }
-        if self.layer_shell.is_none() || inline_render_active {
+        if self.protocol.layer_shell().is_none() || inline_render_active {
             // Inline mode uses cached rects, so force a relayout.
             self.clear_inline_toolbar_hits();
         }

--- a/src/backend/wayland/state/toolbar/visibility/pointer.rs
+++ b/src/backend/wayland/state/toolbar/visibility/pointer.rs
@@ -30,7 +30,7 @@ impl WaylandState {
             log::info!("skip pointer lock: already_locked");
             return;
         }
-        if self.pointer_constraints_state.bound_global().is_err() {
+        if self.protocol.pointer_constraints().bound_global().is_err() {
             log::info!("pointer lock unavailable: constraints global missing");
             return;
         }
@@ -39,7 +39,7 @@ impl WaylandState {
             return;
         };
 
-        match self.pointer_constraints_state.lock_pointer(
+        match self.protocol.pointer_constraints().lock_pointer(
             surface,
             &pointer,
             None,
@@ -76,7 +76,8 @@ impl WaylandState {
         }
 
         match self
-            .relative_pointer_state
+            .protocol
+            .relative_pointer()
             .get_relative_pointer(&pointer, qh)
         {
             Ok(rp) => {

--- a/src/backend/wayland/state/toolbar/visibility/sync.rs
+++ b/src/backend/wayland/state/toolbar/visibility/sync.rs
@@ -31,7 +31,7 @@ impl WaylandState {
         keyboard_interactivity_for(KeyboardInteractivityPolicyInput {
             keyboard_release_requested: self.overlay_keyboard_passthrough_requested(),
             main_layer_focus_acquiring: self.main_layer_focus_acquiring(),
-            layer_shell_available: self.layer_shell.is_some(),
+            layer_shell_available: self.protocol.layer_shell().is_some(),
             separate_toolbar_visible: toolbar_visible,
             inline_toolbars_active: self.inline_toolbars_active(),
             canvas_modal_active: self.input_state.is_color_picker_popup_open(),
@@ -110,7 +110,7 @@ impl WaylandState {
             log::debug!(
                 "Toolbar visibility sync: top_visible={}, layer_shell_available={}, inline_active={}, top_created={}, needs_recreate={}, scale={}",
                 top_visible,
-                self.layer_shell.is_some(),
+                self.protocol.layer_shell().is_some(),
                 inline_active,
                 self.toolbar.top_created(),
                 self.toolbar_needs_recreate(),
@@ -122,14 +122,14 @@ impl WaylandState {
                     self.data.toolbar_top_offset,
                     self.data.toolbar_top_offset_y,
                     inline_active,
-                    self.layer_shell.is_some(),
+                    self.protocol.layer_shell().is_some(),
                     self.toolbar_needs_recreate()
                 )
             });
         }
 
         // Warn the user when layer-shell is unavailable and we're forced to inline fallback.
-        if any_visible && self.layer_shell.is_none() {
+        if any_visible && self.protocol.layer_shell().is_none() {
             self.log_toolbar_layer_shell_missing_once();
         }
 
@@ -144,7 +144,7 @@ impl WaylandState {
             self.data.toolbar_configure_miss_count = 0;
         }
 
-        if any_visible && self.layer_shell.is_some() && !inline_active && !drag_preview {
+        if any_visible && self.protocol.layer_shell().is_some() && !inline_active && !drag_preview {
             // Detect compositors ignoring or failing to configure toolbar layer surfaces; if they
             // never configure after repeated attempts, fall back to inline toolbars automatically.
             let top_configured = self.toolbar.top_configured();
@@ -188,12 +188,12 @@ impl WaylandState {
             if !self.is_move_dragging() {
                 let _ = self.apply_toolbar_offsets(&snapshot);
             }
-            if let Some(layer_shell) = self.layer_shell.as_ref() {
+            if let Some(layer_shell) = self.protocol.layer_shell() {
                 let scale = self.surface.scale();
                 let output = self.surface.current_output();
                 self.toolbar.ensure_created(
                     qh,
-                    &self.compositor_state,
+                    self.protocol.compositor(),
                     layer_shell,
                     scale,
                     output.as_ref(),
@@ -218,8 +218,8 @@ impl WaylandState {
         // No hover tracking yet; pass None. Can be updated when we record pointer positions per surface.
         let render_profile = self.input_state.active_ui_render_profile().cloned();
         self.toolbar
-            .render(&self.shm, snapshot, None, render_profile.as_ref());
-        self.toolbar.apply_input_regions(&self.compositor_state);
+            .render(self.protocol.shm(), snapshot, None, render_profile.as_ref());
+        self.toolbar.apply_input_regions(self.protocol.compositor());
     }
 
     pub(in crate::backend::wayland) fn render_layer_toolbars_if_needed(&mut self) {


### PR DESCRIPTION
## Summary

- Replace the ten root protocol-global fields with `ProtocolGlobals`.
- Preserve Smithay handler contracts through mutable registry, output, seat, and SHM accessors.
- Add narrow immutable accessors for regular consumers.
- Keep delegate macros and `handlers/mod.rs` unchanged.

## Stack

2 of 4. #374 is merged. Base: `main`.

## Validation

- `cargo test --all-features`
- `cargo test --no-default-features`
- `cargo fmt --all -- --check`
- Strict Clippy in both feature matrices reports only the known Rust 1.98 baseline diagnostics.
